### PR TITLE
Fix risk management web tests under constrained environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ python3 -m jupyter lab
 - Python >= 3.8
 - [requirements.txt](requirements.txt) dependencies
 
+## Running tests
+
+Install the testing dependencies from the repository root so that `pytest` and its asyncio plugin are available:
+
+```sh
+python -m pip install -r requirements.txt
+```
+
+Then execute the suite with:
+
+```sh
+python -m pytest
+```
+
+Running the installation command from a subdirectory will not find `requirements.txt`, so make sure you are in the project root before invoking it.
+
 ## Pre-optimized configurations
 
 Coming soon...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 -r requirements-rust.txt
 -r requirements-live.txt
+pytest>=7.4
+pytest-asyncio>=0.21
 matplotlib==3.5.1
 prospector==1.6.0
 colorama==0.4.4

--- a/tests/risk_management/test_web_server.py
+++ b/tests/risk_management/test_web_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 
@@ -70,6 +71,15 @@ def test_determine_uvicorn_logging_uses_uvicorn_config(monkeypatch) -> None:
 def test_determine_uvicorn_logging_handles_missing_uvicorn(monkeypatch) -> None:
     monkeypatch.delitem(sys.modules, "uvicorn", raising=False)
     monkeypatch.delitem(sys.modules, "uvicorn.config", raising=False)
+
+    original_import = importlib.import_module
+
+    def fake_import(name, package=None):
+        if name == "uvicorn.config":
+            raise ModuleNotFoundError("uvicorn unavailable")
+        return original_import(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
 
     config = _make_config(account_debug=True)
 

--- a/tests/test_risk_management_account_clients.py
+++ b/tests/test_risk_management_account_clients.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
@@ -14,7 +15,13 @@ from risk_management.account_clients import CCXTAccountClient, BaseError
 
 
 class StubExchange:
-    def __init__(self, *, bid: float | None = None, ask: float | None = None, last: float | None = None):
+    def __init__(
+        self,
+        *,
+        bid: Optional[float] = None,
+        ask: Optional[float] = None,
+        last: Optional[float] = None,
+    ) -> None:
         self._bid = bid
         self._ask = ask
         self._last = last

--- a/tests/test_risk_management_web.py
+++ b/tests/test_risk_management_web.py
@@ -1,5 +1,7 @@
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -7,16 +9,8 @@ pytest.importorskip("fastapi")
 pytest.importorskip("passlib")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import pytest
-
-pytest.importorskip("fastapi")
-pytest.importorskip("passlib")
-
-from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
-from passlib.context import CryptContext
-
 from risk_management.configuration import AccountConfig, RealtimeConfig
 from risk_management.web import AuthManager, RiskDashboardService, create_app
 
@@ -25,7 +19,7 @@ class StubFetcher:
     def __init__(self, snapshot: dict) -> None:
         self.snapshot = snapshot
         self.closed = False
-        self.kill_requests: list[str | None] = []
+        self.kill_requests: list[Optional[str]] = []
 
     async def fetch_snapshot(self) -> dict:
         return self.snapshot
@@ -33,7 +27,7 @@ class StubFetcher:
     async def close(self) -> None:
         self.closed = True
 
-    async def execute_kill_switch(self, account_name: str | None = None) -> dict:
+    async def execute_kill_switch(self, account_name: Optional[str] = None) -> dict:
         self.kill_requests.append(account_name)
         return {"status": "ok"}
 
@@ -74,8 +68,8 @@ def sample_snapshot() -> dict:
 
 @pytest.fixture
 def auth_manager() -> AuthManager:
-    context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-    password_hash = context.hash("admin123")
+    # Pre-generated bcrypt hash for the password "admin123".
+    password_hash = "$2b$12$KIX0dYvEhvdZ4InENa9e6uU30IoqRxG7Pecg/6tiTZeVOw13K9IRG"
     return AuthManager(secret_key="super-secret", users={"admin": password_hash})
 
 


### PR DESCRIPTION
## Summary
- use a pre-generated bcrypt hash in the web dashboard tests so passlib no longer tries to hash passwords during setup
- harden the uvicorn logging helper test by monkeypatching importlib to simulate a missing uvicorn package

## Testing
- pytest tests/risk_management/test_web_server.py::test_determine_uvicorn_logging_handles_missing_uvicorn
- pytest tests/test_risk_management_web.py -k kill_switch --maxfail=1

------
https://chatgpt.com/codex/tasks/task_b_68fd94c1bce88323abf266c3085bbab8