### PR TITLE
Ensure debug payload logging persists under uvicorn logging config

### DIFF
--- a/tests/risk_management/test_configuration.py
+++ b/tests/risk_management/test_configuration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import List
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -191,6 +192,40 @@ def test_load_realtime_config_expands_user_path(tmp_path: Path, monkeypatch) -> 
     config = load_realtime_config(config_path)
     assert config.accounts[0].credentials["apiKey"] == "x"
     assert config.config_root == config_path.parent.resolve()
+
+
+def test_debug_logging_enabled_for_global_flag(tmp_path: Path, monkeypatch) -> None:
+    payload = _base_payload()
+    payload["debug_api_payloads"] = True
+    config_path = _write_config(tmp_path, payload)
+
+    calls: List[None] = []
+
+    def record_call() -> None:
+        calls.append(None)
+
+    monkeypatch.setattr("risk_management.configuration._ensure_debug_logging_enabled", record_call)
+
+    load_realtime_config(config_path)
+
+    assert calls, "expected debug logging to be enabled when global flag is set"
+
+
+def test_debug_logging_enabled_for_account_flag(tmp_path: Path, monkeypatch) -> None:
+    payload = _base_payload()
+    payload["accounts"][0]["debug_api_payloads"] = True
+    config_path = _write_config(tmp_path, payload)
+
+    calls: List[None] = []
+
+    def record_call() -> None:
+        calls.append(None)
+
+    monkeypatch.setattr("risk_management.configuration._ensure_debug_logging_enabled", record_call)
+
+    load_realtime_config(config_path)
+
+    assert calls, "expected debug logging to be enabled when account flag is set"
 
 
 def test_load_realtime_config_discovers_api_keys_file(tmp_path: Path) -> None:

--- a/tests/risk_management/test_web_server.py
+++ b/tests/risk_management/test_web_server.py
@@ -1,0 +1,79 @@
+"""Tests for risk management web server helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "uvicorn" not in sys.modules:
+    uvicorn_stub = types.ModuleType("uvicorn")
+
+    def _noop_run(*_args, **_kwargs) -> None:  # pragma: no cover - helper for import
+        return None
+
+    uvicorn_stub.run = _noop_run
+    sys.modules["uvicorn"] = uvicorn_stub
+
+from risk_management.configuration import AccountConfig, RealtimeConfig  # noqa: E402
+from risk_management.web_server import _determine_uvicorn_logging  # noqa: E402
+
+
+def _make_config(global_debug: bool = False, account_debug: bool = False) -> RealtimeConfig:
+    account = AccountConfig(
+        name="Example",
+        exchange="binance",
+        credentials={},
+        debug_api_payloads=account_debug,
+    )
+    return RealtimeConfig(accounts=[account], debug_api_payloads=global_debug)
+
+
+def test_determine_uvicorn_logging_defaults_when_disabled() -> None:
+    config = _make_config()
+
+    log_config, log_level = _determine_uvicorn_logging(config)
+
+    assert log_config is None
+    assert log_level == "info"
+
+
+def test_determine_uvicorn_logging_uses_uvicorn_config(monkeypatch) -> None:
+    dummy_logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {},
+        "handlers": {},
+        "loggers": {"": {"handlers": ["default"], "level": "INFO"}},
+    }
+    uvicorn_module = types.ModuleType("uvicorn")
+    uvicorn_config_module = types.ModuleType("uvicorn.config")
+    uvicorn_config_module.LOGGING_CONFIG = dummy_logging_config
+
+    monkeypatch.setitem(sys.modules, "uvicorn", uvicorn_module)
+    monkeypatch.setitem(sys.modules, "uvicorn.config", uvicorn_config_module)
+
+    config = _make_config(global_debug=True)
+
+    log_config, log_level = _determine_uvicorn_logging(config)
+
+    assert log_level == "debug"
+    assert log_config["loggers"][""]["level"] == "DEBUG"
+    assert log_config["loggers"]["risk_management"]["level"] == "DEBUG"
+
+
+def test_determine_uvicorn_logging_handles_missing_uvicorn(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "uvicorn", raising=False)
+    monkeypatch.delitem(sys.modules, "uvicorn.config", raising=False)
+
+    config = _make_config(account_debug=True)
+
+    log_config, log_level = _determine_uvicorn_logging(config)
+
+    assert log_config is None
+    assert log_level == "debug"


### PR DESCRIPTION
## Summary
- trigger debug logging when any account enables payload tracing
- configure uvicorn to respect debug logging when payload tracing is active
- add regression tests covering configuration and web server logging behaviour

## Testing
- pytest tests/risk_management

------
https://chatgpt.com/codex/tasks/task_b_68fc8deb45248323b42b4664be4782b1