### PR TITLE
Add configurable debug logging for exchange payloads

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -134,6 +134,21 @@ fine for venues that default to USD-M perpetual endpoints.
 
 
 
+### Debugging exchange payloads
+
+Set `"debug_api_payloads": true` at the top level of your realtime
+configuration to capture the raw JSON returned by `fetch_balance()` and
+`fetch_positions()` for every account. The payloads, along with the request
+parameters, are emitted at the DEBUG log level and can help compare responses
+between exchanges or custom endpoint variants. Toggle the flag back to `false`
+after finishing your investigation to avoid cluttering the logs.
+
+When only a subset of accounts requires verbose tracing, add
+`"debug_api_payloads": true` to the specific account blocks instead of the
+global setting. This keeps logging focused on the venues under review.
+
+
+
 ## Web dashboard
 
 Launch the FastAPI web server to obtain an authenticated dashboard with live

--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -109,6 +109,15 @@ class RealtimeDataFetcher:
         else:
             self._account_clients = list(account_clients)
         self._last_auth_errors: Dict[str, str] = {}
+        if config.debug_api_payloads:
+            logger.info(
+                "Exchange API payload debug logging enabled for realtime fetcher"
+            )
+        for account in config.accounts:
+            if account.debug_api_payloads and not config.debug_api_payloads:
+                logger.info(
+                    "Debug API payload logging enabled for account %s", account.name
+                )
 
     async def fetch_snapshot(self) -> Dict[str, Any]:
         tasks = [client.fetch() for client in self._account_clients]

--- a/risk_management/realtime_config.example.json
+++ b/risk_management/realtime_config.example.json
@@ -3,6 +3,7 @@
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false
   },
+  "debug_api_payloads": false,
   "accounts": [
     {
       "name": "Binance Futures",

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -1,5 +1,6 @@
 {
   "api_keys_file": "../api-keys.json",
+  "debug_api_payloads": false,
   "custom_endpoints": {
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false


### PR DESCRIPTION
## Summary
- add configuration flags to enable exchange API payload debugging globally or per account
- log full JSON payloads from ccxt balance and position calls when debugging is enabled
- document the new option and update sample realtime configuration templates

## Testing
- python -m compileall risk_management

------
https://chatgpt.com/codex/tasks/task_b_68fc88569c808323a0b73e3e4519f85a