### PR TITLE
Add pytest dependencies and document test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ python3 -m jupyter lab
 - Python >= 3.8
 - [requirements.txt](requirements.txt) dependencies
 
+## Running tests
+
+Install the testing dependencies from the repository root so that `pytest` and its asyncio plugin are available:
+
+```sh
+python -m pip install -r requirements.txt
+```
+
+Then execute the suite with:
+
+```sh
+python -m pytest
+```
+
+Running the installation command from a subdirectory will not find `requirements.txt`, so make sure you are in the project root before invoking it.
+
 ## Pre-optimized configurations
 
 Coming soon...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 -r requirements-rust.txt
 -r requirements-live.txt
+pytest>=7.4
+pytest-asyncio>=0.21
 matplotlib==3.5.1
 prospector==1.6.0
 colorama==0.4.4


### PR DESCRIPTION
## Summary
- include pytest and pytest-asyncio in the default dependency set so the pytest.ini configuration is honored
- document how to install dependencies and run the test suite from the repository root to avoid missing requirement files

## Testing
- not run (environment lacks the Python packages required to execute the suite)


------
https://chatgpt.com/codex/tasks/task_b_68fd94c1bce88323abf266c3085bbab8