### PR TITLE
Add Grafana analytics embeds and fix Python 3.9 dataclass usage

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -90,6 +90,26 @@ class EmailSettings:
 
 
 @dataclass()
+class GrafanaDashboardConfig:
+    """Description of a Grafana dashboard or panel to embed."""
+
+    title: str
+    url: str
+    description: str | None = None
+    height: int | None = None
+
+
+@dataclass()
+class GrafanaConfig:
+    """Settings for embedding Grafana dashboards in the web UI."""
+
+    dashboards: List[GrafanaDashboardConfig] = field(default_factory=list)
+    default_height: int = 600
+    theme: str = "dark"
+    base_url: str | None = None
+
+
+@dataclass()
 class RealtimeConfig:
     """Top level realtime configuration."""
 
@@ -102,6 +122,8 @@ class RealtimeConfig:
     email: EmailSettings | None = None
     config_root: Path | None = None
     debug_api_payloads: bool = False
+    reports_dir: Path | None = None
+    grafana: GrafanaConfig | None = None
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
@@ -265,6 +287,79 @@ def _parse_email_settings(settings: Any) -> EmailSettings | None:
     )
 
 
+def _parse_grafana_config(settings: Any) -> GrafanaConfig | None:
+    """Return Grafana embedding settings from ``settings``."""
+
+    if settings is None:
+        return None
+    if not isinstance(settings, Mapping):
+        raise TypeError("Grafana settings must be provided as an object in the configuration file.")
+
+    dashboards_raw = settings.get("dashboards")
+    if dashboards_raw in (None, []):
+        return None
+    if not isinstance(dashboards_raw, Iterable):
+        raise TypeError("Grafana 'dashboards' must be an array of dashboard definitions.")
+
+    dashboards: List[GrafanaDashboardConfig] = []
+    for entry in dashboards_raw:
+        if not isinstance(entry, Mapping):
+            raise TypeError(
+                "Each Grafana dashboard entry must be an object with at least a title and url."
+            )
+        url_raw = entry.get("url")
+        if not url_raw or not str(url_raw).strip():
+            raise ValueError("Grafana dashboard entries require a non-empty 'url'.")
+        title_raw = entry.get("title", "Grafana dashboard")
+        description_raw = entry.get("description")
+        height_raw = entry.get("height")
+
+        height: int | None = None
+        if height_raw not in (None, ""):
+            try:
+                height = int(height_raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Grafana dashboard 'height' must be an integer when provided."
+                ) from exc
+            if height <= 0:
+                raise ValueError(
+                    "Grafana dashboard 'height' must be greater than zero when provided."
+                )
+
+        dashboards.append(
+            GrafanaDashboardConfig(
+                title=str(title_raw).strip() or "Grafana dashboard",
+                url=str(url_raw).strip(),
+                description=str(description_raw).strip()
+                if description_raw not in (None, "")
+                else None,
+                height=height,
+            )
+        )
+
+    default_height_raw = settings.get("default_height", 600)
+    try:
+        default_height = int(default_height_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Grafana 'default_height' must be an integer.") from exc
+    if default_height <= 0:
+        raise ValueError("Grafana 'default_height' must be greater than zero.")
+
+    theme_raw = settings.get("theme", "dark")
+    theme = str(theme_raw).strip() or "dark"
+
+    base_url_raw = settings.get("base_url")
+    base_url = str(base_url_raw).strip() if base_url_raw not in (None, "") else None
+
+    return GrafanaConfig(
+        dashboards=dashboards,
+        default_height=default_height,
+        theme=theme,
+        base_url=base_url,
+    )
+
+
 def _parse_accounts(
     accounts_raw: Iterable[Mapping[str, Any]],
     api_keys: Mapping[str, Mapping[str, Any]] | None,
@@ -381,6 +476,16 @@ def load_realtime_config(path: Path) -> RealtimeConfig:
     auth = _parse_auth(config.get("auth"))
     custom_endpoints = _parse_custom_endpoints(config.get("custom_endpoints"))
     email_settings = _parse_email_settings(config.get("email"))
+    grafana_settings = _parse_grafana_config(config.get("grafana"))
+    reports_dir_value = config.get("reports_dir")
+    reports_dir: Path | None = None
+    if reports_dir_value:
+        candidate = Path(str(reports_dir_value)).expanduser()
+        if not candidate.is_absolute():
+            candidate = (path.parent / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        reports_dir = candidate
 
     if custom_endpoints and custom_endpoints.path:
         resolved_path = Path(custom_endpoints.path).expanduser()
@@ -402,4 +507,6 @@ def load_realtime_config(path: Path) -> RealtimeConfig:
         email=email_settings,
         config_root=config_root,
         debug_api_payloads=debug_api_payloads_default,
+        reports_dir=reports_dir,
+        grafana=grafana_settings,
     )

--- a/risk_management/realtime_config.example.json
+++ b/risk_management/realtime_config.example.json
@@ -3,6 +3,23 @@
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false
   },
+  "reports_dir": "../risk_reports",
+  "grafana": {
+    "base_url": "https://grafana.example.com/",
+    "default_height": 620,
+    "dashboards": [
+      {
+        "title": "Portfolio overview",
+        "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
+        "description": "NAV, profit rate, and drawdown metrics across the portfolio."
+      },
+      {
+        "title": "Exposure & leverage",
+        "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
+        "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
+      }
+    ]
+  },
   "debug_api_payloads": false,
   "accounts": [
     {

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -5,6 +5,23 @@
     "path": "../configs/custom_endpoints.json",
     "autodiscover": false
   },
+  "reports_dir": "../risk_reports",
+  "grafana": {
+    "base_url": "https://grafana.example.com/",
+    "default_height": 620,
+    "dashboards": [
+      {
+        "title": "Portfolio overview",
+        "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
+        "description": "NAV, profit rate, and drawdown metrics across the portfolio."
+      },
+      {
+        "title": "Exposure & leverage",
+        "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
+        "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
+      }
+    ]
+  },
   "accounts": [
     {
       "name": "Binance Futures",

--- a/risk_management/reporting.py
+++ b/risk_management/reporting.py
@@ -1,0 +1,354 @@
+"""Utilities for storing and retrieving generated account reports."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+@dataclass()
+class StoredReport:
+    """Metadata about a stored report."""
+
+    account: str
+    report_id: str
+    path: Path
+    created_at: datetime
+    size: int
+
+    def to_view(self) -> dict[str, Any]:
+        """Return a JSON serialisable representation."""
+
+        return {
+            "account": self.account,
+            "report_id": self.report_id,
+            "filename": self.path.name,
+            "created_at": self.created_at.replace(tzinfo=timezone.utc).isoformat(),
+            "size": self.size,
+        }
+
+
+class ReportManager:
+    """Persist generated reports to disk."""
+
+    _FILENAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]+")
+
+    def __init__(self, base_directory: Path) -> None:
+        self.base_directory = base_directory
+        self.base_directory.mkdir(parents=True, exist_ok=True)
+
+    async def create_account_report(
+        self, account_name: str, snapshot: Mapping[str, Any]
+    ) -> StoredReport:
+        """Generate and store a CSV report for ``account_name``."""
+
+        return await asyncio.to_thread(
+            self._create_account_report_sync,
+            account_name,
+            snapshot,
+        )
+
+    async def list_reports(self, account_name: str) -> list[StoredReport]:
+        """Return stored reports for ``account_name`` sorted by newest first."""
+
+        return await asyncio.to_thread(self._list_reports_sync, account_name)
+
+    async def get_report_path(self, account_name: str, report_id: str) -> Path | None:
+        """Return the path to a stored report, if it exists."""
+
+        return await asyncio.to_thread(self._get_report_path_sync, account_name, report_id)
+
+    # --- internal helpers -------------------------------------------------
+
+    def _create_account_report_sync(
+        self, account_name: str, snapshot: Mapping[str, Any]
+    ) -> StoredReport:
+        account = self._extract_account(snapshot.get("accounts"), account_name)
+        if account is None:
+            raise ValueError(
+                f"Account '{account_name}' is not available in the latest snapshot."
+            )
+        generated_at = snapshot.get("generated_at")
+        generated_at_dt: datetime | None = None
+        if isinstance(generated_at, str):
+            try:
+                generated_at_dt = datetime.fromisoformat(generated_at)
+            except ValueError:
+                generated_at_dt = None
+
+        timestamp = datetime.now(timezone.utc)
+        report_id = timestamp.strftime("%Y%m%dT%H%M%S%fZ")
+        account_dir = self._account_directory(account_name)
+        account_dir.mkdir(parents=True, exist_ok=True)
+        file_path = account_dir / f"{report_id}.csv"
+
+        portfolio = snapshot.get("portfolio") if isinstance(snapshot, Mapping) else None
+        alerts = snapshot.get("alerts") if isinstance(snapshot, Mapping) else None
+
+        rows: list[list[str]] = []
+        rows.extend(self._build_summary_rows(account_name, account, portfolio, alerts))
+        rows.extend(self._build_exposure_rows(account.get("symbol_exposures")))
+        rows.extend(self._build_positions_rows(account.get("positions")))
+        rows.extend(self._build_orders_rows(account.get("orders")))
+
+        with file_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            if generated_at_dt is not None:
+                writer.writerow(["Snapshot generated at", generated_at_dt.isoformat()])
+                writer.writerow([])
+            for row in rows:
+                writer.writerow(row)
+
+        stat = file_path.stat()
+        return StoredReport(
+            account=account_name,
+            report_id=report_id,
+            path=file_path,
+            created_at=timestamp,
+            size=stat.st_size,
+        )
+
+    def _list_reports_sync(self, account_name: str) -> list[StoredReport]:
+        account_dir = self._account_directory(account_name)
+        if not account_dir.exists():
+            return []
+        reports: list[StoredReport] = []
+        for path in account_dir.glob("*.csv"):
+            report_id = path.stem
+            created_at = self._parse_report_timestamp(report_id) or datetime.fromtimestamp(
+                path.stat().st_mtime, tz=timezone.utc
+            )
+            reports.append(
+                StoredReport(
+                    account=account_name,
+                    report_id=report_id,
+                    path=path,
+                    created_at=created_at,
+                    size=path.stat().st_size,
+                )
+            )
+        reports.sort(key=lambda item: item.created_at, reverse=True)
+        return reports
+
+    def _get_report_path_sync(self, account_name: str, report_id: str) -> Path | None:
+        account_dir = self._account_directory(account_name)
+        if not account_dir.exists():
+            return None
+        filename = f"{report_id}.csv"
+        candidate = account_dir / filename
+        return candidate if candidate.exists() else None
+
+    def _account_directory(self, account_name: str) -> Path:
+        safe_name = self._FILENAME_PATTERN.sub("_", account_name.strip() or "account")
+        return self.base_directory / safe_name
+
+    @staticmethod
+    def _extract_account(
+        accounts: Any, account_name: str
+    ) -> Mapping[str, Any] | None:
+        if not isinstance(accounts, Iterable):
+            return None
+        for entry in accounts:
+            if isinstance(entry, Mapping) and entry.get("name") == account_name:
+                return entry
+        return None
+
+    @staticmethod
+    def _parse_report_timestamp(report_id: str) -> datetime | None:
+        for fmt in ("%Y%m%dT%H%M%S%fZ", "%Y%m%dT%H%M%SZ"):
+            try:
+                return datetime.strptime(report_id, fmt).replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+        return None
+
+    # --- CSV builders -----------------------------------------------------
+
+    def _build_summary_rows(
+        self,
+        account_name: str,
+        account: Mapping[str, Any],
+        portfolio: Mapping[str, Any] | None,
+        alerts: Iterable[str] | None,
+    ) -> list[list[str]]:
+        balance = account.get("balance", 0.0)
+        gross_notional = account.get("gross_exposure_notional", 0.0)
+        gross_pct = account.get("gross_exposure", 0.0)
+        net_notional = account.get("net_exposure_notional", 0.0)
+        net_pct = account.get("net_exposure", 0.0)
+        unrealized = account.get("unrealized_pnl", 0.0)
+        positions_count = len(account.get("positions", []) or [])
+        orders_count = len(account.get("orders", []) or [])
+        alerts_summary = (
+            ", ".join(str(alert) for alert in alerts) if alerts else "None"
+        )
+        portfolio_balance = (
+            portfolio.get("balance") if isinstance(portfolio, Mapping) else None
+        )
+        balance_share = (
+            balance / portfolio_balance if portfolio_balance else None
+        )
+        rows = [
+            [
+                "Account",
+                "Balance",
+                "Gross Exposure",
+                "Gross %",
+                "Net Exposure",
+                "Net %",
+                "Unrealized PnL",
+                "Positions",
+                "Orders",
+                "Alerts",
+                "Portfolio Share",
+            ],
+            [
+                account_name,
+                self._format_currency(balance),
+                self._format_currency(gross_notional),
+                self._format_pct(gross_pct),
+                self._format_currency(net_notional),
+                self._format_pct(net_pct),
+                self._format_currency(unrealized),
+                str(positions_count),
+                str(orders_count),
+                alerts_summary,
+                self._format_pct(balance_share) if balance_share is not None else "-",
+            ],
+            [],
+        ]
+        return rows
+
+    def _build_exposure_rows(self, exposures: Any) -> list[list[str]]:
+        items = []
+        if isinstance(exposures, Iterable):
+            for entry in exposures:
+                if not isinstance(entry, Mapping):
+                    continue
+                items.append(
+                    [
+                        entry.get("symbol", "-"),
+                        self._format_currency(entry.get("gross_notional", 0.0)),
+                        self._format_pct(entry.get("gross_pct", 0.0)),
+                        self._format_currency(entry.get("net_notional", 0.0)),
+                        self._format_pct(entry.get("net_pct", 0.0)),
+                    ]
+                )
+        if not items:
+            return [["Symbol exposures"], ["No symbol exposure data available"], []]
+        header = [
+            "Symbol",
+            "Gross Exposure",
+            "Gross %",
+            "Net Exposure",
+            "Net %",
+        ]
+        return [["Symbol exposures"], header, *items, []]
+
+    def _build_positions_rows(self, positions: Any) -> list[list[str]]:
+        items = []
+        if isinstance(positions, Iterable):
+            for position in positions:
+                if not isinstance(position, Mapping):
+                    continue
+                items.append(
+                    [
+                        position.get("symbol", "-"),
+                        position.get("side", "-"),
+                        self._format_currency(position.get("notional", 0.0)),
+                        self._format_pct(position.get("exposure", 0.0)),
+                        self._format_currency(position.get("unrealized_pnl", 0.0)),
+                        self._format_pct(position.get("pnl_pct", 0.0)),
+                        self._format_price(position.get("entry_price")),
+                        self._format_price(position.get("mark_price")),
+                        self._format_price(position.get("liquidation_price")),
+                        self._format_price(position.get("take_profit_price")),
+                        self._format_price(position.get("stop_loss_price")),
+                    ]
+                )
+        if not items:
+            return [["Open positions"], ["No open positions"], []]
+        header = [
+            "Symbol",
+            "Side",
+            "Notional",
+            "Exposure %",
+            "Unrealized PnL",
+            "PnL %",
+            "Entry",
+            "Mark",
+            "Liquidation",
+            "Take profit",
+            "Stop loss",
+        ]
+        return [["Open positions"], header, *items, []]
+
+    def _build_orders_rows(self, orders: Any) -> list[list[str]]:
+        items = []
+        if isinstance(orders, Iterable):
+            for order in orders:
+                if not isinstance(order, Mapping):
+                    continue
+                items.append(
+                    [
+                        order.get("order_id") or "-",
+                        order.get("symbol", "-"),
+                        order.get("side", "-"),
+                        order.get("type", "-"),
+                        self._format_price(order.get("price")),
+                        str(order.get("amount", "-")),
+                        str(order.get("remaining", "-")),
+                        order.get("status", "-"),
+                        "Yes" if order.get("reduce_only") else "No",
+                        self._format_currency(order.get("notional")),
+                        self._format_price(order.get("stop_price")),
+                        order.get("created_at", "-"),
+                    ]
+                )
+        if not items:
+            return [["Open orders"], ["No open orders"], []]
+        header = [
+            "Order ID",
+            "Symbol",
+            "Side",
+            "Type",
+            "Price",
+            "Amount",
+            "Remaining",
+            "Status",
+            "Reduce only",
+            "Notional",
+            "Stop price",
+            "Created",
+        ]
+        return [["Open orders"], header, *items, []]
+
+    @staticmethod
+    def _format_currency(value: Any) -> str:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "-"
+        return f"${number:,.2f}"
+
+    @staticmethod
+    def _format_pct(value: Any) -> str:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "0.00%"
+        return f"{number * 100:.2f}%"
+
+    @staticmethod
+    def _format_price(value: Any) -> str:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "-"
+        return f"{number:,.4f}"
+

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -32,6 +32,115 @@
     .page-section[hidden] {
       display: none;
     }
+
+    .button.secondary {
+      background: rgba(148, 163, 184, 0.2);
+      color: var(--text);
+    }
+
+    .button.secondary:hover {
+      background: rgba(148, 163, 184, 0.3);
+      box-shadow: 0 8px 20px rgba(148, 163, 184, 0.2);
+    }
+
+    .status-message {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .status-message.success {
+      color: var(--success);
+    }
+
+    .status-message.error {
+      color: var(--danger);
+    }
+
+    .report-section {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .report-actions {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+
+    .report-list {
+      width: 100%;
+      background: rgba(15, 23, 42, 0.5);
+      border-radius: 0.75rem;
+      padding: 0.75rem 1rem;
+    }
+
+    .report-list__items {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .report-list__item {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 0.75rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+      padding-bottom: 0.5rem;
+    }
+
+    .report-list__item:last-child {
+      border-bottom: none;
+      padding-bottom: 0;
+    }
+
+    .report-list__meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      color: var(--muted);
+      font-size: 0.85rem;
+    }
+
+    .report-list__empty {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin: 0;
+    }
+
+    .grafana-grid {
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    }
+
+    .grafana-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .grafana-panel iframe {
+      width: 100%;
+      border: none;
+      border-radius: 0.75rem;
+      background: rgba(15, 23, 42, 0.75);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+    }
+
+    .grafana-panel__meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
   </style>
 {% endblock %}
 
@@ -73,6 +182,17 @@
     >
       Alerts &amp; notifications
     </button>
+    {% if grafana_dashboards %}
+      <button
+        type="button"
+        class="view-nav__button"
+        role="tab"
+        aria-selected="false"
+        data-page-target="analytics"
+      >
+        Analytics
+      </button>
+    {% endif %}
   </nav>
 
   <div class="page-sections">
@@ -154,7 +274,7 @@
               </div>
               <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 0.5rem;">
                 <button type="button" class="button danger" data-kill-switch="{{ account.name }}">Kill switch</button>
-                <div class="status" data-kill-status="{{ account.name }}" style="display: none;"></div>
+                <div class="status-message" data-kill-status="{{ account.name }}" hidden></div>
               </div>
             </div>
             {% if account.message %}
@@ -206,6 +326,15 @@
                 </table>
               </div>
             {% endif %}
+            <div class="report-section">
+              <div class="report-actions">
+                <button type="button" class="button secondary" data-generate-report="{{ account.name }}">Generate report</button>
+                <div class="status-message" data-report-status="{{ account.name }}" hidden></div>
+              </div>
+              <div class="report-list" data-report-list="{{ account.name }}">
+                <p class="report-list__empty">No stored reports yet.</p>
+              </div>
+            </div>
             {% if account.positions %}
               <div class="table-wrapper" style="overflow-x: auto;">
                 <table>
@@ -321,6 +450,43 @@
         {% endif %}
       </section>
     </div>
+    {% if grafana_dashboards %}
+      <div class="page-section" data-page-section="analytics" hidden>
+        <section class="card">
+          <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;">
+            <div>
+              <h2 style="margin-bottom: 0.25rem;">Performance analytics</h2>
+              <p style="color: var(--muted); margin: 0;">Live Grafana dashboards embedded from your monitoring stack.</p>
+            </div>
+          </div>
+          <div class="grafana-grid" style="margin-top: 1.5rem;">
+            {% for dashboard in grafana_dashboards %}
+              <article class="grafana-panel">
+                <div class="grafana-panel__meta">
+                  <div>
+                    <h3 style="margin: 0 0 0.25rem;">{{ dashboard.title }}</h3>
+                    {% if dashboard.description %}
+                      <p style="margin: 0; color: var(--muted); font-size: 0.9rem;">{{ dashboard.description }}</p>
+                    {% endif %}
+                  </div>
+                  <a class="button secondary" href="{{ dashboard.url }}" target="_blank" rel="noopener">
+                    Open in Grafana
+                  </a>
+                </div>
+                <iframe
+                  src="{{ dashboard.url }}"
+                  title="{{ dashboard.title }}"
+                  height="{{ dashboard.height }}"
+                  loading="lazy"
+                  referrerpolicy="no-referrer-when-downgrade"
+                  allowfullscreen
+                ></iframe>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+      </div>
+    {% endif %}
   </div>
 {% endblock %}
 
@@ -396,6 +562,18 @@
       return `${number.toFixed(2)}%`;
     };
 
+    const formatBytes = (value) => {
+      const number = Number(value);
+      if (!Number.isFinite(number) || number <= 0) {
+        return "0 B";
+      }
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      const exponent = Math.min(Math.floor(Math.log(number) / Math.log(1024)), units.length - 1);
+      const size = number / 1024 ** exponent;
+      const precision = exponent === 0 ? 0 : 2;
+      return `${size.toFixed(precision)} ${units[exponent]}`;
+    };
+
     const renderPortfolio = (snapshot) => {
       const portfolioSection = document.querySelector(
         '[data-page-section="overview"] [data-portfolio]'
@@ -469,7 +647,8 @@
       if (!accountsContainer) {
         return;
       }
-      accountsContainer.innerHTML = (snapshot.accounts || [])
+      const accountsData = Array.isArray(snapshot.accounts) ? snapshot.accounts : [];
+      accountsContainer.innerHTML = accountsData
         .map((account) => {
           const exposures = Array.isArray(account.symbol_exposures)
             ? account.symbol_exposures
@@ -540,7 +719,7 @@
                 </div>
                 <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 0.5rem;">
                   <button type="button" class="button danger" data-kill-switch="${account.name}">Kill switch</button>
-                  <div class="status" data-kill-status="${account.name}" style="display: none;"></div>
+                  <div class="status-message" data-kill-status="${account.name}" hidden></div>
                 </div>
               </div>
               ${account.message ? `<div class="status">${account.message}</div>` : ""}
@@ -580,6 +759,15 @@
                     </table>
                   </div>`
                 : ""}
+              <div class="report-section">
+                <div class="report-actions">
+                  <button type="button" class="button secondary" data-generate-report="${account.name}">Generate report</button>
+                  <div class="status-message" data-report-status="${account.name}" hidden></div>
+                </div>
+                <div class="report-list" data-report-list="${account.name}">
+                  <p class="report-list__empty">No stored reports yet.</p>
+                </div>
+              </div>
               ${positions.length > 0
                 ? `<div class="table-wrapper" style=\"overflow-x: auto;\">
                     <table>
@@ -630,6 +818,150 @@
           `;
         })
         .join("");
+      accountsData.forEach((account) => {
+        if (account && account.name) {
+          loadAccountReports(account.name);
+        }
+      });
+    };
+
+    const setReportStatus = (accountName, message, variant = "info") => {
+      const statusEl = document.querySelector(`[data-report-status="${accountName}"]`);
+      if (!statusEl) {
+        return;
+      }
+      statusEl.classList.remove("success", "error");
+      if (!message) {
+        statusEl.textContent = "";
+        statusEl.hidden = true;
+        return;
+      }
+      statusEl.textContent = message;
+      statusEl.hidden = false;
+      if (variant === "success") {
+        statusEl.classList.add("success");
+      } else if (variant === "error") {
+        statusEl.classList.add("error");
+      }
+    };
+
+    const renderReportList = (accountName, reports) => {
+      const container = document.querySelector(`[data-report-list="${accountName}"]`);
+      if (!container) {
+        return;
+      }
+      if (!Array.isArray(reports) || reports.length === 0) {
+        container.innerHTML = '<p class="report-list__empty">No stored reports yet.</p>';
+        return;
+      }
+      const items = reports
+        .map((report) => {
+          const timestamp = report.created_at
+            ? new Date(report.created_at).toLocaleString()
+            : "";
+          const size = formatBytes(report.size ?? 0);
+          const filename = report.filename || `report-${report.report_id}.csv`;
+          const downloadUrl = report.download_url || "#";
+          return `
+            <li class="report-list__item">
+              <div>
+                <a href="${downloadUrl}" class="button" style="padding: 0.4rem 0.9rem;" download="${filename}">
+                  Download
+                </a>
+                <span style="margin-left: 0.75rem; font-weight: 600;">${filename}</span>
+              </div>
+              <div class="report-list__meta">
+                <span>${timestamp}</span>
+                <span>${size}</span>
+              </div>
+            </li>
+          `;
+        })
+        .join("");
+      container.innerHTML = `<ul class="report-list__items">${items}</ul>`;
+    };
+
+    const loadAccountReports = async (accountName) => {
+      if (!accountName) {
+        return;
+      }
+      try {
+        const response = await fetch(`/api/accounts/${encodeURIComponent(accountName)}/reports`, {
+          credentials: "include",
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to load reports (${response.status})`);
+        }
+        const payload = await response.json();
+        renderReportList(accountName, payload.reports || []);
+        const statusEl = document.querySelector(`[data-report-status="${accountName}"]`);
+        if (statusEl && statusEl.classList.contains("error")) {
+          setReportStatus(accountName, "");
+        }
+      } catch (error) {
+        console.error(error);
+        setReportStatus(accountName, "Unable to load stored reports.", "error");
+      }
+    };
+
+    const triggerReportDownload = (downloadUrl, filename) => {
+      if (!downloadUrl) {
+        return;
+      }
+      const anchor = document.createElement("a");
+      anchor.href = downloadUrl;
+      if (filename) {
+        anchor.download = filename;
+      }
+      anchor.rel = "noopener";
+      anchor.style.display = "none";
+      document.body.appendChild(anchor);
+      anchor.click();
+      requestAnimationFrame(() => anchor.remove());
+    };
+
+    const generateAccountReport = async (accountName, button) => {
+      if (!accountName) {
+        return;
+      }
+      const statusEl = document.querySelector(`[data-report-status="${accountName}"]`);
+      if (statusEl) {
+        statusEl.hidden = false;
+        statusEl.classList.remove("success", "error");
+        statusEl.textContent = "Generating report...";
+      }
+      if (button) {
+        button.disabled = true;
+      }
+      try {
+        const response = await fetch(`/api/accounts/${encodeURIComponent(accountName)}/reports`, {
+          method: "POST",
+          credentials: "include",
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to generate report (${response.status})`);
+        }
+        const payload = await response.json();
+        if (statusEl) {
+          statusEl.textContent = "Report generated.";
+          statusEl.classList.remove("error");
+          statusEl.classList.add("success");
+        }
+        await loadAccountReports(accountName);
+        triggerReportDownload(payload.download_url, payload.filename);
+      } catch (error) {
+        console.error(error);
+        if (statusEl) {
+          statusEl.textContent = `Report generation failed: ${error.message}`;
+          statusEl.classList.remove("success");
+          statusEl.classList.add("error");
+          statusEl.hidden = false;
+        }
+      } finally {
+        if (button) {
+          button.disabled = false;
+        }
+      }
     };
 
     const renderAlerts = (snapshot) => {
@@ -751,13 +1083,27 @@
     }
 
     document.addEventListener("click", (event) => {
-      const button = event.target.closest("[data-kill-switch]");
-      if (!button) {
+      const killButton = event.target.closest("[data-kill-switch]");
+      if (killButton) {
+        const accountName = killButton.getAttribute("data-kill-switch");
+        triggerKillSwitch(accountName, killButton);
         return;
       }
-      const accountName = button.getAttribute("data-kill-switch");
-      triggerKillSwitch(accountName, button);
+      const reportButton = event.target.closest("[data-generate-report]");
+      if (reportButton) {
+        const accountName = reportButton.getAttribute("data-generate-report");
+        generateAccountReport(accountName, reportButton);
+      }
     });
+
+    document
+      .querySelectorAll('[data-page-section="accounts"] [data-report-list]')
+      .forEach((element) => {
+        const accountName = element.getAttribute("data-report-list");
+        if (accountName) {
+          loadAccountReports(accountName);
+        }
+      });
 
     setInterval(poll, REFRESH_INTERVAL_MS);
     poll();

--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -6,13 +6,15 @@ from pathlib import Path
 from typing import Any, Dict, Mapping
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from passlib.context import CryptContext
 from starlette.middleware.sessions import SessionMiddleware
+from urllib.parse import quote, urljoin
 
 from .configuration import RealtimeConfig
 from .realtime import RealtimeDataFetcher
+from .reporting import ReportManager
 from .snapshot_utils import build_presentable_snapshot
 
 
@@ -79,6 +81,38 @@ def create_app(
     app = FastAPI(title="Risk Management Dashboard")
     app.state.service = service
     app.state.auth_manager = auth_manager
+    reports_dir = config.reports_dir
+    if reports_dir is None:
+        base_root = config.config_root or Path.cwd()
+        reports_dir = base_root / "reports"
+    app.state.report_manager = ReportManager(reports_dir)
+
+    def resolve_grafana_context() -> dict[str, Any]:
+        grafana_cfg = config.grafana
+        if grafana_cfg is None:
+            return {"dashboards": [], "theme": None}
+
+        def resolve_url(raw_url: str) -> str:
+            url = raw_url.strip()
+            if grafana_cfg.base_url and not url.lower().startswith(("http://", "https://")):
+                base = grafana_cfg.base_url.rstrip("/") + "/"
+                return urljoin(base, url.lstrip("/"))
+            return url
+
+        dashboards: list[dict[str, Any]] = []
+        for dashboard in grafana_cfg.dashboards:
+            dashboards.append(
+                {
+                    "title": dashboard.title,
+                    "url": resolve_url(dashboard.url),
+                    "description": dashboard.description,
+                    "height": dashboard.height or grafana_cfg.default_height,
+                }
+            )
+
+        return {"dashboards": dashboards, "theme": grafana_cfg.theme}
+
+    app.state.grafana_context = resolve_grafana_context()
 
     templates_path = templates_dir or Path(__file__).with_name("templates")
     templates = Jinja2Templates(directory=str(templates_path))
@@ -115,6 +149,9 @@ def create_app(
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
         return str(user)
 
+    def get_report_manager(request: Request) -> ReportManager:
+        return request.app.state.report_manager
+
     @app.get("/login", response_class=HTMLResponse)
     async def login_form(request: Request) -> HTMLResponse:
         if request.session.get("user"):
@@ -145,12 +182,15 @@ def create_app(
             return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
         snapshot = await service.fetch_snapshot()
         view_model = build_presentable_snapshot(snapshot)
+        grafana_context: dict[str, Any] = request.app.state.grafana_context
         return templates.TemplateResponse(
             "dashboard.html",
             {
                 "request": request,
                 "user": user,
                 "snapshot": view_model,
+                "grafana_dashboards": grafana_context.get("dashboards", []),
+                "grafana_theme": grafana_context.get("theme"),
             },
         )
 
@@ -179,6 +219,53 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         return JSONResponse(result)
+
+    @app.get("/api/accounts/{account_name}/reports", response_class=JSONResponse)
+    async def api_list_reports(
+        account_name: str,
+        manager: ReportManager = Depends(get_report_manager),
+        _: str = Depends(require_user),
+    ) -> JSONResponse:
+        reports = await manager.list_reports(account_name)
+        items = []
+        for report in reports:
+            data = report.to_view()
+            data["download_url"] = (
+                f"/api/accounts/{quote(account_name, safe='')}/reports/{quote(report.report_id, safe='')}"
+            )
+            items.append(data)
+        return JSONResponse({"account": account_name, "reports": items})
+
+    @app.post("/api/accounts/{account_name}/reports", response_class=JSONResponse)
+    async def api_generate_report(
+        account_name: str,
+        service: RiskDashboardService = Depends(get_service),
+        manager: ReportManager = Depends(get_report_manager),
+        _: str = Depends(require_user),
+    ) -> JSONResponse:
+        snapshot = await service.fetch_snapshot()
+        view_model = build_presentable_snapshot(snapshot)
+        try:
+            report = await manager.create_account_report(account_name, view_model)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        data = report.to_view()
+        data["download_url"] = (
+            f"/api/accounts/{quote(account_name, safe='')}/reports/{quote(report.report_id, safe='')}"
+        )
+        return JSONResponse(data)
+
+    @app.get("/api/accounts/{account_name}/reports/{report_id}")
+    async def api_download_report(
+        account_name: str,
+        report_id: str,
+        manager: ReportManager = Depends(get_report_manager),
+        _: str = Depends(require_user),
+    ) -> FileResponse:
+        path = await manager.get_report_path(account_name, report_id)
+        if path is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+        return FileResponse(path, media_type="text/csv", filename=path.name)
 
     @app.on_event("shutdown")
     async def shutdown() -> None:  # pragma: no cover - FastAPI lifecycle


### PR DESCRIPTION
## Summary
- remove dataclass slots usage so the report manager works on Python 3.9
- extend realtime configuration parsing with optional Grafana dashboard settings and surface them in the UI
- embed configured Grafana dashboards in a new analytics tab of the dashboard

## Testing
- python -m compileall risk_management

------
https://chatgpt.com/codex/tasks/task_b_68fcb71631a48323924844915fdb2c6d