### PR TITLE
Align risk management debug logging with Passivbot defaults

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -139,8 +139,10 @@ Override the lookup with `"custom_endpoints": {"path": "../configs/custom_endpoi
 ### Debugging helpers
 
 Set `"debug_api_payloads": true` globally or per account to dump the raw JSON
-returned by ccxt.  Use this sparingly; responses include large payloads and
-secret values are not redacted automatically.
+returned by ccxt.  When enabled the loader now initialises the same logging
+format used by Passivbot's trading and backtesting commands so payloads respect
+`TRACE`/`DEBUG` verbosity and include timestamps.  Use this sparingly; responses
+include large payloads and secret values are not redacted automatically.
 
 ## 3. Run the terminal dashboard
 


### PR DESCRIPTION
## Summary
- configure risk management debug payload logging to reuse Passivbot's logging setup when no handlers are configured
- ensure root and risk_management logger handlers are promoted to DEBUG when debug_api_payloads is enabled
- document the improved logging behaviour in the risk management README

## Testing
- pytest tests/risk_management/test_configuration.py

------
https://chatgpt.com/codex/tasks/task_b_68fd04d55f148323a4bdcc65be04f84f