### PR TITLE
Hide errored accounts from risk dashboard

### DIFF
--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Sequence
 
 from .dashboard import (
     Account,
@@ -19,24 +19,48 @@ def build_presentable_snapshot(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
     generated_at, accounts, thresholds, notifications = parse_snapshot(dict(snapshot))
     alerts = evaluate_alerts(accounts, thresholds)
     account_messages = snapshot.get("account_messages", {}) if isinstance(snapshot, Mapping) else {}
-    return {
+    account_views = _build_account_views(accounts, account_messages)
+
+    payload: Dict[str, Any] = {
         "generated_at": generated_at.isoformat(),
-        "accounts": [_build_account_view(account, account_messages) for account in accounts],
+        "accounts": account_views["visible"],
         "alerts": alerts,
         "notifications": notifications,
         "thresholds": _thresholds_to_view(thresholds),
     }
 
+    if account_views["hidden"]:
+        payload["hidden_accounts"] = account_views["hidden"]
+
+    return payload
+
+
+def _build_account_views(
+    accounts: Sequence[Account], account_messages: Mapping[str, str]
+) -> Dict[str, list[Dict[str, Any]]]:
+    visible_accounts: list[Dict[str, Any]] = []
+    hidden_accounts: list[Dict[str, Any]] = []
+
+    for account in accounts:
+        view = _build_account_view(account, account_messages)
+        if view["message"]:
+            hidden_accounts.append({"name": view["name"], "message": view["message"]})
+            continue
+        visible_accounts.append(view)
+
+    return {"visible": visible_accounts, "hidden": hidden_accounts}
+
 
 def _build_account_view(account: Account, account_messages: Mapping[str, str]) -> Dict[str, Any]:
     positions = [_build_position_view(position, account.balance) for position in account.positions]
+    message = account_messages.get(account.name)
     return {
         "name": account.name,
         "balance": account.balance,
         "exposure": account.exposure_pct(),
         "unrealized_pnl": account.total_unrealized(),
         "positions": positions,
-        "message": account_messages.get(account.name),
+        "message": message,
     }
 
 

--- a/tests/test_risk_management_realtime.py
+++ b/tests/test_risk_management_realtime.py
@@ -100,6 +100,7 @@ def test_realtime_fetcher_reports_errors() -> None:
     assert "Problematic" in snapshot["account_messages"]
 
     view = build_presentable_snapshot(snapshot)
-    assert view["accounts"][0]["message"] is not None
+    assert view["accounts"] == []
+    assert view["hidden_accounts"][0]["name"] == "Problematic"
 
     asyncio.run(fetcher.close())


### PR DESCRIPTION
## Summary
- filter snapshot data so accounts with authentication or configuration errors are excluded from the dashboard
- expose metadata for hidden accounts while keeping the visible list unchanged for healthy portfolios

## Testing
- pytest tests/test_risk_management_realtime.py tests/test_risk_management_web.py

------
https://chatgpt.com/codex/tasks/task_b_68fca0204720832390ca5e28fbc2af36