### PR TITLE
Add CLI custom endpoint override to risk dashboard server

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -89,6 +89,13 @@ feature off entirely.  Omitting the section keeps the default auto-discovery
 behaviour, which searches for `configs/custom_endpoints.json` relative to the
 current working directory.
 
+Alternatively, override the behaviour at launch time with
+`--custom-endpoints`.  For example, run the web server with
+`--custom-endpoints ../configs/custom_endpoints.json` to force the same proxy
+file Passivbot uses, `--custom-endpoints auto` to re-enable discovery, or
+`--custom-endpoints none` to disable overrides regardless of the configuration
+file.
+
 ### Authentication
 
 The web UI requires bcrypt hashed passwords.  Use the helper script to generate

--- a/risk_management/web_server.py
+++ b/risk_management/web_server.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import uvicorn
 
-from .configuration import load_realtime_config
+from .configuration import CustomEndpointSettings, load_realtime_config
 from .web import create_app
 
 
@@ -16,10 +16,34 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--config", type=Path, required=True, help="Path to the realtime configuration file")
     parser.add_argument("--host", default="0.0.0.0", help="Host address for the web server")
     parser.add_argument("--port", type=int, default=8000, help="Port for the web server")
+    parser.add_argument(
+        "--custom-endpoints",
+        help=(
+            "Override custom endpoint behaviour. Provide a JSON file path to reuse the same "
+            "proxy configuration as Passivbot, 'auto' to enable auto-discovery, or 'none' to "
+            "disable overrides."
+        ),
+    )
     parser.add_argument("--reload", action="store_true", help="Enable autoreload (development only)")
     args = parser.parse_args(argv)
 
     config = load_realtime_config(args.config)
+    override = args.custom_endpoints
+    if override is not None:
+        override_normalized = override.strip()
+        if not override_normalized:
+            config.custom_endpoints = None
+        else:
+            lowered = override_normalized.lower()
+            if lowered in {"none", "off", "disable"}:
+                config.custom_endpoints = CustomEndpointSettings(path=None, autodiscover=False)
+            elif lowered in {"auto", "autodiscover", "default"}:
+                config.custom_endpoints = CustomEndpointSettings(path=None, autodiscover=True)
+            else:
+                config.custom_endpoints = CustomEndpointSettings(
+                    path=override_normalized,
+                    autodiscover=False,
+                )
     app = create_app(config)
     uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)
 


### PR DESCRIPTION
## Summary
- add a `--custom-endpoints` flag to the risk dashboard web server CLI so deployments can reuse Passivbot proxy configs or disable overrides explicitly
- update the risk management README to document the new launch-time override option for custom endpoints

## Testing
- not run (not easily testable in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68fa196eb5148323a759ea77b1096c3b