### PR TITLE
Automate Let's Encrypt provisioning for the dashboard

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -134,6 +134,33 @@ it only for development environments that cannot serve TLS. Supply
 (optionally with `--ssl-keyfile-password`) when launching the web server to
 enable HTTPS directly. Both paths must be provided together or the server will
 refuse to start.
+
+### Automating TLS with Let's Encrypt
+
+Passivbot can request and renew certificates automatically through
+[`certbot`](https://certbot.eff.org/). Provide one or more `--letsencrypt-domain`
+flags and the server will invoke certbot in standalone mode before launching
+Uvicorn:
+
+```bash
+python -m risk_management.web_server \
+  --config risk_management/realtime_config.json \
+  --letsencrypt-domain dashboard.example.com \
+  --letsencrypt-email sre@example.com \
+  --letsencrypt-http-port 80
+```
+
+The helper reuses existing certificates until renewal is required (`certbot
+--keep-until-expiring`). Set `--letsencrypt-staging` (optionally with
+`--letsencrypt-dry-run`) while testing to avoid production rate limits. To store
+certbot data outside the default `/etc/letsencrypt` directory, pass
+`--letsencrypt-config-dir`, `--letsencrypt-work-dir`, and `--letsencrypt-logs-dir`
+paths.
+
+When managing certificates separately, point `--letsencrypt-webroot` at the
+directory certbot writes `/.well-known/acme-challenge/*` files into. The web
+server exposes the directory automatically so http-01 challenges succeed during
+renewals triggered by external automation.
 endpoints.
 
 your API key store.  The optional `params.balance` and `params.positions`

--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -435,7 +435,13 @@ def _parse_auth(auth_raw: Mapping[str, Any] | None) -> AuthConfig | None:
     else:
         users = {str(entry["username"]): str(entry["password_hash"]) for entry in users_raw}
     session_cookie = str(auth_raw.get("session_cookie_name", "risk_dashboard_session"))
-    return AuthConfig(secret_key=str(secret_key), users=users, session_cookie_name=session_cookie)
+    https_only = _coerce_bool(auth_raw.get("https_only"), True)
+    return AuthConfig(
+        secret_key=str(secret_key),
+        users=users,
+        session_cookie_name=session_cookie,
+        https_only=https_only,
+    )
 
 
 def load_realtime_config(path: Path) -> RealtimeConfig:

--- a/risk_management/letsencrypt.py
+++ b/risk_management/letsencrypt.py
@@ -1,0 +1,120 @@
+"""Utilities for provisioning TLS certificates via Let's Encrypt."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LetsEncryptError(RuntimeError):
+    """Raised when Let's Encrypt automation fails."""
+
+
+def _normalize_domains(domains: Iterable[str]) -> list[str]:
+    normalized: list[str] = []
+    for domain in domains:
+        candidate = domain.strip()
+        if not candidate:
+            continue
+        normalized.append(candidate)
+    return normalized
+
+
+def ensure_certificate(
+    *,
+    executable: str = "certbot",
+    domains: Sequence[str],
+    email: str | None = None,
+    staging: bool = False,
+    http_port: int = 80,
+    cert_name: str | None = None,
+    config_dir: Path | None = None,
+    work_dir: Path | None = None,
+    logs_dir: Path | None = None,
+    dry_run: bool = False,
+) -> tuple[Path, Path]:
+    """Ensure a Let's Encrypt certificate exists and return its paths.
+
+    The helper invokes the ``certbot`` CLI in standalone mode so the http-01
+    challenge is handled automatically. Existing certificates are reused until
+    renewal is required thanks to the ``--keep-until-expiring`` flag.
+    """
+
+    normalized_domains = _normalize_domains(domains)
+    if not normalized_domains:
+        raise LetsEncryptError("At least one domain must be supplied for Let's Encrypt provisioning.")
+
+    certbot_path = shutil.which(executable)
+    if certbot_path is None:
+        raise LetsEncryptError(
+            f"Unable to locate the '{executable}' executable required for Let's Encrypt automation."
+        )
+
+    storage_dir = Path(config_dir) if config_dir else Path("/etc/letsencrypt")
+    lineage = cert_name or normalized_domains[0]
+
+    command: list[str] = [
+        certbot_path,
+        "certonly",
+        "--non-interactive",
+        "--agree-tos",
+        "--keep-until-expiring",
+        "--standalone",
+        "--preferred-challenges",
+        "http",
+        "--http-01-port",
+        str(http_port),
+    ]
+
+    if email:
+        command.extend(["--email", email])
+    else:
+        command.append("--register-unsafely-without-email")
+
+    if staging:
+        command.append("--staging")
+
+    if cert_name:
+        command.extend(["--cert-name", cert_name])
+
+    if config_dir:
+        command.extend(["--config-dir", str(config_dir)])
+    if work_dir:
+        command.extend(["--work-dir", str(work_dir)])
+    if logs_dir:
+        command.extend(["--logs-dir", str(logs_dir)])
+    if dry_run:
+        command.append("--dry-run")
+
+    for domain in normalized_domains:
+        command.extend(["-d", domain])
+
+    LOGGER.info(
+        "Requesting/renewing Let's Encrypt certificate for %s via %s",
+        ", ".join(normalized_domains),
+        certbot_path,
+    )
+
+    try:
+        subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - exercised via unit tests
+        raise LetsEncryptError(
+            "Let's Encrypt provisioning failed; inspect certbot output for details."
+        ) from exc
+
+    certfile = storage_dir / "live" / lineage / "fullchain.pem"
+    keyfile = storage_dir / "live" / lineage / "privkey.pem"
+
+    if not certfile.exists() or not keyfile.exists():
+        raise LetsEncryptError(
+            "Certbot completed but expected certificate files were not found at "
+            f"{certfile} and {keyfile}."
+        )
+
+    return certfile, keyfile
+

--- a/tests/risk_management/test_configuration.py
+++ b/tests/risk_management/test_configuration.py
@@ -228,6 +228,22 @@ def test_debug_logging_enabled_for_account_flag(tmp_path: Path, monkeypatch) -> 
     assert calls, "expected debug logging to be enabled when account flag is set"
 
 
+def test_auth_https_only_flag_respected(tmp_path: Path) -> None:
+    payload = _base_payload()
+    payload["auth"] = {
+        "secret_key": "abc",
+        "users": {"demo": "hashed"},
+        "https_only": False,
+    }
+
+    config_path = _write_config(tmp_path, payload)
+
+    config = load_realtime_config(config_path)
+
+    assert config.auth is not None
+    assert config.auth.https_only is False
+
+
 def test_load_realtime_config_parses_email_settings(tmp_path: Path) -> None:
     payload = _base_payload()
     payload["email"] = {

--- a/tests/risk_management/test_letsencrypt.py
+++ b/tests/risk_management/test_letsencrypt.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from risk_management.letsencrypt import LetsEncryptError, ensure_certificate
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.command: Sequence[str] | None = None
+
+
+def test_ensure_certificate_invokes_certbot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    recorder = Recorder()
+
+    def fake_run(command: Sequence[str], **kwargs) -> None:  # type: ignore[no-untyped-def]
+        recorder.command = command
+        assert kwargs.get("check") is True
+
+    monkeypatch.setattr("risk_management.letsencrypt.shutil.which", lambda exe: "/usr/bin/certbot")
+    monkeypatch.setattr("risk_management.letsencrypt.subprocess.run", fake_run)
+
+    live_dir = tmp_path / "live" / "example.com"
+    live_dir.mkdir(parents=True)
+    cert_path = live_dir / "fullchain.pem"
+    key_path = live_dir / "privkey.pem"
+    cert_path.write_text("dummy-cert")
+    key_path.write_text("dummy-key")
+
+    returned_cert, returned_key = ensure_certificate(
+        executable="certbot",
+        domains=["example.com"],
+        email="ops@example.com",
+        staging=True,
+        http_port=5002,
+        config_dir=tmp_path,
+    )
+
+    assert recorder.command is not None
+    assert "--staging" in recorder.command
+    assert "-d" in recorder.command
+    assert "example.com" in recorder.command
+    assert returned_cert == cert_path
+    assert returned_key == key_path
+
+
+def test_ensure_certificate_missing_certbot(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("risk_management.letsencrypt.shutil.which", lambda exe: None)
+    with pytest.raises(LetsEncryptError):
+        ensure_certificate(domains=("example.com",))
+
+
+def test_ensure_certificate_handles_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("risk_management.letsencrypt.shutil.which", lambda exe: "/usr/bin/certbot")
+
+    def fake_run(command, **kwargs):  # type: ignore[no-untyped-def]
+        raise subprocess.CalledProcessError(returncode=1, cmd=command)
+
+    import subprocess
+
+    monkeypatch.setattr("risk_management.letsencrypt.subprocess.run", fake_run)
+
+    with pytest.raises(LetsEncryptError):
+        ensure_certificate(domains=("example.com",), config_dir=tmp_path)


### PR DESCRIPTION
## Summary
- integrate certbot-based automation to obtain TLS certificates for the web dashboard
- expose an ACME challenge webroot and document Let's Encrypt configuration steps
- add regression coverage for certificate provisioning and challenge mounting

## Testing
- pytest tests/risk_management/test_configuration.py tests/risk_management/test_letsencrypt.py tests/test_risk_management_web.py

------
https://chatgpt.com/codex/tasks/task_b_68fce77cec088323968e3ec8fc900df3