### PR TITLE
Reduce repeated authentication warnings in realtime fetcher

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -13,6 +13,15 @@ from custom_endpoint_overrides import (
     load_custom_endpoint_config,
 )
 
+try:  # pragma: no cover - optional dependency when running tests
+    from ccxt.base.errors import AuthenticationError
+except (ModuleNotFoundError, ImportError):  # pragma: no cover - ccxt is optional for tests
+
+    class AuthenticationError(Exception):
+        """Fallback authentication error used when ccxt is unavailable."""
+
+        pass
+
 from .account_clients import AccountClientProtocol, CCXTAccountClient
 from .configuration import CustomEndpointSettings, RealtimeConfig
 
@@ -66,6 +75,7 @@ class RealtimeDataFetcher:
             self._account_clients = clients
         else:
             self._account_clients = list(account_clients)
+        self._last_auth_errors: Dict[str, str] = {}
 
     async def fetch_snapshot(self) -> Dict[str, Any]:
         tasks = [client.fetch() for client in self._account_clients]
@@ -74,12 +84,39 @@ class RealtimeDataFetcher:
         account_messages: Dict[str, str] = {}
         for account_config, result in zip(self.config.accounts, results):
             if isinstance(result, Exception):
-                message = f"{account_config.name}: {result}"
-                logger.exception("Failed to fetch snapshot for %s", account_config.name, exc_info=result)
+                if isinstance(result, AuthenticationError):
+                    message = (
+                        f"{account_config.name}: authentication failed - {result}"
+                    )
+                    error_message = str(result)
+                    previous_error = self._last_auth_errors.get(account_config.name)
+                    if previous_error != error_message:
+                        logger.warning(
+                            "Authentication failed for %s: %s",
+                            account_config.name,
+                            result,
+                        )
+                        self._last_auth_errors[account_config.name] = error_message
+                    else:
+                        logger.debug(
+                            "Authentication failure for %s unchanged: %s",
+                            account_config.name,
+                            result,
+                        )
+                else:
+                    message = f"{account_config.name}: {result}"
+                    logger.exception(
+                        "Failed to fetch snapshot for %s", account_config.name, exc_info=result
+                    )
                 account_messages[account_config.name] = message
                 accounts_payload.append({"name": account_config.name, "balance": 0.0, "positions": []})
             else:
                 accounts_payload.append(result)
+                if account_config.name in self._last_auth_errors:
+                    logger.info(
+                        "Authentication for %s restored", account_config.name
+                    )
+                    self._last_auth_errors.pop(account_config.name, None)
         snapshot = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "accounts": accounts_payload,

--- a/tests/risk_management/test_realtime.py
+++ b/tests/risk_management/test_realtime.py
@@ -1,0 +1,79 @@
+"""Tests for realtime snapshot fetching behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Iterable, List
+
+from risk_management.configuration import AccountConfig, RealtimeConfig
+from risk_management.realtime import AuthenticationError, RealtimeDataFetcher
+
+
+class StubAccountClient:
+    """Test double for ``AccountClientProtocol`` returning predefined outcomes."""
+
+    def __init__(self, outcomes: Iterable[object]):
+        self._outcomes: List[object] = list(outcomes)
+
+    async def fetch(self):  # pragma: no cover - exercised through tests
+        if not self._outcomes:
+            raise RuntimeError("No more outcomes configured for StubAccountClient")
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    async def close(self) -> None:  # pragma: no cover - included for interface completeness
+        return None
+
+
+def _make_config() -> RealtimeConfig:
+    return RealtimeConfig(accounts=[AccountConfig(name="Test", exchange="test")])
+
+
+def test_authentication_warning_logged_once(caplog) -> None:
+    client = StubAccountClient(
+        [AuthenticationError("invalid"), AuthenticationError("invalid")]
+    )
+    fetcher = RealtimeDataFetcher(_make_config(), account_clients=[client])
+
+    caplog.set_level(logging.WARNING)
+
+    snapshot_first = asyncio.run(fetcher.fetch_snapshot())
+    snapshot_second = asyncio.run(fetcher.fetch_snapshot())
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert snapshot_first["account_messages"]["Test"].startswith(
+        "Test: authentication failed"
+    )
+    assert snapshot_second["account_messages"]["Test"].startswith(
+        "Test: authentication failed"
+    )
+    asyncio.run(fetcher.close())
+
+
+def test_authentication_warning_resets_after_success(caplog) -> None:
+    client = StubAccountClient(
+        [
+            AuthenticationError("invalid"),
+            {"name": "Test", "balance": 123.0, "positions": []},
+            AuthenticationError("invalid"),
+        ]
+    )
+    fetcher = RealtimeDataFetcher(_make_config(), account_clients=[client])
+
+    caplog.set_level(logging.INFO)
+
+    asyncio.run(fetcher.fetch_snapshot())
+    snapshot_success = asyncio.run(fetcher.fetch_snapshot())
+    asyncio.run(fetcher.fetch_snapshot())
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    infos = [record for record in caplog.records if record.levelno == logging.INFO]
+
+    assert len(warnings) == 2
+    assert any("Authentication for Test restored" in record.message for record in infos)
+    assert snapshot_success["accounts"][0]["balance"] == 123.0
+    asyncio.run(fetcher.close())


### PR DESCRIPTION
## Summary
- suppress duplicate realtime authentication warnings by tracking the last error per account
- log when authentication recovers and reset the stored state
- add regression tests covering the new logging behaviour

## Testing
- pytest tests/risk_management -q

------
https://chatgpt.com/codex/tasks/task_b_68f9fc3c16b483238276932980ef64f7