### PR TITLE
Ensure risk management logging behaves at sane defaults

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -101,6 +101,9 @@ Update the new file with the following information.
   - `enabled`: set to `false` to temporarily disable an account without
     removing the block.
   - `debug_api_payloads`: enable verbose logging for a single account.
+  - `credentials.enableRateLimit`: defaults to `true`.  The loader preserves
+    ccxt's built-in throttling so API calls respect exchange rate limits unless
+    you explicitly opt out.
 
 ### Credentials discovery
 
@@ -139,8 +142,12 @@ Override the lookup with `"custom_endpoints": {"path": "../configs/custom_endpoi
 ### Debugging helpers
 
 Set `"debug_api_payloads": true` globally or per account to dump the raw JSON
-returned by ccxt.  Use this sparingly; responses include large payloads and
-secret values are not redacted automatically.
+returned by ccxt.  When disabled the loader still provisions Passivbot's
+handlers at INFO level so warnings and errors surface consistently.  Enabling
+the flag raises verbosity to the familiar trading/backtesting format so payloads
+respect `TRACE`/`DEBUG` levels and include timestamps.  Use this sparingly;
+responses include large payloads and secret values are not redacted
+automatically.
 
 ## 3. Run the terminal dashboard
 

--- a/tests/risk_management/test_configuration.py
+++ b/tests/risk_management/test_configuration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import List
@@ -13,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from risk_management.configuration import (  # noqa: E402
+    _ensure_debug_logging_enabled,
     _merge_credentials,
     _normalise_credentials,
     load_realtime_config,
@@ -226,6 +228,69 @@ def test_debug_logging_enabled_for_account_flag(tmp_path: Path, monkeypatch) -> 
     load_realtime_config(config_path)
 
     assert calls, "expected debug logging to be enabled when account flag is set"
+
+
+def test_default_logging_provisioned_without_debug(tmp_path: Path, monkeypatch) -> None:
+    payload = _base_payload()
+    config_path = _write_config(tmp_path, payload)
+
+    calls: List[int] = []
+
+    def record_call(debug_level: int = 1) -> bool:
+        calls.append(debug_level)
+        return True
+
+    monkeypatch.setattr("risk_management.configuration._configure_default_logging", record_call)
+
+    load_realtime_config(config_path)
+
+    assert calls == [1], "expected INFO-level logging to be provisioned by default"
+
+
+def test_debug_logging_promotes_root_and_risk_loggers(monkeypatch) -> None:
+    root_logger = logging.getLogger()
+    risk_logger = logging.getLogger("risk_management")
+
+    original_root_level = root_logger.level
+    original_root_handlers = list(root_logger.handlers)
+    original_risk_level = risk_logger.level
+    original_risk_handlers = list(risk_logger.handlers)
+
+    for handler in root_logger.handlers:
+        root_logger.removeHandler(handler)
+    root_handler = logging.StreamHandler()
+    root_handler.setLevel(logging.WARNING)
+    root_logger.addHandler(root_handler)
+    root_logger.setLevel(logging.WARNING)
+
+    for handler in risk_logger.handlers:
+        risk_logger.removeHandler(handler)
+    risk_handler = logging.StreamHandler()
+    risk_handler.setLevel(logging.WARNING)
+    risk_logger.addHandler(risk_handler)
+    risk_logger.setLevel(logging.WARNING)
+
+    monkeypatch.setattr(
+        "risk_management.configuration._configure_default_logging", lambda debug_level=2: False
+    )
+
+    try:
+        _ensure_debug_logging_enabled()
+
+        assert root_logger.level == logging.DEBUG
+        assert root_handler.level == logging.DEBUG
+        assert risk_logger.level == logging.DEBUG
+        assert risk_handler.level == logging.DEBUG
+    finally:
+        risk_logger.removeHandler(risk_handler)
+        for handler in original_risk_handlers:
+            risk_logger.addHandler(handler)
+        risk_logger.setLevel(original_risk_level)
+
+        root_logger.removeHandler(root_handler)
+        for handler in original_root_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(original_root_level)
 
 
 def test_auth_https_only_flag_respected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- provision Passivbot's logging handlers at INFO level when realtime configs are loaded so important messages appear without debug payloads
- retain exchange rate-limit protections in the docs while clarifying how debug payloads elevate verbosity
- extend configuration tests to cover default logging setup and the DEBUG promotion path

## Testing
- pytest tests/risk_management/test_configuration.py

------
https://chatgpt.com/codex/tasks/task_b_68fd04d55f148323a4bdcc65be04f84f