### PR TITLE
Handle reduceOnly for hedge-mode kill switch orders

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -753,7 +753,27 @@ class CCXTAccountClient(AccountClientProtocol):
                 continue
             side = "sell" if float(size) > 0 else "buy"
             params = dict(self._close_params)
-            params.setdefault("reduceOnly", True)
+            position_side: Optional[str] = None
+            info = position.get("info")
+            if isinstance(info, Mapping):
+                raw_position_side = info.get("positionSide") or info.get("position_side")
+                if isinstance(raw_position_side, str):
+                    normalized = raw_position_side.upper()
+                    if normalized in {"LONG", "SHORT", "BOTH"}:
+                        position_side = normalized
+            if position_side is None:
+                raw_position_side = position.get("positionSide") or position.get("position_side")
+                if isinstance(raw_position_side, str):
+                    normalized = raw_position_side.upper()
+                    if normalized in {"LONG", "SHORT", "BOTH"}:
+                        position_side = normalized
+            if position_side and "positionSide" not in params:
+                params["positionSide"] = position_side
+            if position_side in {"LONG", "SHORT"}:
+                params.pop("reduceOnly", None)
+                params.pop("reduceonly", None)
+            elif "reduceOnly" not in params and "reduceonly" not in params:
+                params["reduceOnly"] = True
             mark_price = _first_float(
                 position.get("markPrice"),
                 position.get("mark_price"),

--- a/tests/test_risk_management_account_clients.py
+++ b/tests/test_risk_management_account_clients.py
@@ -21,6 +21,7 @@ class StubExchange:
         bid: Optional[float] = None,
         ask: Optional[float] = None,
         last: Optional[float] = None,
+        position_info: Optional[dict] = None,
     ) -> None:
         self._bid = bid
         self._ask = ask
@@ -28,6 +29,7 @@ class StubExchange:
         self._cancel_calls = []
         self._orders = []
         self.markets = True
+        self._position_info = dict(position_info or {})
 
     async def cancel_all_orders(self, symbol=None, params=None):
         self._cancel_calls.append({"symbol": symbol, "params": params})
@@ -37,7 +39,7 @@ class StubExchange:
             {
                 "symbol": "BTC/USDT",
                 "contracts": 1,
-                "info": {},
+                "info": dict(self._position_info),
             }
         ]
 
@@ -86,7 +88,7 @@ def test_kill_switch_falls_back_to_ticker_price(caplog):
     assert summary["closed_positions"], "Position should be closed when ticker price is available"
     order = exchange._orders[0]
     assert order["price"] == pytest.approx(101.2)
-    assert order["params"]["reduceOnly"] is True
+    assert order["params"].get("reduceOnly") is True
     assert any("Executing kill switch" in record.message for record in caplog.records)
     assert any("Kill switch completed" in record.message for record in caplog.records)
 
@@ -112,3 +114,46 @@ def test_kill_switch_logs_failures_when_price_missing(caplog):
     assert any("Kill switch completed" in record.message for record in caplog.records)
     # Debug details are only emitted when failures occur
     assert any("Kill switch details" in record.message for record in caplog.records)
+
+
+def test_kill_switch_uses_position_side_from_exchange_payload():
+    exchange = StubExchange(bid=99.5, position_info={"positionSide": "LONG"})
+    client = CCXTAccountClient.__new__(CCXTAccountClient)
+    client.config = SimpleNamespace(name="Demo", symbols=None)
+    client.client = exchange
+    client._balance_params = {}
+    client._positions_params = {}
+    client._orders_params = {}
+    client._close_params = {}
+    client._markets_loaded = None
+    client._debug_api_payloads = False
+
+    summary = asyncio.run(client.kill_switch("BTC/USDT"))
+
+    assert summary["closed_positions"], "Kill switch should attempt to close the position"
+    order = exchange._orders[0]
+    assert order["params"]["positionSide"] == "LONG"
+    assert "reduceOnly" not in order["params"]
+    assert "reduceonly" not in order["params"]
+
+
+def test_kill_switch_drops_reduce_only_from_configured_close_params():
+    exchange = StubExchange(bid=100.4, position_info={"positionSide": "SHORT"})
+    client = CCXTAccountClient.__new__(CCXTAccountClient)
+    client.config = SimpleNamespace(name="Demo", symbols=None)
+    client.client = exchange
+    client._balance_params = {}
+    client._positions_params = {}
+    client._orders_params = {}
+    client._close_params = {"reduceOnly": True, "foo": "bar"}
+    client._markets_loaded = None
+    client._debug_api_payloads = False
+
+    summary = asyncio.run(client.kill_switch("BTC/USDT"))
+
+    assert summary["closed_positions"], "Kill switch should attempt to close the position"
+    order = exchange._orders[0]
+    assert order["params"]["positionSide"] == "SHORT"
+    assert order["params"].get("foo") == "bar"
+    assert "reduceOnly" not in order["params"]
+    assert "reduceonly" not in order["params"]

--- a/tests/test_risk_management_web.py
+++ b/tests/test_risk_management_web.py
@@ -137,9 +137,6 @@ def create_test_app(
     kill_switch_responses: Optional[List[dict]] = None,
 ) -> tuple[TestClient, StubFetcher]:
     fetcher = StubFetcher(snapshot, kill_switch_responses=kill_switch_responses)
-
-def create_test_app(snapshot: dict, auth_manager: AuthManager) -> tuple[TestClient, StubFetcher]:
-    fetcher = StubFetcher(snapshot)
     service = RiskDashboardService(fetcher)  # type: ignore[arg-type]
     config = RealtimeConfig(accounts=[AccountConfig(name="Demo", exchange="binance", credentials={})])
     app = create_app(config, service=service, auth_manager=auth_manager)


### PR DESCRIPTION
## Summary
- avoid sending the reduceOnly flag when closing hedge-mode positions while still defaulting it for one-way accounts
- ensure configured close-order parameters survive hedge-mode adjustments without reintroducing reduceOnly
- extend the CCXT account client tests to cover hedge-mode behaviour

## Testing
- pytest tests/test_risk_management_account_clients.py -q

------
https://chatgpt.com/codex/tasks/task_b_68fdb42ff0148323b6b69d254566dc88