### PR TITLE
Enable debug logging when payload tracing is requested

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -12,6 +12,18 @@ from typing import Any, Dict, Iterable, List, Mapping, Set
 logger = logging.getLogger(__name__)
 
 
+def _ensure_debug_logging_enabled() -> None:
+    """Raise logging verbosity when debug API payloads are requested."""
+
+    root_logger = logging.getLogger()
+    if root_logger.level in {logging.NOTSET, logging.WARNING, logging.ERROR, logging.CRITICAL} or root_logger.level > logging.DEBUG:
+        root_logger.setLevel(logging.DEBUG)
+
+    risk_logger = logging.getLogger("risk_management")
+    if risk_logger.level in {logging.NOTSET} or risk_logger.level > logging.DEBUG:
+        risk_logger.setLevel(logging.DEBUG)
+
+
 def _coerce_bool(value: Any, default: bool = False) -> bool:
     """Return a boolean for ``value`` supporting common string representations."""
 
@@ -305,6 +317,9 @@ def load_realtime_config(path: Path) -> RealtimeConfig:
     if not accounts_raw:
         raise ValueError("Realtime configuration must include at least one account entry.")
     debug_api_payloads_default = _coerce_bool(config.get("debug_api_payloads"), False)
+    if debug_api_payloads_default:
+        _ensure_debug_logging_enabled()
+
     accounts = _parse_accounts(accounts_raw, api_keys, debug_api_payloads_default)
     alert_thresholds = {str(k): float(v) for k, v in config.get("alert_thresholds", {}).items()}
     notification_channels = [str(item) for item in config.get("notification_channels", [])]


### PR DESCRIPTION
## Summary
- set the risk management loggers to DEBUG when debug_api_payloads is enabled
- ensure the realtime configuration loader raises verbosity for payload tracing

## Testing
- pytest tests/risk_management

------
https://chatgpt.com/codex/tasks/task_b_68fc8deb45248323b42b4664be4782b1