### PR TITLE
Align risk dashboard config with shared API keys

### DIFF
--- a/api-keys.json
+++ b/api-keys.json
@@ -1,0 +1,45 @@
+{
+    "referrals": {
+        "bybit": "https://partner.bybit.com/b/passivbot",
+        "bitget": "https://partner.bitget.com/bg/Y8FU1W",
+        "okx": "https://www.okx.com/join/PASSIVBOT",
+        "binance": "https://accounts.binance.com/register?ref=TII4B07C",
+        "gateio": "https://www.gate.io/signup/AQCRUVTE",
+        "hyperliquid": "https://app.hyperliquid.xyz/join/PASSIVBOT",
+        "defx": "https://app.defx.com/join/4DKR14",
+        "kucoin": "https://www.kucoin.com/r/rf/CX8Q6DUF"
+    },
+    "binance_01": {
+        "exchange": "binance",
+        "key": "3a85ae8aghfghv",
+        "secret": "hvgvuhgj"
+    },
+    "bybit_01": {
+        "exchange": "bybit",
+        "key": "9f2d4d1c-5dcd-4a9c-b823-e4e9b4705ba0",
+        "secret": "7bb418d6a21177908d1a40de4fa288b7c2e47890edef1ebd453846f85531b0e1"
+    },
+    "bitget_01": {
+        "exchange": "bitget",
+        "key": "key",
+        "secret": "secret",
+        "passphrase": "passphrase"
+    },
+    "okx_01": {
+        "exchange": "okx",
+        "key": "key",
+        "secret": "secret",
+        "passphrase": "passphrase"
+    },
+    "hyperliquid_01": {
+        "exchange": "hyperliquid",
+        "wallet_address": "wallet_address",
+        "private_key": "private_key",
+        "is_vault": false
+    },
+    "gateio_01": {
+        "exchange": "gateio",
+        "key": "key",
+        "secret": "secret"
+    }
+}

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -1,4 +1,9 @@
 {
+  "api_keys_file": "../api-keys.json",
+  "custom_endpoints": {
+    "path": "../configs/custom_endpoints.json",
+    "autodiscover": false
+  },
   "accounts": [
     {
       "name": "Binance Futures",
@@ -15,6 +20,16 @@
         "balance": {"type": "swap"},
         "positions": {"type": "swap"}
       }
+    },
+    {
+      "name": "Bybit USDT Perpetuals",
+      "exchange": "bybit",
+      "api_key_id": "bybit_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
     }
   ],
   "alert_thresholds": {
@@ -24,14 +39,14 @@
     "loss_threshold_pct": -0.08
   },
   "notification_channels": [
-    "email:risk-team@example.com",
+    "email:admin@plezna.com",
     "slack:#passivbot-risk-alerts"
   ],
   "auth": {
-    "secret_key": "replace-me-with-a-long-random-string",
+    "secret_key": "jhgjhguyg^^554$$67CFCGFDGFd",
     "session_cookie_name": "risk_dashboard_session",
     "users": {
-      "admin": "replace-with-bcrypt-hash"
+      "admin": "$2b$12$0ZCLkFp6iuhlEFshgPCBz.jhgjhbhb"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a concrete api-keys.json matching the shared credentials structure
- update the realtime dashboard config to reference the shared keys file and include the new account settings

## Testing
- python -m json.tool api-keys.json
- python -m json.tool risk_management/realtime_config.json

------
https://chatgpt.com/codex/tasks/task_b_68fb6ac43d808323a1ada043e381a9a9