### PR TITLE
Adjust risk management tests for Python 3.9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ python3 -m jupyter lab
 - Python >= 3.8
 - [requirements.txt](requirements.txt) dependencies
 
+## Running tests
+
+Install the testing dependencies from the repository root so that `pytest` and its asyncio plugin are available:
+
+```sh
+python -m pip install -r requirements.txt
+```
+
+Then execute the suite with:
+
+```sh
+python -m pytest
+```
+
+Running the installation command from a subdirectory will not find `requirements.txt`, so make sure you are in the project root before invoking it.
+
 ## Pre-optimized configurations
 
 Coming soon...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 -r requirements-rust.txt
 -r requirements-live.txt
+pytest>=7.4
+pytest-asyncio>=0.21
 matplotlib==3.5.1
 prospector==1.6.0
 colorama==0.4.4

--- a/tests/test_risk_management_account_clients.py
+++ b/tests/test_risk_management_account_clients.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
@@ -14,7 +15,13 @@ from risk_management.account_clients import CCXTAccountClient, BaseError
 
 
 class StubExchange:
-    def __init__(self, *, bid: float | None = None, ask: float | None = None, last: float | None = None):
+    def __init__(
+        self,
+        *,
+        bid: Optional[float] = None,
+        ask: Optional[float] = None,
+        last: Optional[float] = None,
+    ) -> None:
         self._bid = bid
         self._ask = ask
         self._last = last

--- a/tests/test_risk_management_web.py
+++ b/tests/test_risk_management_web.py
@@ -1,5 +1,7 @@
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -7,12 +9,6 @@ pytest.importorskip("fastapi")
 pytest.importorskip("passlib")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import pytest
-
-pytest.importorskip("fastapi")
-pytest.importorskip("passlib")
-
-from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 from passlib.context import CryptContext
@@ -25,7 +21,7 @@ class StubFetcher:
     def __init__(self, snapshot: dict) -> None:
         self.snapshot = snapshot
         self.closed = False
-        self.kill_requests: list[str | None] = []
+        self.kill_requests: list[Optional[str]] = []
 
     async def fetch_snapshot(self) -> dict:
         return self.snapshot
@@ -33,7 +29,7 @@ class StubFetcher:
     async def close(self) -> None:
         self.closed = True
 
-    async def execute_kill_switch(self, account_name: str | None = None) -> dict:
+    async def execute_kill_switch(self, account_name: Optional[str] = None) -> dict:
         self.kill_requests.append(account_name)
         return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- update the risk management account client tests to use Optional type hints instead of the Python 3.10 ``|`` union syntax
- clean up the web dashboard tests by deduplicating imports and using Optional for kill switch annotations so they run under Python 3.9

## Testing
- pytest *(fails: missing third-party dependencies such as numpy, hjson, and ccxt in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68fd94c1bce88323abf266c3085bbab8