### PR TITLE
Auto-discover shared credentials for risk dashboard

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -53,11 +53,13 @@ inline under the affected account.
 The sample file `risk_management/realtime_config.example.json` is ready to be
 copied and adjusted.  It expects API key entries named `binance_01`, `okx_01`,
 and `bybit_01` in the credentials file and demonstrates the venue-specific
-parameters required to fetch balances and positions:
+parameters required to fetch balances and positions.  When the `api_keys_file`
+field is omitted (as below) the loader walks up from the realtime config
+directory and uses the first `api-keys.json` it encounters, matching Passivbot's
+default layout.  Provide an explicit path when storing credentials elsewhere:
 
 ```json
 {
-  "api_keys_file": "../api-keys.json",
   "custom_endpoints": {
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false
@@ -150,11 +152,11 @@ cards, alerts, and notification channels without a full refresh.
 If your Passivbot installation proxies REST requests through
 `configs/custom_endpoints.json`, mirror the same routing for the risk
 dashboard by declaring a `custom_endpoints` block in your realtime
-configuration:
+configuration.  The example below keeps automatic API key discovery and
+overrides only the endpoint file:
 
 ```json
 {
-  "api_keys_file": "../api-keys.json",
   "custom_endpoints": {
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false

--- a/risk_management/realtime_config.example.json
+++ b/risk_management/realtime_config.example.json
@@ -1,5 +1,4 @@
 {
-  "api_keys_file": "../api-keys.json",
   "custom_endpoints": {
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -1,5 +1,4 @@
 {
-  "api_keys_file": "../api-keys.json",
   "accounts": [
     {
       "name": "Binance Futures",

--- a/tests/risk_management/test_configuration.py
+++ b/tests/risk_management/test_configuration.py
@@ -192,3 +192,36 @@ def test_load_realtime_config_expands_user_path(tmp_path: Path, monkeypatch) -> 
     assert config.accounts[0].credentials["apiKey"] == "x"
     assert config.config_root == config_path.parent.resolve()
 
+
+def test_load_realtime_config_discovers_api_keys_file(tmp_path: Path) -> None:
+    repo_root = tmp_path / "passivbot"
+    repo_root.mkdir()
+
+    api_keys_path = repo_root / "api-keys.json"
+    api_keys_path.write_text(
+        json.dumps({"binance": {"exchange": "binance", "key": "auto", "secret": "secret"}}),
+        encoding="utf-8",
+    )
+
+    config_dir = repo_root / "risk_management"
+    config_dir.mkdir()
+    config_path = config_dir / "realtime.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "accounts": [
+                    {
+                        "name": "Binance",
+                        "exchange": "binance",
+                        "api_key_id": "binance",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_realtime_config(config_path)
+
+    assert config.accounts[0].credentials["apiKey"] == "auto"
+


### PR DESCRIPTION
## Summary
- auto-detect api-keys.json when the realtime config omits api_keys_file
- update docs and sample configs to rely on automatic credential discovery
- add coverage ensuring the loader finds shared credentials without manual wiring

## Testing
- pytest tests/risk_management/test_configuration.py

------
https://chatgpt.com/codex/tasks/task_b_68fb4807adc083239720a9129922e09d