### PR TITLE
Document branching strategy for stable and dev workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 v7.4.2
 
+## Branching Strategy
+
+The repository now maintains two primary long-lived branches:
+
+* `stable` &mdash; tracks the latest confirmed stable release. Once a version has
+  been validated, create or update this branch from the commit to preserve the
+  known-good state.
+* `dev` &mdash; the default branch for ongoing work. Continue running tests and
+  landing new features here while keeping the stable branch untouched.
+
+To cut a new stable release, checkout `dev`, ensure it is green, and fast-forward
+the `stable` branch to the desired commit.
+
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- create a `stable` branch that locks the current release
- continue day-to-day work on the renamed `dev` branch
- document the branching workflow in the README

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68fdcd5bfbb083238ad7d2c67de83ee2