### PR TITLE
Apply custom endpoints to realtime ccxt clients

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -19,6 +19,11 @@ except ModuleNotFoundError:  # pragma: no cover - allow tests without ccxt
 
         pass
 
+from custom_endpoint_overrides import (
+    apply_rest_overrides_to_ccxt,
+    resolve_custom_endpoint_override,
+)
+
 try:  # pragma: no cover - passivbot is optional when running tests
     from passivbot.utils import load_ccxt_instance, normalize_exchange_name
 except (ModuleNotFoundError, ImportError):  # pragma: no cover - allow running without passivbot
@@ -213,6 +218,8 @@ def _instantiate_ccxt_client(exchange_id: str, credentials: Mapping[str, Any]) -
         client = load_ccxt_instance(normalized, enable_rate_limit=rate_limited)
         _apply_credentials(client, credentials)
         _disable_fetch_currencies(client)
+        override = resolve_custom_endpoint_override(normalized)
+        apply_rest_overrides_to_ccxt(client, override)
         return client
 
     if ccxt_async is None:
@@ -230,6 +237,8 @@ def _instantiate_ccxt_client(exchange_id: str, credentials: Mapping[str, Any]) -
     client = exchange_class(params)
     _apply_credentials(client, credentials)
     _disable_fetch_currencies(client)
+    override = resolve_custom_endpoint_override(normalized)
+    apply_rest_overrides_to_ccxt(client, override)
     return client
 
 

--- a/tests/risk_management/test_account_clients.py
+++ b/tests/risk_management/test_account_clients.py
@@ -5,7 +5,8 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from risk_management.account_clients import _apply_credentials
+from custom_endpoint_overrides import ResolvedEndpointOverride
+from risk_management.account_clients import _apply_credentials, _instantiate_ccxt_client
 
 
 class DummyClient:
@@ -48,3 +49,43 @@ def test_apply_credentials_formats_header_placeholders() -> None:
     _apply_credentials(client, credentials)
 
     assert client.headers["Authorization"] == "Bearer alpha:beta"
+
+
+def test_instantiate_ccxt_client_applies_custom_endpoints(monkeypatch) -> None:
+    from risk_management import account_clients as module
+
+    class DummyExchange:
+        def __init__(self, params):
+            self.params = params
+            self.hostname = "bybit.com"
+            self.urls = {
+                "api": {"public": "https://api.bybit.com/v5"},
+                "host": "https://api.bybit.com",
+            }
+            self.headers = {}
+            self.options = {}
+            self.has = {}
+
+    class DummyNamespace:
+        def __init__(self):
+            self.bybit = DummyExchange
+
+    monkeypatch.setattr(module, "load_ccxt_instance", None)
+    monkeypatch.setattr(module, "ccxt_async", DummyNamespace())
+    monkeypatch.setattr(module, "normalize_exchange_name", lambda exchange: "bybit")
+
+    override = ResolvedEndpointOverride(
+        exchange_id="bybit",
+        rest_domain_rewrites={"https://api.bybit.com": "https://proxy.example"},
+    )
+
+    def fake_resolve(exchange_id: str):
+        assert exchange_id == "bybit"
+        return override
+
+    monkeypatch.setattr(module, "resolve_custom_endpoint_override", fake_resolve)
+
+    client = _instantiate_ccxt_client("bybit", {})
+
+    assert client.urls["api"]["public"] == "https://proxy.example/v5"
+    assert client.urls["host"] == "https://proxy.example"

--- a/tests/test_custom_endpoints.py
+++ b/tests/test_custom_endpoints.py
@@ -89,6 +89,36 @@ def test_apply_rest_overrides_to_ccxt_updates_urls_and_headers():
     assert exchange.headers["X-Test"] == "1"
 
 
+def test_apply_rest_overrides_handles_nested_api_urls_and_host():
+    override = ResolvedEndpointOverride(
+        exchange_id="bybit",
+        rest_domain_rewrites={"https://api.bybit.com": "https://proxy.example"},
+    )
+
+    class DummyBybit:
+        def __init__(self):
+            self.hostname = "bybit.com"
+            self.urls = {
+                "api": {
+                    "public": {
+                        "linear": "https://api.bybit.com/v5",
+                        "inverse": "https://api.bybit.com/v5",
+                    },
+                    "private": "https://api.bybit.com/v5",
+                },
+                "host": "https://api.bybit.com",
+            }
+            self.headers = {}
+
+    exchange = DummyBybit()
+    apply_rest_overrides_to_ccxt(exchange, override)
+
+    assert exchange.urls["api"]["public"]["linear"] == "https://proxy.example/v5"
+    assert exchange.urls["api"]["public"]["inverse"] == "https://proxy.example/v5"
+    assert exchange.urls["api"]["private"] == "https://proxy.example/v5"
+    assert exchange.urls["host"] == "https://proxy.example"
+
+
 def test_apply_rest_overrides_handles_hostname_placeholder():
     override = ResolvedEndpointOverride(
         exchange_id="bybit",


### PR DESCRIPTION
## Summary
- ensure realtime ccxt account clients always apply resolved REST endpoint overrides
- cover the fallback ccxt-instantiation path with a regression test that verifies rewritten URLs

## Testing
- pytest tests/risk_management/test_account_clients.py tests/test_custom_endpoints.py

------
https://chatgpt.com/codex/tasks/task_b_68fc94f08248832386d14d86109801a0