### PR TITLE
Add installer scaffold for risk management extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,6 +297,8 @@ dmypy.json
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
+!risk_management/scripts/
+!risk_management/scripts/*
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/risk_management/.gitignore
+++ b/risk_management/.gitignore
@@ -1,0 +1,2 @@
+.venv_passivbot_risk/
+__pycache__/

--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -1,0 +1,42 @@
+# Passivbot Risk Management Extension
+
+This directory contains a stand-alone risk management, portfolio monitoring,
+and alerting system designed to work *with* Passivbot without modifying the
+core trading bot.  The extension will grow iteratively.  In this iteration we
+focus on providing a reproducible way to install Passivbot into a dedicated
+virtual environment that the risk management service will rely on.
+
+## Installation Overview
+
+The risk management service is developed as a separate Python package that
+imports Passivbot as a library.  To keep concerns separated and avoid mutating
+existing Passivbot installation requirements, we maintain an isolated virtual
+environment under `risk_management/.venv_passivbot_risk`.
+
+Run the helper script to bootstrap the environment and install Passivbot in
+editable mode:
+
+```bash
+./scripts/install_passivbot.sh
+```
+
+After installation the virtual environment will be ready for future
+iterations—where portfolio analytics, monitoring, and alerting features will be
+added—to import Passivbot modules and configurations.
+
+## What the installer does
+
+* Creates (or reuses) the virtual environment at
+  `risk_management/.venv_passivbot_risk`.
+* Upgrades `pip`, `setuptools`, and `wheel` to recent versions.
+* Installs Passivbot from the repository root in editable mode so that local
+  changes to Passivbot are instantly available to the risk management package.
+
+## Requirements
+
+* Python 3.9+ available on the host system.
+* `bash` compatible shell (for Windows users, WSL or Git Bash is recommended).
+
+Future iterations will introduce the risk management package itself, portfolio
+metrics calculations, monitoring pipelines, and alert integrations while
+respecting the isolation between Passivbot and the new tooling.

--- a/risk_management/scripts/install_passivbot.sh
+++ b/risk_management/scripts/install_passivbot.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PROJECT_ROOT}/.." && pwd)"
+VENV_DIR="${PROJECT_ROOT}/.venv_passivbot_risk"
+
+PYTHON_BIN="python3"
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+    echo "python3 is required but not found. Please install Python 3.9 or newer." >&2
+    exit 1
+fi
+
+if [ ! -d "${VENV_DIR}" ]; then
+    echo "Creating virtual environment at ${VENV_DIR}"
+    "${PYTHON_BIN}" -m venv "${VENV_DIR}"
+else
+    echo "Reusing existing virtual environment at ${VENV_DIR}"
+fi
+
+# shellcheck disable=SC1090
+source "${VENV_DIR}/bin/activate"
+
+pip install --upgrade pip setuptools wheel
+
+# Install passivbot from repository root in editable mode
+pip install -e "${REPO_ROOT}"
+
+echo "Passivbot has been installed into ${VENV_DIR}."
+echo "Activate the environment with:"
+echo "  source ${VENV_DIR}/bin/activate"


### PR DESCRIPTION
## Summary
- document a dedicated risk_management workspace for the upcoming portfolio tooling
- add a helper script that provisions a virtual environment and installs Passivbot in editable mode
- adjust .gitignore so the new installer script is tracked in version control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f9990a0cc883238b4e55e8424c6708