### PR TITLE
Add realtime risk data pipeline and web dashboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ dictdiffer==0.9.0
 openpyxl==3.1.5
 msgpack==1.1.0
 plotly==6.0.1
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9

--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -34,6 +34,45 @@ freely.
    the JSON file in another terminal.  The CLI will re-read the file on the
    chosen cadence and immediately reflect the changes.
 
+## Realtime monitoring
+
+Provide exchange credentials via `risk_management/realtime_config.json` (see
+`realtime_config.example.json` for a complete template) and point the CLI at the
+file to fetch balances and positions directly from the exchanges:
+
+```bash
+python -m risk_management.dashboard --realtime-config risk_management/realtime_config.json --interval 30 --iterations 0
+```
+
+The command connects to each configured account, aggregates the portfolio
+metrics, and continuously renders the dashboard.  Any fetch issues are surfaced
+inline under the affected account.
+
+## Web dashboard
+
+Launch the FastAPI web server to obtain an authenticated dashboard with live
+updates:
+
+```bash
+python -m risk_management.web_server --config risk_management/realtime_config.json --host 0.0.0.0 --port 8000
+```
+
+Navigate to `http://localhost:8000` to sign in and view the interactive
+dashboard.  The page automatically polls for fresh data and updates account
+cards, alerts, and notification channels without a full refresh.
+
+### Authentication
+
+The web UI requires bcrypt hashed passwords.  Use the helper script to generate
+hashes:
+
+```bash
+python risk_management/scripts/hash_password.py
+```
+
+Paste the resulting hash into the `auth.users` section of your realtime
+configuration file.
+
 The previous quick start guide that focused solely on creating the virtual
 environment is kept below for reference.
 

--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -1,0 +1,166 @@
+"""Utilities for loading realtime risk management configuration files."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+
+@dataclass(slots=True)
+class AccountConfig:
+    """Configuration for a single exchange account."""
+
+    name: str
+    exchange: str
+    settle_currency: str = "USDT"
+    api_key_id: str | None = None
+    credentials: Dict[str, Any] = field(default_factory=dict)
+    symbols: List[str] | None = None
+    params: Dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+
+
+@dataclass(slots=True)
+class AuthConfig:
+    """Settings for session authentication in the web dashboard."""
+
+    secret_key: str
+    users: Mapping[str, str]
+    session_cookie_name: str = "risk_dashboard_session"
+
+
+@dataclass(slots=True)
+class RealtimeConfig:
+    """Top level realtime configuration."""
+
+    accounts: List[AccountConfig]
+    alert_thresholds: Dict[str, float] = field(default_factory=dict)
+    notification_channels: List[str] = field(default_factory=list)
+    auth: AuthConfig | None = None
+    account_messages: Dict[str, str] = field(default_factory=dict)
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Configuration file not found: {path}") from exc
+
+
+def _normalise_credentials(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalise credential keys to ccxt's expected names."""
+
+    mapping = {
+        "key": "apiKey",
+        "apikey": "apiKey",
+        "api_key": "apiKey",
+        "secret": "secret",
+        "password": "password",
+        "passphrase": "password",
+        "uid": "uid",
+    }
+    normalised: Dict[str, Any] = {}
+    for raw_key, value in data.items():
+        if value is None:
+            continue
+        key = mapping.get(raw_key, raw_key)
+        normalised[key] = value
+    return normalised
+
+
+def _merge_credentials(primary: Mapping[str, Any], secondary: Mapping[str, Any]) -> Dict[str, Any]:
+    merged = dict(secondary)
+    merged.update(primary)
+    return _normalise_credentials(merged)
+
+
+def _parse_accounts(
+    accounts_raw: Iterable[Mapping[str, Any]],
+    api_keys: Mapping[str, Mapping[str, Any]] | None,
+) -> List[AccountConfig]:
+    accounts: List[AccountConfig] = []
+    for raw in accounts_raw:
+        if not raw.get("enabled", True):
+            continue
+        api_key_id = raw.get("api_key_id")
+        credentials: Mapping[str, Any] = raw.get("credentials", {})
+        exchange = raw.get("exchange")
+        if api_key_id:
+            if api_keys is None:
+                raise ValueError(
+                    f"Account '{raw.get('name')}' references api_key_id '{api_key_id}' but no api key file was provided"
+                )
+            if api_key_id not in api_keys:
+                raise ValueError(
+                    f"Account '{raw.get('name')}' references unknown api_key_id '{api_key_id}'"
+                )
+            key_payload = api_keys[api_key_id]
+            if not exchange:
+                exchange = key_payload.get("exchange")
+            credentials = _merge_credentials(credentials, key_payload)
+        else:
+            credentials = _normalise_credentials(credentials)
+        if not exchange:
+            raise ValueError(
+                f"Account '{raw.get('name')}' must specify an exchange either directly or via the api key entry."
+            )
+        account = AccountConfig(
+            name=str(raw.get("name", exchange)),
+            exchange=str(exchange),
+            settle_currency=str(raw.get("settle_currency", "USDT")),
+            api_key_id=api_key_id,
+            credentials=dict(credentials),
+            symbols=list(raw.get("symbols") or []) or None,
+            params=dict(raw.get("params", {})),
+            enabled=bool(raw.get("enabled", True)),
+        )
+        accounts.append(account)
+    return accounts
+
+
+def _parse_auth(auth_raw: Mapping[str, Any] | None) -> AuthConfig | None:
+    if not auth_raw:
+        return None
+    secret_key = auth_raw.get("secret_key")
+    if not secret_key:
+        raise ValueError("Authentication configuration requires a 'secret_key'.")
+    users_raw = auth_raw.get("users")
+    if not users_raw:
+        raise ValueError("Authentication configuration requires at least one user entry.")
+    if isinstance(users_raw, Mapping):
+        users = dict(users_raw)
+    else:
+        users = {str(entry["username"]): str(entry["password_hash"]) for entry in users_raw}
+    session_cookie = str(auth_raw.get("session_cookie_name", "risk_dashboard_session"))
+    return AuthConfig(secret_key=str(secret_key), users=users, session_cookie_name=session_cookie)
+
+
+def load_realtime_config(path: Path) -> RealtimeConfig:
+    """Load a realtime configuration file."""
+
+    config = _load_json(path)
+    api_keys_file = config.get("api_keys_file")
+    api_keys: Mapping[str, Any] | None = None
+    if api_keys_file:
+        api_keys_path = (path.parent / api_keys_file).resolve()
+        api_keys_raw = _load_json(api_keys_path)
+        api_keys = {
+            key: value
+            for key, value in api_keys_raw.items()
+            if isinstance(value, Mapping) and key != "referrals"
+        }
+    accounts_raw = config.get("accounts")
+    if not accounts_raw:
+        raise ValueError("Realtime configuration must include at least one account entry.")
+    accounts = _parse_accounts(accounts_raw, api_keys)
+    alert_thresholds = {str(k): float(v) for k, v in config.get("alert_thresholds", {}).items()}
+    notification_channels = [str(item) for item in config.get("notification_channels", [])]
+    auth = _parse_auth(config.get("auth"))
+    return RealtimeConfig(
+        accounts=accounts,
+        alert_thresholds=alert_thresholds,
+        notification_channels=notification_channels,
+        auth=auth,
+    )

--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -1,0 +1,263 @@
+"""Realtime data gathering for the risk management dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+try:  # pragma: no cover - optional dependency for tests
+    import ccxt.async_support as ccxt_async
+    from ccxt.base.errors import BaseError
+except ModuleNotFoundError:  # pragma: no cover - allow tests without ccxt
+    ccxt_async = None  # type: ignore[assignment]
+
+    class BaseError(Exception):
+        """Fallback error when ccxt is unavailable."""
+
+        pass
+
+from .configuration import AccountConfig, RealtimeConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AccountClientProtocol:
+    """Protocol describing realtime account clients."""
+
+    async def fetch(self) -> Dict[str, Any]:  # pragma: no cover - protocol definition
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover - protocol definition
+        raise NotImplementedError
+
+
+class CCXTAccountClient(AccountClientProtocol):
+    """Realtime account client backed by ccxt asynchronous exchanges."""
+
+    def __init__(self, config: AccountConfig):
+        self.config = config
+        exchange_id = config.exchange
+        if ccxt_async is None:  # pragma: no cover - configuration error
+            raise RuntimeError("ccxt is required to instantiate CCXTAccountClient")
+        try:
+            exchange_class = getattr(ccxt_async, exchange_id)
+        except AttributeError as exc:  # pragma: no cover - configuration error
+            raise ValueError(f"Exchange '{exchange_id}' is not supported by ccxt.") from exc
+        params = dict(config.credentials)
+        params.setdefault("enableRateLimit", True)
+        self.client = exchange_class(params)
+        self._balance_params = dict(config.params.get("balance", {}))
+        self._positions_params = dict(config.params.get("positions", {}))
+
+    async def fetch(self) -> Dict[str, Any]:
+        await self.client.load_markets()
+        balance_raw = await self.client.fetch_balance(params=self._balance_params)
+        balance_value = _extract_balance(balance_raw, self.config.settle_currency)
+        positions_raw: Iterable[Mapping[str, Any]] = []
+        positions: List[Dict[str, Any]] = []
+        if hasattr(self.client, "fetch_positions"):
+            try:
+                positions_raw = await self.client.fetch_positions(params=self._positions_params)
+            except BaseError as exc:
+                logger.warning(
+                    "Failed to fetch positions for %s: %s", self.config.name, exc, exc_info=True
+                )
+        for position_raw in positions_raw or []:
+            parsed = _parse_position(position_raw, balance_value)
+            if parsed is not None:
+                positions.append(parsed)
+        return {
+            "name": self.config.name,
+            "balance": balance_value,
+            "positions": positions,
+        }
+
+    async def close(self) -> None:
+        await self.client.close()
+
+
+class RealtimeDataFetcher:
+    """Fetch realtime snapshots across multiple accounts."""
+
+    def __init__(
+        self,
+        config: RealtimeConfig,
+        account_clients: Sequence[AccountClientProtocol] | None = None,
+    ) -> None:
+        self.config = config
+        if account_clients is None:
+            if ccxt_async is None:
+                raise RuntimeError(
+                    "ccxt is required to create realtime exchange clients."
+                )
+            self._account_clients = [CCXTAccountClient(account) for account in config.accounts]
+        else:
+            self._account_clients = list(account_clients)
+
+    async def fetch_snapshot(self) -> Dict[str, Any]:
+        tasks = [client.fetch() for client in self._account_clients]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        accounts_payload: List[Dict[str, Any]] = []
+        account_messages: Dict[str, str] = {}
+        for account_config, result in zip(self.config.accounts, results):
+            if isinstance(result, Exception):
+                message = f"{account_config.name}: {result}"
+                logger.exception("Failed to fetch snapshot for %s", account_config.name, exc_info=result)
+                account_messages[account_config.name] = message
+                accounts_payload.append({"name": account_config.name, "balance": 0.0, "positions": []})
+            else:
+                accounts_payload.append(result)
+        snapshot = {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "accounts": accounts_payload,
+            "alert_thresholds": self.config.alert_thresholds,
+            "notification_channels": self.config.notification_channels,
+        }
+        if account_messages:
+            snapshot["account_messages"] = account_messages
+        return snapshot
+
+    async def close(self) -> None:
+        await asyncio.gather(*(client.close() for client in self._account_clients))
+
+
+def _extract_balance(balance: Mapping[str, Any], settle_currency: str) -> float:
+    """Extract a numeric balance from ccxt balance payloads."""
+
+    total = balance.get("total") if isinstance(balance, Mapping) else None
+    if isinstance(total, Mapping) and total:
+        if settle_currency in total and total[settle_currency] is not None:
+            try:
+                return float(total[settle_currency])
+            except (TypeError, ValueError):
+                logger.debug("Non-numeric balance for %s: %s", settle_currency, total[settle_currency])
+        try:
+            return float(sum(float(v or 0.0) for v in total.values()))
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            logger.debug("Unable to aggregate total balances: %s", total)
+    info = balance.get("info") if isinstance(balance, Mapping) else None
+    if isinstance(info, Mapping):
+        for key in (
+            "totalWalletBalance",
+            "totalMarginBalance",
+            "equity",
+            "totalEquity",
+            "marginBalance",
+            "totalBalance",
+        ):
+            value = info.get(key)
+            if value is not None:
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    logger.debug("Non-numeric balance info %s=%s", key, value)
+    balances = [
+        balance.get(settle_currency) if isinstance(balance, Mapping) else None,
+        balance.get("USDT") if isinstance(balance, Mapping) else None,
+    ]
+    for entry in balances:
+        if isinstance(entry, Mapping):
+            value = entry.get("total") or entry.get("free") or entry.get("used")
+            if value is not None:
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        elif entry is not None:
+            try:
+                return float(entry)
+            except (TypeError, ValueError):
+                continue
+    return 0.0
+
+
+def _parse_position(position: Mapping[str, Any], balance: float) -> Dict[str, Any] | None:
+    size = _first_float(
+        position.get("contracts"),
+        position.get("size"),
+        position.get("amount"),
+        position.get("info", {}).get("positionAmt") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("size") if isinstance(position.get("info"), Mapping) else None,
+    )
+    if size is None or abs(size) < 1e-12:
+        return None
+    side = "long" if size > 0 else "short"
+    entry_price = _first_float(
+        position.get("entryPrice"),
+        position.get("entry_price"),
+        position.get("info", {}).get("entryPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("avgEntryPrice") if isinstance(position.get("info"), Mapping) else None,
+    )
+    mark_price = _first_float(
+        position.get("markPrice"),
+        position.get("mark_price"),
+        position.get("info", {}).get("markPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("last") if isinstance(position.get("info"), Mapping) else None,
+    )
+    liquidation_price = _first_float(
+        position.get("liquidationPrice"),
+        position.get("info", {}).get("liquidationPrice") if isinstance(position.get("info"), Mapping) else None,
+    )
+    unrealized = _first_float(
+        position.get("unrealizedPnl"),
+        position.get("info", {}).get("unRealizedProfit") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("unrealisedPnl") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("upl") if isinstance(position.get("info"), Mapping) else None,
+    ) or 0.0
+    contract_size = _first_float(
+        position.get("contractSize"),
+        position.get("info", {}).get("contractSize") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("ctVal") if isinstance(position.get("info"), Mapping) else None,
+    ) or 1.0
+    notional = _first_float(
+        position.get("notional"),
+        position.get("notionalValue"),
+        position.get("info", {}).get("notionalValue") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("notionalUsd") if isinstance(position.get("info"), Mapping) else None,
+    )
+    if notional is None:
+        reference_price = mark_price or entry_price or 0.0
+        notional = abs(size) * contract_size * reference_price
+    take_profit = _first_float(
+        position.get("takeProfitPrice"),
+        position.get("tpPrice"),
+        position.get("info", {}).get("takeProfitPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("tpTriggerPx") if isinstance(position.get("info"), Mapping) else None,
+    )
+    stop_loss = _first_float(
+        position.get("stopLossPrice"),
+        position.get("slPrice"),
+        position.get("info", {}).get("stopLossPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("slTriggerPx") if isinstance(position.get("info"), Mapping) else None,
+    )
+    wallet_exposure = None
+    if balance:
+        wallet_exposure = abs(notional) / balance if balance else None
+    return {
+        "symbol": str(position.get("symbol") or position.get("id") or "unknown"),
+        "side": side,
+        "notional": float(notional or 0.0),
+        "entry_price": float(entry_price or 0.0),
+        "mark_price": float(mark_price or 0.0),
+        "liquidation_price": float(liquidation_price) if liquidation_price is not None else None,
+        "wallet_exposure_pct": float(wallet_exposure) if wallet_exposure is not None else None,
+        "unrealized_pnl": float(unrealized),
+        "max_drawdown_pct": None,
+        "take_profit_price": float(take_profit) if take_profit is not None else None,
+        "stop_loss_price": float(stop_loss) if stop_loss is not None else None,
+    }
+
+
+def _first_float(*values: Any) -> float | None:
+    for value in values:
+        if value in (None, ""):
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None

--- a/risk_management/realtime_config.example.json
+++ b/risk_management/realtime_config.example.json
@@ -1,0 +1,38 @@
+{
+  "api_keys_file": "../api-keys.json",
+  "accounts": [
+    {
+      "name": "Binance Futures",
+      "exchange": "binanceusdm",
+      "api_key_id": "binance_01",
+      "settle_currency": "USDT"
+    },
+    {
+      "name": "OKX Futures",
+      "exchange": "okx",
+      "api_key_id": "okx_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
+    }
+  ],
+  "alert_thresholds": {
+    "wallet_exposure_pct": 0.65,
+    "position_wallet_exposure_pct": 0.25,
+    "max_drawdown_pct": 0.25,
+    "loss_threshold_pct": -0.08
+  },
+  "notification_channels": [
+    "email:risk-team@example.com",
+    "slack:#passivbot-risk-alerts"
+  ],
+  "auth": {
+    "secret_key": "replace-me-with-a-long-random-string",
+    "session_cookie_name": "risk_dashboard_session",
+    "users": {
+      "admin": "replace-with-bcrypt-hash"
+    }
+  }
+}

--- a/risk_management/scripts/hash_password.py
+++ b/risk_management/scripts/hash_password.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Utility script to create bcrypt password hashes for the web dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+
+from passlib.context import CryptContext
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a bcrypt hash for dashboard users")
+    parser.add_argument("password", nargs="?", help="Optional password to hash. If omitted a prompt is used.")
+    args = parser.parse_args(argv)
+
+    password = args.password or getpass.getpass("Password: ")
+    if not password:
+        parser.error("Password cannot be empty")
+    context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    print(context.hash(password))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -1,0 +1,69 @@
+"""Helpers for transforming risk management snapshots into presentation data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .dashboard import (
+    Account,
+    AlertThresholds,
+    Position,
+    evaluate_alerts,
+    parse_snapshot,
+)
+
+
+def build_presentable_snapshot(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
+    """Convert a snapshot payload into UI friendly structures."""
+
+    generated_at, accounts, thresholds, notifications = parse_snapshot(dict(snapshot))
+    alerts = evaluate_alerts(accounts, thresholds)
+    account_messages = snapshot.get("account_messages", {}) if isinstance(snapshot, Mapping) else {}
+    return {
+        "generated_at": generated_at.isoformat(),
+        "accounts": [_build_account_view(account, account_messages) for account in accounts],
+        "alerts": alerts,
+        "notifications": notifications,
+        "thresholds": _thresholds_to_view(thresholds),
+    }
+
+
+def _build_account_view(account: Account, account_messages: Mapping[str, str]) -> Dict[str, Any]:
+    positions = [_build_position_view(position, account.balance) for position in account.positions]
+    return {
+        "name": account.name,
+        "balance": account.balance,
+        "exposure": account.exposure_pct(),
+        "unrealized_pnl": account.total_unrealized(),
+        "positions": positions,
+        "message": account_messages.get(account.name),
+    }
+
+
+def _build_position_view(position: Position, balance: float) -> Dict[str, Any]:
+    exposure = position.exposure_relative_to(balance)
+    pnl_pct = position.pnl_pct(balance)
+    return {
+        "symbol": position.symbol,
+        "side": position.side,
+        "notional": position.notional,
+        "entry_price": position.entry_price,
+        "mark_price": position.mark_price,
+        "liquidation_price": position.liquidation_price,
+        "wallet_exposure_pct": position.wallet_exposure_pct if position.wallet_exposure_pct is not None else exposure,
+        "exposure": exposure,
+        "unrealized_pnl": position.unrealized_pnl,
+        "pnl_pct": pnl_pct,
+        "max_drawdown_pct": position.max_drawdown_pct,
+        "take_profit_price": position.take_profit_price,
+        "stop_loss_price": position.stop_loss_price,
+    }
+
+
+def _thresholds_to_view(thresholds: AlertThresholds) -> Dict[str, float]:
+    return {
+        "wallet_exposure_pct": thresholds.wallet_exposure_pct,
+        "position_wallet_exposure_pct": thresholds.position_wallet_exposure_pct,
+        "max_drawdown_pct": thresholds.max_drawdown_pct,
+        "loss_threshold_pct": thresholds.loss_threshold_pct,
+    }

--- a/risk_management/templates/base.html
+++ b/risk_management/templates/base.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Passivbot Risk Dashboard{% endblock %}</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --background: #0f172a;
+        --surface: #1e293b;
+        --accent: #38bdf8;
+        --text: #e2e8f0;
+        --muted: #94a3b8;
+        --danger: #f87171;
+        --success: #34d399;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--background);
+        color: var(--text);
+      }
+
+      header {
+        background: var(--surface);
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 1.5rem 2rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+
+      main {
+        padding: 2rem;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      button,
+      .button {
+        background: var(--accent);
+        color: #0f172a;
+        border: none;
+        padding: 0.6rem 1.2rem;
+        border-radius: 0.75rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      button:hover,
+      .button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 25px rgba(56, 189, 248, 0.25);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(30, 41, 59, 0.6);
+        border-radius: 0.75rem;
+        overflow: hidden;
+      }
+
+      th,
+      td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+      }
+
+      thead {
+        background: rgba(148, 163, 184, 0.1);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        font-size: 0.75rem;
+        color: var(--muted);
+      }
+
+      tbody tr:nth-child(odd) {
+        background: rgba(15, 23, 42, 0.4);
+      }
+
+      tbody tr:nth-child(even) {
+        background: rgba(15, 23, 42, 0.6);
+      }
+
+      .card {
+        background: rgba(30, 41, 59, 0.6);
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+      }
+
+      .card h2 {
+        margin: 0 0 0.5rem;
+        font-size: 1.25rem;
+      }
+
+      .metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .metric {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 0.75rem;
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .metric .label {
+        color: var(--muted);
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      .metric .value {
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.3rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: rgba(148, 163, 184, 0.2);
+        color: var(--muted);
+      }
+
+      .badge.alert {
+        background: rgba(248, 113, 113, 0.2);
+        color: var(--danger);
+      }
+
+      .badge.ok {
+        background: rgba(52, 211, 153, 0.2);
+        color: var(--success);
+      }
+
+      .alerts,
+      .notifications {
+        margin-top: 2rem;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      ul li {
+        padding: 0.5rem 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+      }
+
+      footer {
+        margin-top: 2rem;
+        padding: 2rem;
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+
+      .status {
+        color: var(--danger);
+        font-size: 0.9rem;
+        margin-bottom: 1rem;
+      }
+
+      .gain {
+        color: var(--success);
+      }
+
+      .loss {
+        color: var(--danger);
+      }
+    </style>
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    <header>
+      <h1>Passivbot Risk Dashboard</h1>
+      {% block header_controls %}{% endblock %}
+    </header>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+    <footer>
+      Updated at <span data-generated-at="true">{% block generated_at %}{% endblock %}</span>
+    </footer>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -1,0 +1,322 @@
+{% extends "base.html" %}
+
+{% block header_controls %}
+  <div style="display: flex; align-items: center; gap: 1rem;">
+    <span class="badge">Logged in as {{ user }}</span>
+    <form method="post" action="/logout">
+      <button type="submit">Logout</button>
+    </form>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <section class="card">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+      <div>
+        <h2 style="margin-bottom: 0.5rem;">Portfolio overview</h2>
+        <p style="color: var(--muted); margin: 0;">
+          Snapshot generated at <strong data-overview-generated>{{ snapshot.generated_at }}</strong>
+        </p>
+      </div>
+      <span class="badge {% if snapshot.alerts %}alert{% else %}ok{% endif %}" data-alert-summary>
+        {% if snapshot.alerts %}
+          {{ snapshot.alerts|length }} active alert{{ 's' if snapshot.alerts|length != 1 }}
+        {% else %}
+          All clear
+        {% endif %}
+      </span>
+    </div>
+  </section>
+
+  <div data-accounts>
+    {% for account in snapshot.accounts %}
+      <section class="card" data-account="{{ account.name }}">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+          <h2>{{ account.name }}</h2>
+          <span class="badge">{{ account.positions|length }} position{{ 's' if account.positions|length != 1 }}</span>
+        </div>
+        {% if account.message %}
+          <div class="status">{{ account.message }}</div>
+        {% endif %}
+        <div class="metrics">
+          <div class="metric">
+            <span class="label">Balance</span>
+            <span class="value">{{ account.balance|currency }}</span>
+          </div>
+          <div class="metric">
+            <span class="label">Exposure</span>
+            <span class="value">{{ account.exposure|pct }}</span>
+          </div>
+          <div class="metric">
+            <span class="label">Unrealized PnL</span>
+            <span class="value {% if account.unrealized_pnl >= 0 %}gain{% else %}loss{% endif %}">
+              {{ account.unrealized_pnl|currency }}
+            </span>
+          </div>
+          <div class="metric">
+            <span class="label">Positions</span>
+            <span class="value">{{ account.positions|length }}</span>
+          </div>
+        </div>
+        {% if account.positions %}
+          <div class="table-wrapper" style="overflow-x: auto;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Symbol</th>
+                  <th>Side</th>
+                  <th>Exposure</th>
+                  <th>PnL</th>
+                  <th>Entry</th>
+                  <th>Mark</th>
+                  <th>Liq.</th>
+                  <th>Max DD</th>
+                  <th>TP</th>
+                  <th>SL</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for position in account.positions %}
+                  <tr>
+                    <td>{{ position.symbol }}</td>
+                    <td>{{ position.side }}</td>
+                    <td>{{ position.exposure|pct }}</td>
+                    <td class="{% if position.unrealized_pnl >= 0 %}gain{% else %}loss{% endif %}">
+                      {{ position.unrealized_pnl|currency }} ({{ position.pnl_pct|pct }})
+                    </td>
+                    <td>{{ position.entry_price|currency }}</td>
+                    <td>{{ position.mark_price|currency }}</td>
+                    <td>{% if position.liquidation_price is not none %}{{ position.liquidation_price|currency }}{% else %}-{% endif %}</td>
+                    <td>{% if position.max_drawdown_pct is not none %}{{ position.max_drawdown_pct|pct }}{% else %}-{% endif %}</td>
+                    <td>{% if position.take_profit_price is not none %}{{ position.take_profit_price|currency }}{% else %}-{% endif %}</td>
+                    <td>{% if position.stop_loss_price is not none %}{{ position.stop_loss_price|currency }}{% else %}-{% endif %}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p style="color: var(--muted);">No open positions.</p>
+        {% endif %}
+      </section>
+    {% endfor %}
+  </div>
+
+  <section class="card alerts">
+    <h2>Alerts</h2>
+    {% if snapshot.alerts %}
+      <ul data-alerts>
+        {% for alert in snapshot.alerts %}
+          <li>{{ alert }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p data-alerts style="color: var(--muted);">No active alerts. All monitored metrics are within thresholds.</p>
+    {% endif %}
+  </section>
+
+  <section class="card notifications">
+    <h2>Notification channels</h2>
+    {% if snapshot.notifications %}
+      <ul data-notifications>
+        {% for channel in snapshot.notifications %}
+          <li>{{ channel }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p data-notifications style="color: var(--muted);">No notification channels configured.</p>
+    {% endif %}
+  </section>
+{% endblock %}
+
+{% block generated_at %}{{ snapshot.generated_at }}{% endblock %}
+
+{% block scripts %}
+  <script>
+    const REFRESH_INTERVAL_MS = 10000;
+
+    const formatCurrency = (value) => {
+      const number = Number(value || 0);
+      return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(number);
+    };
+
+    const formatPrice = (value) => {
+      if (value === null || value === undefined || Number.isNaN(Number(value))) {
+        return "-";
+      }
+      return Number(value).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+    };
+
+    const formatPct = (value) => {
+      const number = Number(value || 0) * 100;
+      return `${number.toFixed(2)}%`;
+    };
+
+    const renderSnapshot = (snapshot) => {
+      const generatedAtEl = document.querySelector("[data-generated-at]");
+      if (generatedAtEl) {
+        generatedAtEl.textContent = new Date(snapshot.generated_at).toLocaleString();
+      }
+
+      const overviewGenerated = document.querySelector("[data-overview-generated]");
+      if (overviewGenerated) {
+        overviewGenerated.textContent = new Date(snapshot.generated_at).toLocaleString();
+      }
+
+      const alertBadge = document.querySelector("[data-alert-summary]");
+      if (alertBadge) {
+        if (Array.isArray(snapshot.alerts) && snapshot.alerts.length > 0) {
+          alertBadge.classList.add("alert");
+          alertBadge.classList.remove("ok");
+          const count = snapshot.alerts.length;
+          alertBadge.textContent = `${count} active alert${count === 1 ? "" : "s"}`;
+        } else {
+          alertBadge.classList.add("ok");
+          alertBadge.classList.remove("alert");
+          alertBadge.textContent = "All clear";
+        }
+      }
+
+      const accountsContainer = document.querySelector("[data-accounts]");
+      accountsContainer.innerHTML = snapshot.accounts
+        .map((account) => {
+          const positionsRows = account.positions
+            .map((position) => {
+              const pnlClass = Number(position.unrealized_pnl) >= 0 ? "gain" : "loss";
+              const maxDd = position.max_drawdown_pct !== null && position.max_drawdown_pct !== undefined
+                ? formatPct(position.max_drawdown_pct)
+                : "-";
+              return `
+                <tr>
+                  <td>${position.symbol}</td>
+                  <td>${position.side}</td>
+                  <td>${formatPct(position.exposure)}</td>
+                  <td class="${pnlClass}">${formatCurrency(position.unrealized_pnl)} (${formatPct(position.pnl_pct)})</td>
+                  <td>${formatPrice(position.entry_price)}</td>
+                  <td>${formatPrice(position.mark_price)}</td>
+                  <td>${formatPrice(position.liquidation_price)}</td>
+                  <td>${maxDd}</td>
+                  <td>${formatPrice(position.take_profit_price)}</td>
+                  <td>${formatPrice(position.stop_loss_price)}</td>
+                </tr>
+              `;
+            })
+            .join("");
+
+          const exposureClass = Number(account.unrealized_pnl) >= 0 ? "gain" : "loss";
+
+          return `
+            <section class="card" data-account="${account.name}">
+              <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+                <h2>${account.name}</h2>
+                <span class="badge">${account.positions.length} position${account.positions.length === 1 ? "" : "s"}</span>
+              </div>
+              ${account.message ? `<div class="status">${account.message}</div>` : ""}
+              <div class="metrics">
+                <div class="metric">
+                  <span class="label">Balance</span>
+                  <span class="value">${formatCurrency(account.balance)}</span>
+                </div>
+                <div class="metric">
+                  <span class="label">Exposure</span>
+                  <span class="value">${formatPct(account.exposure)}</span>
+                </div>
+                <div class="metric">
+                  <span class="label">Unrealized PnL</span>
+                  <span class="value ${exposureClass}">${formatCurrency(account.unrealized_pnl)}</span>
+                </div>
+                <div class="metric">
+                  <span class="label">Positions</span>
+                  <span class="value">${account.positions.length}</span>
+                </div>
+              </div>
+              ${account.positions.length > 0
+                ? `<div class="table-wrapper" style="overflow-x: auto;">
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Symbol</th>
+                          <th>Side</th>
+                          <th>Exposure</th>
+                          <th>PnL</th>
+                          <th>Entry</th>
+                          <th>Mark</th>
+                          <th>Liq.</th>
+                          <th>Max DD</th>
+                          <th>TP</th>
+                          <th>SL</th>
+                        </tr>
+                      </thead>
+                      <tbody>${positionsRows}</tbody>
+                    </table>
+                  </div>`
+                : `<p style="color: var(--muted);">No open positions.</p>`}
+            </section>
+          `;
+        })
+        .join("");
+
+      const alertsContainer = document.querySelector("[data-alerts]");
+      if (Array.isArray(snapshot.alerts) && snapshot.alerts.length > 0) {
+        if (alertsContainer.tagName === "UL") {
+          alertsContainer.innerHTML = snapshot.alerts.map((alert) => `<li>${alert}</li>`).join("");
+        } else {
+          const ul = document.createElement("ul");
+          ul.innerHTML = snapshot.alerts.map((alert) => `<li>${alert}</li>`).join("");
+          alertsContainer.replaceWith(ul);
+          ul.setAttribute("data-alerts", "");
+        }
+      } else if (alertsContainer) {
+        if (alertsContainer.tagName === "UL") {
+          const replacement = document.createElement("p");
+          replacement.textContent = "No active alerts. All monitored metrics are within thresholds.";
+          replacement.style.color = "var(--muted)";
+          replacement.setAttribute("data-alerts", "");
+          alertsContainer.replaceWith(replacement);
+        } else {
+          alertsContainer.textContent = "No active alerts. All monitored metrics are within thresholds.";
+        }
+      }
+
+      const notificationsContainer = document.querySelector("[data-notifications]");
+      if (Array.isArray(snapshot.notifications) && snapshot.notifications.length > 0) {
+        if (notificationsContainer.tagName === "UL") {
+          notificationsContainer.innerHTML = snapshot.notifications
+            .map((channel) => `<li>${channel}</li>`)
+            .join("");
+        } else {
+          const ul = document.createElement("ul");
+          ul.innerHTML = snapshot.notifications.map((channel) => `<li>${channel}</li>`).join("");
+          notificationsContainer.replaceWith(ul);
+          ul.setAttribute("data-notifications", "");
+        }
+      } else if (notificationsContainer) {
+        if (notificationsContainer.tagName === "UL") {
+          const replacement = document.createElement("p");
+          replacement.textContent = "No notification channels configured.";
+          replacement.style.color = "var(--muted)";
+          replacement.setAttribute("data-notifications", "");
+          notificationsContainer.replaceWith(replacement);
+        } else {
+          notificationsContainer.textContent = "No notification channels configured.";
+        }
+      }
+    };
+
+    const poll = async () => {
+      try {
+        const response = await fetch("/api/snapshot", { credentials: "include" });
+        if (!response.ok) {
+          return;
+        }
+        const snapshot = await response.json();
+        renderSnapshot(snapshot);
+      } catch (error) {
+        console.error("Failed to refresh snapshot", error);
+      }
+    };
+
+    setInterval(poll, REFRESH_INTERVAL_MS);
+    poll();
+  </script>
+{% endblock %}

--- a/risk_management/templates/login.html
+++ b/risk_management/templates/login.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Login · Passivbot Risk Dashboard{% endblock %}
+
+{% block header_controls %}{% endblock %}
+
+{% block content %}
+  <div class="card" style="max-width: 420px; margin: 4rem auto; text-align: center;">
+    <h2>Sign in</h2>
+    <p style="color: var(--muted); margin-bottom: 1.5rem;">
+      Authenticate to access live portfolio telemetry.
+    </p>
+    {% if error %}
+      <div class="status">{{ error }}</div>
+    {% endif %}
+    <form method="post" action="/login" style="display: grid; gap: 1rem; text-align: left;">
+      <label style="display: grid; gap: 0.4rem; font-size: 0.9rem;">
+        <span>Username</span>
+        <input
+          type="text"
+          name="username"
+          required
+          style="padding: 0.75rem 1rem; border-radius: 0.65rem; border: none; font-size: 1rem;"
+        />
+      </label>
+      <label style="display: grid; gap: 0.4rem; font-size: 0.9rem;">
+        <span>Password</span>
+        <input
+          type="password"
+          name="password"
+          required
+          style="padding: 0.75rem 1rem; border-radius: 0.65rem; border: none; font-size: 1rem;"
+        />
+      </label>
+      <button type="submit">Login</button>
+    </form>
+  </div>
+{% endblock %}
+
+{% block generated_at %}—{% endblock %}

--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -1,0 +1,168 @@
+"""FastAPI powered web dashboard for Passivbot risk management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from passlib.context import CryptContext
+from starlette.middleware.sessions import SessionMiddleware
+
+from .configuration import RealtimeConfig
+from .realtime import RealtimeDataFetcher
+from .snapshot_utils import build_presentable_snapshot
+
+
+class AuthManager:
+    """Handle authentication for the dashboard."""
+
+    def __init__(
+        self,
+        secret_key: str,
+        users: Mapping[str, str],
+        session_cookie_name: str = "risk_dashboard_session",
+    ) -> None:
+        if not secret_key:
+            raise ValueError("Authentication requires a non-empty secret key.")
+        if not users:
+            raise ValueError("At least one dashboard user must be configured.")
+        self.secret_key = secret_key
+        self.users = dict(users)
+        self.session_cookie_name = session_cookie_name
+        self._password_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+    def authenticate(self, username: str, password: str) -> bool:
+        hashed = self.users.get(username)
+        if not hashed:
+            return False
+        return self._password_context.verify(password, hashed)
+
+
+class RiskDashboardService:
+    """Wrap a realtime fetcher to expose snapshot data."""
+
+    def __init__(self, fetcher: RealtimeDataFetcher) -> None:
+        self._fetcher = fetcher
+
+    async def fetch_snapshot(self) -> Dict[str, Any]:
+        return await self._fetcher.fetch_snapshot()
+
+    async def close(self) -> None:
+        await self._fetcher.close()
+
+
+def create_app(
+    config: RealtimeConfig,
+    *,
+    service: RiskDashboardService | None = None,
+    auth_manager: AuthManager | None = None,
+    templates_dir: Path | None = None,
+) -> FastAPI:
+    if service is None:
+        service = RiskDashboardService(RealtimeDataFetcher(config))
+    if config.auth is None and auth_manager is None:
+        raise ValueError("Realtime configuration must include authentication details for the web dashboard.")
+    if auth_manager is None and config.auth is not None:
+        auth_manager = AuthManager(
+            config.auth.secret_key,
+            config.auth.users,
+            session_cookie_name=config.auth.session_cookie_name,
+        )
+    assert auth_manager is not None  # for mypy/static tools
+
+    app = FastAPI(title="Passivbot Risk Dashboard")
+    app.state.service = service
+    app.state.auth_manager = auth_manager
+
+    templates_path = templates_dir or Path(__file__).with_name("templates")
+    templates = Jinja2Templates(directory=str(templates_path))
+
+    def currency_filter(value: Any) -> str:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "-"
+        return f"${number:,.2f}"
+
+    def pct_filter(value: Any) -> str:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "0.00%"
+        return f"{number * 100:.2f}%"
+
+    templates.env.filters.setdefault("currency", currency_filter)
+    templates.env.filters.setdefault("pct", pct_filter)
+
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=auth_manager.secret_key,
+        session_cookie=auth_manager.session_cookie_name,
+    )
+
+    def get_service(request: Request) -> RiskDashboardService:
+        return request.app.state.service
+
+    def require_user(request: Request) -> str:
+        user = request.session.get("user")
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        return str(user)
+
+    @app.get("/login", response_class=HTMLResponse)
+    async def login_form(request: Request) -> HTMLResponse:
+        if request.session.get("user"):
+            return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
+        return templates.TemplateResponse("login.html", {"request": request, "error": None})
+
+    @app.post("/login", response_class=HTMLResponse)
+    async def login_submit(
+        request: Request,
+        username: str = Form(...),
+        password: str = Form(...),
+    ) -> HTMLResponse:
+        if not auth_manager.authenticate(username, password):
+            context = {"request": request, "error": "Invalid username or password."}
+            return templates.TemplateResponse("login.html", context, status_code=status.HTTP_401_UNAUTHORIZED)
+        request.session["user"] = username
+        return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.post("/logout")
+    async def logout(request: Request) -> RedirectResponse:
+        request.session.pop("user", None)
+        return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def dashboard(request: Request, service: RiskDashboardService = Depends(get_service)) -> HTMLResponse:
+        user = request.session.get("user")
+        if not user:
+            return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+        snapshot = await service.fetch_snapshot()
+        view_model = build_presentable_snapshot(snapshot)
+        return templates.TemplateResponse(
+            "dashboard.html",
+            {
+                "request": request,
+                "user": user,
+                "snapshot": view_model,
+            },
+        )
+
+    @app.get("/api/snapshot", response_class=JSONResponse)
+    async def api_snapshot(
+        request: Request,
+        service: RiskDashboardService = Depends(get_service),
+        _: str = Depends(require_user),
+    ) -> JSONResponse:
+        snapshot = await service.fetch_snapshot()
+        view_model = build_presentable_snapshot(snapshot)
+        return JSONResponse(view_model)
+
+    @app.on_event("shutdown")
+    async def shutdown() -> None:  # pragma: no cover - FastAPI lifecycle
+        await service.close()
+
+    return app

--- a/risk_management/web_server.py
+++ b/risk_management/web_server.py
@@ -1,0 +1,28 @@
+"""Command line entry point for the risk management web dashboard."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import uvicorn
+
+from .configuration import load_realtime_config
+from .web import create_app
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Launch the Passivbot risk dashboard web UI")
+    parser.add_argument("--config", type=Path, required=True, help="Path to the realtime configuration file")
+    parser.add_argument("--host", default="0.0.0.0", help="Host address for the web server")
+    parser.add_argument("--port", type=int, default=8000, help="Port for the web server")
+    parser.add_argument("--reload", action="store_true", help="Enable autoreload (development only)")
+    args = parser.parse_args(argv)
+
+    config = load_realtime_config(args.config)
+    app = create_app(config)
+    uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_risk_management_realtime.py
+++ b/tests/test_risk_management_realtime.py
@@ -1,0 +1,105 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from risk_management.configuration import AccountConfig, RealtimeConfig
+from risk_management.dashboard import build_dashboard
+from risk_management.realtime import RealtimeDataFetcher
+from risk_management.snapshot_utils import build_presentable_snapshot
+
+
+class StubAccountClient:
+    def __init__(self, name: str, balance: float, positions: list[dict[str, float]]) -> None:
+        self.name = name
+        self.balance = balance
+        self.positions = positions
+        self.closed = False
+
+    async def fetch(self) -> dict:
+        return {"name": self.name, "balance": self.balance, "positions": list(self.positions)}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FailingAccountClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def fetch(self) -> dict:
+        raise RuntimeError("simulated failure")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_realtime_fetcher_combines_accounts() -> None:
+    config = RealtimeConfig(
+        accounts=[
+            AccountConfig(name="Demo A", exchange="binance", credentials={}),
+            AccountConfig(name="Demo B", exchange="okx", credentials={}),
+        ],
+        alert_thresholds={
+            "wallet_exposure_pct": 0.5,
+            "position_wallet_exposure_pct": 0.3,
+            "max_drawdown_pct": 0.4,
+            "loss_threshold_pct": -0.2,
+        },
+        notification_channels=["email:test@example.com"],
+    )
+    clients = [
+        StubAccountClient(
+            "Demo A",
+            10_000,
+            [
+                {
+                    "symbol": "BTCUSDT",
+                    "side": "long",
+                    "notional": 2_500,
+                    "entry_price": 62_000,
+                    "mark_price": 63_000,
+                    "wallet_exposure_pct": 0.25,
+                    "unrealized_pnl": 200,
+                    "max_drawdown_pct": 0.1,
+                }
+            ],
+        ),
+        StubAccountClient("Demo B", 5_000, []),
+    ]
+    fetcher = RealtimeDataFetcher(config, account_clients=clients)
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+
+    assert snapshot["accounts"][0]["name"] == "Demo A"
+    assert snapshot["accounts"][0]["positions"][0]["symbol"] == "BTCUSDT"
+
+    view = build_presentable_snapshot(snapshot)
+    assert view["accounts"][0]["positions"][0]["symbol"] == "BTCUSDT"
+    assert view["alerts"] == []
+
+    dashboard = build_dashboard(snapshot)
+    assert "Demo A" in dashboard
+
+    asyncio.run(fetcher.close())
+    assert clients[0].closed and clients[1].closed
+
+
+def test_realtime_fetcher_reports_errors() -> None:
+    config = RealtimeConfig(
+        accounts=[AccountConfig(name="Problematic", exchange="binance", credentials={})],
+        alert_thresholds={},
+        notification_channels=[],
+    )
+    fetcher = RealtimeDataFetcher(config, account_clients=[FailingAccountClient()])
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+
+    assert "account_messages" in snapshot
+    assert "Problematic" in snapshot["account_messages"]
+
+    view = build_presentable_snapshot(snapshot)
+    assert view["accounts"][0]["message"] is not None
+
+    asyncio.run(fetcher.close())

--- a/tests/test_risk_management_web.py
+++ b/tests/test_risk_management_web.py
@@ -1,0 +1,119 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("passlib")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("passlib")
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from passlib.context import CryptContext
+
+from risk_management.configuration import AccountConfig, RealtimeConfig
+from risk_management.web import AuthManager, RiskDashboardService, create_app
+
+
+class StubFetcher:
+    def __init__(self, snapshot: dict) -> None:
+        self.snapshot = snapshot
+        self.closed = False
+
+    async def fetch_snapshot(self) -> dict:
+        return self.snapshot
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def sample_snapshot() -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "generated_at": now,
+        "accounts": [
+            {
+                "name": "Demo Account",
+                "balance": 12_000,
+                "positions": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "side": "long",
+                        "notional": 3_000,
+                        "entry_price": 62_500,
+                        "mark_price": 63_200,
+                        "liquidation_price": 52_000,
+                        "wallet_exposure_pct": 0.25,
+                        "unrealized_pnl": 210,
+                        "max_drawdown_pct": 0.12,
+                    }
+                ],
+            }
+        ],
+        "alert_thresholds": {
+            "wallet_exposure_pct": 0.65,
+            "position_wallet_exposure_pct": 0.25,
+            "max_drawdown_pct": 0.25,
+            "loss_threshold_pct": -0.08,
+        },
+        "notification_channels": ["email:risk-team@example.com"],
+    }
+
+
+@pytest.fixture
+def auth_manager() -> AuthManager:
+    context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    password_hash = context.hash("admin123")
+    return AuthManager(secret_key="super-secret", users={"admin": password_hash})
+
+
+def create_test_app(snapshot: dict, auth_manager: AuthManager) -> tuple[TestClient, StubFetcher]:
+    fetcher = StubFetcher(snapshot)
+    service = RiskDashboardService(fetcher)  # type: ignore[arg-type]
+    config = RealtimeConfig(accounts=[AccountConfig(name="Demo", exchange="binance", credentials={})])
+    app = create_app(config, service=service, auth_manager=auth_manager)
+    return TestClient(app), fetcher
+
+
+def test_web_dashboard_auth_flow(sample_snapshot: dict, auth_manager: AuthManager) -> None:
+    client, fetcher = create_test_app(sample_snapshot, auth_manager)
+    with client:
+        response = client.get("/", allow_redirects=False)
+        assert response.status_code in {302, 303}
+        assert response.headers["location"].endswith("/login")
+
+        response = client.get("/login")
+        assert response.status_code == 200
+        assert "Sign in" in response.text
+
+        response = client.post("/login", data={"username": "admin", "password": "wrong"})
+        assert response.status_code == 401
+        assert "Invalid username" in response.text
+
+        response = client.post(
+            "/login",
+            data={"username": "admin", "password": "admin123"},
+            allow_redirects=False,
+        )
+        assert response.status_code in {302, 303}
+
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "Demo Account" in response.text
+
+        api_response = client.get("/api/snapshot")
+        assert api_response.status_code == 200
+        payload = api_response.json()
+        assert payload["accounts"][0]["name"] == "Demo Account"
+
+        logout_response = client.post("/logout", allow_redirects=False)
+        assert logout_response.status_code in {302, 303}
+
+    assert fetcher.closed


### PR DESCRIPTION
## Summary
- add configuration parsing and realtime data fetcher that surfaces per-account status messages
- extend terminal dashboard to consume realtime snapshots and deliver structured data for the new FastAPI web UI
- build authenticated web dashboard with auto-refreshing UI, helper scripts, example config, and regression tests

## Testing
- pytest tests/test_risk_management_realtime.py tests/test_risk_management_web.py


------
https://chatgpt.com/codex/tasks/task_b_68f9d574ad1c832385ac8200b4f867b6