### PR TITLE
Allow risk dashboard headers to reference API credentials

### DIFF
--- a/tests/risk_management/test_account_clients.py
+++ b/tests/risk_management/test_account_clients.py
@@ -37,3 +37,14 @@ def test_apply_credentials_merges_and_sets_sensitive_fields() -> None:
     assert client.uid == "123"
     assert client.headers == {"Existing": "1", "X-First": "A", "X-Nested": "B"}
     assert client.options == {"existing": True, "defaultType": "swap"}
+
+
+def test_apply_credentials_formats_header_placeholders() -> None:
+    client = DummyClient()
+
+    client.headers["Authorization"] = "Bearer {apiKey}:{secret}"
+    credentials = {"apiKey": "alpha", "secret": "beta"}
+
+    _apply_credentials(client, credentials)
+
+    assert client.headers["Authorization"] == "Bearer alpha:beta"


### PR DESCRIPTION
## Summary
- expand realtime account client header handling to substitute credential placeholders
- ensure credential-derived headers are normalised after substitution
- cover the formatting behaviour with a dedicated unit test

## Testing
- pytest tests/risk_management/test_account_clients.py -q

------
https://chatgpt.com/codex/tasks/task_b_68fb41d30844832382eee181b2eefd7b