### PR TITLE
Improve risk management credential handling

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -105,10 +105,6 @@ class RealtimeDataFetcher:
                             result,
                         )
 
-                    logger.warning(
-                        "Authentication failed for %s: %s", account_config.name, result
-                    )
-
                 else:
                     message = f"{account_config.name}: {result}"
                     logger.exception(

--- a/tests/risk_management/test_account_clients.py
+++ b/tests/risk_management/test_account_clients.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from risk_management.account_clients import _apply_credentials
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.headers = {"Existing": "1"}
+        self.options = {"existing": True}
+
+
+def test_apply_credentials_merges_and_sets_sensitive_fields() -> None:
+    client = DummyClient()
+
+    credentials = {
+        "apiKey": "key",
+        "secret": "secret",
+        "password": "pass",
+        "headers": {"X-First": "A"},
+        "options": {"defaultType": "swap"},
+        "ccxt": {
+            "uid": "123",
+            "headers": {"X-Nested": "B"},
+        },
+    }
+
+    _apply_credentials(client, credentials)
+
+    assert client.apiKey == "key"
+    assert client.secret == "secret"
+    assert client.password == "pass"
+    assert client.uid == "123"
+    assert client.headers == {"Existing": "1", "X-First": "A", "X-Nested": "B"}
+    assert client.options == {"existing": True, "defaultType": "swap"}


### PR DESCRIPTION
## Summary
- normalise realtime credential payloads using the same aliases and nested fields as passivbot
- expand ccxt client setup to merge headers, options, and nested ccxt overrides while ignoring metadata
- reduce duplicate authentication warnings and add targeted unit tests covering the new helpers

## Testing
- PYTHONPATH=src:. pytest tests/risk_management -q

------
https://chatgpt.com/codex/tasks/task_b_68fa0ba4e0988323b4300c7ce5917789