### PR TITLE
Add NAV analytics and timeframe filters to risk dashboard

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -15,6 +15,8 @@ health, and automated notifications.
   kill-switch commands.
 - **Web dashboard** – FastAPI application with authenticated access, TLS
   support, report downloads, optional Grafana embeds, and kill-switch controls.
+- **Performance analytics** – rolling NAV history with timeframe filters,
+  realised/unrealised decomposition, equity charts, and enriched CSV reports.
 - **Alerting helpers** – configurable thresholds, SMTP email delivery, and
   human-readable notification channels shown alongside the dashboards.
 
@@ -190,10 +192,14 @@ configuration file.  The page displays:
 
 - Portfolio and per-account exposure metrics.
 - Live funding and volatility snapshots.
+- Performance card with selectable 1h–30d windows, NAV charting, and realised/unrealised splits.
 - Outstanding alerts and notification targets.
 - Kill-switch buttons (global, per account, or per position).
 - CSV report downloads (stored under `reports_dir`).
 - Optional Grafana panels embedded beneath the summary cards.
+
+Use `GET /api/analytics?timeframe=7d` to retrieve the aggregated metrics and
+time-series data powering the performance card programmatically.
 
 ### Enabling TLS
 

--- a/risk_management/analytics.py
+++ b/risk_management/analytics.py
@@ -1,0 +1,373 @@
+"""Utilities for tracking and summarising portfolio time series analytics."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+def _to_datetime(value: str) -> Optional[datetime]:
+    """Return a timezone aware ``datetime`` parsed from ``value``."""
+
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _safe_float(value: object) -> float:
+    """Convert ``value`` to ``float`` returning ``0.0`` on failure."""
+
+    try:
+        if value in (None, ""):
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@dataclass
+class AccountPoint:
+    """Time series datapoint for a single account."""
+
+    balance: float
+    unrealized: float
+    gross: float
+    net: float
+
+
+@dataclass
+class PortfolioPoint:
+    """Aggregated portfolio metrics captured at ``timestamp``."""
+
+    timestamp: datetime
+    nav: float
+    unrealized: float
+    gross: float
+    net: float
+    accounts: Dict[str, AccountPoint]
+
+
+TimeframeDefinition = Tuple[str, timedelta, str]
+
+
+TIMEFRAMES: Tuple[TimeframeDefinition, ...] = (
+    ("1h", timedelta(hours=1), "Last 1 hour"),
+    ("6h", timedelta(hours=6), "Last 6 hours"),
+    ("24h", timedelta(hours=24), "Last 24 hours"),
+    ("7d", timedelta(days=7), "Last 7 days"),
+    ("30d", timedelta(days=30), "Last 30 days"),
+)
+
+
+_TIMEFRAME_LOOKUP: Dict[str, TimeframeDefinition] = {definition[0]: definition for definition in TIMEFRAMES}
+
+
+class PortfolioHistory:
+    """Maintain a rolling history of portfolio snapshots for analytics."""
+
+    def __init__(
+        self,
+        *,
+        max_age: timedelta = timedelta(days=90),
+        max_points: int = 50_000,
+        min_interval: timedelta = timedelta(seconds=60),
+    ) -> None:
+        self._points: Deque[PortfolioPoint] = deque()
+        self._max_age = max_age
+        self._max_points = max_points
+        self._min_interval = min_interval
+
+    # ------------------------------------------------------------------
+    # Recording snapshots
+    # ------------------------------------------------------------------
+    def record_snapshot(self, snapshot: Mapping[str, object]) -> None:
+        """Store ``snapshot`` (presentable view) in the rolling history."""
+
+        timestamp_raw = snapshot.get("generated_at")
+        if not isinstance(timestamp_raw, str):
+            return
+        timestamp = _to_datetime(timestamp_raw)
+        if timestamp is None:
+            return
+
+        portfolio = snapshot.get("portfolio") if isinstance(snapshot, Mapping) else None
+        if not isinstance(portfolio, Mapping):
+            return
+
+        nav = _safe_float(portfolio.get("balance"))
+        gross = _safe_float(portfolio.get("gross_exposure"))
+        net = _safe_float(portfolio.get("net_exposure"))
+
+        accounts_raw = snapshot.get("accounts") if isinstance(snapshot, Mapping) else None
+        accounts: Dict[str, AccountPoint] = {}
+        total_unrealized = 0.0
+        if isinstance(accounts_raw, Iterable):
+            for entry in accounts_raw:
+                if not isinstance(entry, Mapping):
+                    continue
+                name_raw = entry.get("name")
+                if not isinstance(name_raw, str) or not name_raw.strip():
+                    continue
+                name = name_raw.strip()
+                balance = _safe_float(entry.get("balance"))
+                unrealized = _safe_float(entry.get("unrealized_pnl"))
+                gross_notional = _safe_float(entry.get("gross_exposure_notional"))
+                net_notional = _safe_float(entry.get("net_exposure_notional"))
+                total_unrealized += unrealized
+                accounts[name] = AccountPoint(
+                    balance=balance,
+                    unrealized=unrealized,
+                    gross=gross_notional,
+                    net=net_notional,
+                )
+
+        point = PortfolioPoint(
+            timestamp=timestamp,
+            nav=nav,
+            unrealized=total_unrealized,
+            gross=gross,
+            net=net,
+            accounts=accounts,
+        )
+
+        if self._points:
+            last = self._points[-1]
+            if timestamp <= last.timestamp:
+                if timestamp == last.timestamp:
+                    self._points[-1] = point
+                return
+            if timestamp - last.timestamp < self._min_interval:
+                self._points[-1] = point
+            else:
+                self._points.append(point)
+        else:
+            self._points.append(point)
+
+        self._prune(timestamp)
+
+    def _prune(self, now: datetime) -> None:
+        cutoff = now - self._max_age
+        while self._points and self._points[0].timestamp < cutoff:
+            self._points.popleft()
+        while len(self._points) > self._max_points:
+            self._points.popleft()
+
+    # ------------------------------------------------------------------
+    # Timeframe helpers
+    # ------------------------------------------------------------------
+    def available_timeframes(self) -> List[Dict[str, object]]:
+        return [
+            {"id": identifier, "label": label}
+            for identifier, _duration, label in TIMEFRAMES
+        ]
+
+    def _resolve_timeframe(self, timeframe: str) -> TimeframeDefinition:
+        try:
+            return _TIMEFRAME_LOOKUP[timeframe]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported timeframe '{timeframe}'.") from exc
+
+    def _points_for_timeframe(self, duration: timedelta) -> List[PortfolioPoint]:
+        if not self._points:
+            return []
+        end = self._points[-1].timestamp
+        cutoff = end - duration
+        relevant: List[PortfolioPoint] = []
+        for point in reversed(self._points):
+            if point.timestamp < cutoff:
+                break
+            relevant.append(point)
+        if not relevant:
+            return [self._points[-1]]
+        return list(reversed(relevant))
+
+    # ------------------------------------------------------------------
+    # Summary builders
+    # ------------------------------------------------------------------
+    def portfolio_summary(
+        self, timeframe: str, *, include_series: bool = True
+    ) -> Dict[str, object]:
+        identifier, duration, label = self._resolve_timeframe(timeframe)
+        points = self._points_for_timeframe(duration)
+        summary, series = self._summarise_points(points)
+        payload: Dict[str, object] = {
+            "timeframe": identifier,
+            "label": label,
+            "summary": summary,
+        }
+        if include_series:
+            payload["series"] = series
+        return payload
+
+    def account_summary(
+        self, account_name: str, timeframe: str, *, include_series: bool = False
+    ) -> Optional[Dict[str, object]]:
+        identifier, duration, label = self._resolve_timeframe(timeframe)
+        points = self._points_for_timeframe(duration)
+        account_points = [
+            (point.timestamp, point.accounts.get(account_name)) for point in points
+        ]
+        filtered = [entry for entry in account_points if entry[1] is not None]
+        if not filtered:
+            return None
+        summary, series = self._summarise_account_points(filtered)
+        payload: Dict[str, object] = {
+            "timeframe": identifier,
+            "label": label,
+            "summary": summary,
+        }
+        if include_series:
+            payload["series"] = series
+        return payload
+
+    def portfolio_overview(self, timeframes: Sequence[str]) -> Dict[str, Dict[str, object]]:
+        overview: Dict[str, Dict[str, object]] = {}
+        for timeframe in timeframes:
+            payload = self.portfolio_summary(timeframe, include_series=False)
+            overview[timeframe] = {
+                "label": payload.get("label", timeframe),
+                "summary": payload.get("summary", self._empty_summary()),
+            }
+        return overview
+
+    def account_overview(
+        self, account_name: str, timeframes: Sequence[str]
+    ) -> Dict[str, Dict[str, object]]:
+        results: Dict[str, Dict[str, object]] = {}
+        for timeframe in timeframes:
+            summary = self.account_summary(account_name, timeframe, include_series=False)
+            if summary is not None:
+                results[timeframe] = {
+                    "label": summary.get("label", timeframe),
+                    "summary": summary.get("summary", self._empty_summary()),
+                }
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal summarisation helpers
+    # ------------------------------------------------------------------
+    def _summarise_points(
+        self, points: Sequence[PortfolioPoint]
+    ) -> Tuple[Dict[str, object], List[Dict[str, object]]]:
+        if not points:
+            return self._empty_summary(), []
+        start = points[0]
+        end = points[-1]
+        nav_change = end.nav - start.nav
+        unrealized_change = end.unrealized - start.unrealized
+        realized_change = nav_change - unrealized_change
+        nav_high = max(point.nav for point in points)
+        nav_low = min(point.nav for point in points)
+        drawdown = 0.0
+        if nav_high > 0:
+            drawdown = max(0.0, (nav_high - end.nav) / nav_high)
+        summary = {
+            "start": start.timestamp.isoformat(),
+            "end": end.timestamp.isoformat(),
+            "nav": end.nav,
+            "baseline": start.nav,
+            "nav_change": nav_change,
+            "nav_change_pct": nav_change / start.nav if start.nav else 0.0,
+            "realized_change": realized_change,
+            "unrealized_change": unrealized_change,
+            "drawdown_pct": drawdown,
+            "nav_high": nav_high,
+            "nav_low": nav_low,
+            "points": len(points),
+        }
+        series: List[Dict[str, object]] = []
+        baseline_nav = start.nav or end.nav or 1.0
+        baseline_unrealized = start.unrealized
+        for point in points:
+            pnl = point.nav - baseline_nav
+            unrealized_delta = point.unrealized - baseline_unrealized
+            realized_delta = pnl - unrealized_delta
+            series.append(
+                {
+                    "timestamp": point.timestamp.isoformat(),
+                    "nav": point.nav,
+                    "pnl": pnl,
+                    "realized": realized_delta,
+                    "unrealized": unrealized_delta,
+                }
+            )
+        return summary, series
+
+    def _summarise_account_points(
+        self, points: Sequence[Tuple[datetime, AccountPoint]]
+    ) -> Tuple[Dict[str, object], List[Dict[str, object]]]:
+        if not points:
+            return self._empty_summary(), []
+        start_ts, start_point = points[0]
+        end_ts, end_point = points[-1]
+        nav_change = end_point.balance - start_point.balance
+        unrealized_change = end_point.unrealized - start_point.unrealized
+        realized_change = nav_change - unrealized_change
+        high = max(point.balance for _, point in points)
+        low = min(point.balance for _, point in points)
+        drawdown = 0.0
+        if high > 0:
+            drawdown = max(0.0, (high - end_point.balance) / high)
+        summary = {
+            "start": start_ts.isoformat(),
+            "end": end_ts.isoformat(),
+            "nav": end_point.balance,
+            "baseline": start_point.balance,
+            "nav_change": nav_change,
+            "nav_change_pct": nav_change / start_point.balance if start_point.balance else 0.0,
+            "realized_change": realized_change,
+            "unrealized_change": unrealized_change,
+            "drawdown_pct": drawdown,
+            "nav_high": high,
+            "nav_low": low,
+            "points": len(points),
+        }
+        series: List[Dict[str, object]] = []
+        baseline_nav = start_point.balance or end_point.balance or 1.0
+        baseline_unrealized = start_point.unrealized
+        for timestamp, point in points:
+            pnl = point.balance - baseline_nav
+            unrealized_delta = point.unrealized - baseline_unrealized
+            realized_delta = pnl - unrealized_delta
+            series.append(
+                {
+                    "timestamp": timestamp.isoformat(),
+                    "nav": point.balance,
+                    "pnl": pnl,
+                    "realized": realized_delta,
+                    "unrealized": unrealized_delta,
+                }
+            )
+        return summary, series
+
+    @staticmethod
+    def _empty_summary() -> Dict[str, object]:
+        return {
+            "start": None,
+            "end": None,
+            "nav": 0.0,
+            "baseline": 0.0,
+            "nav_change": 0.0,
+            "nav_change_pct": 0.0,
+            "realized_change": 0.0,
+            "unrealized_change": 0.0,
+            "drawdown_pct": 0.0,
+            "nav_high": 0.0,
+            "nav_low": 0.0,
+            "points": 0,
+        }
+
+
+__all__ = [
+    "PortfolioHistory",
+    "TIMEFRAMES",
+]
+

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -83,6 +83,146 @@
       gap: 0.75rem;
       flex-wrap: wrap;
     }
+
+    .analytics-card {
+      margin-top: 2rem;
+      border-top: 1px solid rgba(148, 163, 184, 0.15);
+      padding-top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .analytics-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .analytics-header h3 {
+      margin: 0;
+    }
+
+    .analytics-controls {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .analytics-controls label {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .analytics-controls select {
+      background: rgba(148, 163, 184, 0.1);
+      color: var(--text);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 0.5rem;
+      padding: 0.35rem 0.75rem;
+    }
+
+    .analytics-metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1.25rem;
+    }
+
+    .analytics-metric {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      background: rgba(15, 23, 42, 0.55);
+      border-radius: 0.75rem;
+      padding: 0.85rem 1rem;
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+    }
+
+    .analytics-metric .label {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .analytics-metric .value {
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+
+    .analytics-metric .subvalue {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .analytics-charts {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .analytics-chart {
+      background: rgba(15, 23, 42, 0.55);
+      border-radius: 0.75rem;
+      padding: 1rem;
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+      position: relative;
+      min-height: 260px;
+    }
+
+    .analytics-chart canvas {
+      width: 100%;
+      height: 220px;
+      display: block;
+    }
+
+    .analytics-chart__title {
+      font-size: 0.95rem;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+
+    .analytics-table table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .analytics-table th,
+    .analytics-table td {
+      padding: 0.5rem 0.75rem;
+      text-align: right;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+    }
+
+    .analytics-table th:first-child,
+    .analytics-table td:first-child {
+      text-align: left;
+    }
+
+    .analytics-table th {
+      font-size: 0.85rem;
+      color: var(--muted);
+      font-weight: 600;
+    }
+
+    .analytics-table td.gain {
+      color: var(--success);
+    }
+
+    .analytics-table td.loss {
+      color: var(--danger);
+    }
+
+    .analytics-table tr[data-active="true"] td {
+      font-weight: 600;
+    }
+
+    .analytics-empty {
+      font-size: 0.9rem;
+      color: var(--muted);
+      margin: 0;
+    }
   </style>
 {% endblock %}
 
@@ -179,6 +319,36 @@
             <span class="value {% if snapshot.portfolio.net_exposure >= 0 %}gain{% else %}loss{% endif %}">{{ snapshot.portfolio.net_exposure|currency }}</span>
             <span class="subvalue {% if snapshot.portfolio.net_exposure_pct >= 0 %}gain{% else %}loss{% endif %}">{{ snapshot.portfolio.net_exposure_pct|pct }}</span>
           </div>
+        </div>
+        <div class="analytics-card" data-analytics-card>
+          <div class="analytics-header">
+            <h3>Performance &amp; NAV</h3>
+            <div class="analytics-controls">
+              <label for="analytics-range">Range</label>
+              <select id="analytics-range" data-analytics-range>
+                <option value="1h">Last 1 hour</option>
+                <option value="6h">Last 6 hours</option>
+                <option value="24h" selected>Last 24 hours</option>
+                <option value="7d">Last 7 days</option>
+                <option value="30d">Last 30 days</option>
+              </select>
+            </div>
+          </div>
+          <div class="analytics-metrics" data-analytics-metrics>
+            <div class="analytics-empty">Loading analytics...</div>
+          </div>
+          <div class="analytics-charts">
+            <div class="analytics-chart">
+              <div class="analytics-chart__title">Net asset value</div>
+              <canvas data-nav-chart width="600" height="240" aria-label="NAV chart" role="img"></canvas>
+            </div>
+            <div class="analytics-chart">
+              <div class="analytics-chart__title">PnL breakdown</div>
+              <canvas data-pnl-chart width="600" height="240" aria-label="PnL chart" role="img"></canvas>
+            </div>
+          </div>
+          <div class="analytics-table" data-analytics-table></div>
+          <p class="analytics-empty" data-analytics-empty hidden>No analytics available yet. Continue running the dashboard to build up a performance history.</p>
         </div>
         {% set portfolio_vol = snapshot.portfolio.volatility if snapshot.portfolio.volatility is defined else {} %}
         {% set portfolio_funding = snapshot.portfolio.funding_rates if snapshot.portfolio.funding_rates is defined else {} %}
@@ -559,6 +729,20 @@
     const DEFAULT_PAGE = "overview";
     const STORAGE_KEY = "risk-dashboard.activePage";
     const METRIC_WINDOWS = ["4h", "24h", "3d", "7d"];
+    const ANALYTICS_DEFAULT_RANGE = "24h";
+    const ANALYTICS_REFRESH_MS = 60000;
+    let analyticsRange = ANALYTICS_DEFAULT_RANGE;
+    let lastAnalyticsFetch = 0;
+    const analyticsCache = new Map();
+
+    const analyticsElements = {
+      metrics: document.querySelector("[data-analytics-metrics]"),
+      table: document.querySelector("[data-analytics-table]"),
+      navCanvas: document.querySelector("[data-nav-chart]"),
+      pnlCanvas: document.querySelector("[data-pnl-chart]"),
+      empty: document.querySelector("[data-analytics-empty]"),
+      rangeSelect: document.querySelector("[data-analytics-range]"),
+    };
 
     const pageSections = Array.from(document.querySelectorAll("[data-page-section]"));
     const navButtons = Array.from(document.querySelectorAll("[data-page-target]"));
@@ -638,6 +822,386 @@
       const size = number / 1024 ** exponent;
       const precision = exponent === 0 ? 0 : 2;
       return `${size.toFixed(precision)} ${units[exponent]}`;
+    };
+
+    const populateAnalyticsOptions = (options, selected) => {
+      if (!analyticsElements.rangeSelect) {
+        return;
+      }
+      const entries = Array.isArray(options) && options.length
+        ? options
+        : [
+            { id: "1h", label: "Last 1 hour" },
+            { id: "6h", label: "Last 6 hours" },
+            { id: "24h", label: "Last 24 hours" },
+            { id: "7d", label: "Last 7 days" },
+            { id: "30d", label: "Last 30 days" },
+          ];
+      const availableIds = entries.map((entry) => entry.id);
+      const preferred = selected && availableIds.includes(selected) ? selected : entries[0]?.id;
+      const markup = entries
+        .map(
+          (entry) =>
+            `<option value="${entry.id}"${entry.id === preferred ? " selected" : ""}>${entry.label}</option>`,
+        )
+        .join("");
+      analyticsElements.rangeSelect.innerHTML = markup;
+      analyticsElements.rangeSelect.value = preferred || ANALYTICS_DEFAULT_RANGE;
+      analyticsRange = analyticsElements.rangeSelect.value;
+    };
+
+    const classifyValue = (value, positiveClass = "gain", negativeClass = "loss") => {
+      const number = Number(value || 0);
+      if (number > 0) return positiveClass;
+      if (number < 0) return negativeClass;
+      return "";
+    };
+
+    const renderAnalyticsMetrics = (summary) => {
+      if (!analyticsElements.metrics) {
+        return;
+      }
+      const nav = Number(summary?.nav || 0);
+      const baseline = Number(summary?.baseline || 0);
+      const navChange = Number(summary?.nav_change || 0);
+      const navChangePct = Number(summary?.nav_change_pct || 0);
+      const realized = Number(summary?.realized_change || 0);
+      const unrealized = Number(summary?.unrealized_change || 0);
+      const drawdown = Number(summary?.drawdown_pct || 0);
+      const points = Number(summary?.points || 0);
+
+      analyticsElements.metrics.innerHTML = `
+        <div class="analytics-metric">
+          <span class="label">Net assets</span>
+          <span class="value">${formatCurrency(nav)}</span>
+          <span class="subvalue">Start ${formatCurrency(baseline)}</span>
+        </div>
+        <div class="analytics-metric">
+          <span class="label">Period PnL</span>
+          <span class="value ${classifyValue(navChange)}">${formatCurrency(navChange)}</span>
+          <span class="subvalue ${classifyValue(navChangePct)}">${formatPct(navChangePct)}</span>
+        </div>
+        <div class="analytics-metric">
+          <span class="label">Realised change</span>
+          <span class="value ${classifyValue(realized)}">${formatCurrency(realized)}</span>
+        </div>
+        <div class="analytics-metric">
+          <span class="label">Unrealised change</span>
+          <span class="value ${classifyValue(unrealized)}">${formatCurrency(unrealized)}</span>
+        </div>
+        <div class="analytics-metric">
+          <span class="label">Current drawdown</span>
+          <span class="value ${classifyValue(-drawdown, "", "loss")}">${formatPct(drawdown)}</span>
+          <span class="subvalue">Samples ${points}</span>
+        </div>
+      `;
+    };
+
+    const renderAnalyticsTable = (comparisons, available, active) => {
+      if (!analyticsElements.table) {
+        return;
+      }
+      const entries = Array.isArray(available) && available.length
+        ? available.map((entry) => entry.id)
+        : Object.keys(comparisons || {});
+      const rows = entries
+        .map((identifier) => {
+          const entry = comparisons?.[identifier];
+          if (!entry) {
+            return null;
+          }
+          const summary = entry.summary || {};
+          const label = entry.label || identifier;
+          const navChange = Number(summary.nav_change || 0);
+          const navChangePct = Number(summary.nav_change_pct || 0);
+          const realized = Number(summary.realized_change || 0);
+          const unrealized = Number(summary.unrealized_change || 0);
+          const drawdown = Number(summary.drawdown_pct || 0);
+          return `
+            <tr${identifier === active ? ' data-active="true"' : ""}>
+              <td>${label}</td>
+              <td>${formatCurrency(summary.nav || 0)}</td>
+              <td class="${classifyValue(navChange)}">${formatCurrency(navChange)}</td>
+              <td class="${classifyValue(navChangePct)}">${formatPct(navChangePct)}</td>
+              <td class="${classifyValue(realized)}">${formatCurrency(realized)}</td>
+              <td class="${classifyValue(unrealized)}">${formatCurrency(unrealized)}</td>
+              <td class="${classifyValue(-drawdown, "", "loss")}">${formatPct(drawdown)}</td>
+              <td>${summary.points ?? 0}</td>
+            </tr>
+          `;
+        })
+        .filter(Boolean);
+      if (!rows.length) {
+        analyticsElements.table.innerHTML = '<p class="analytics-empty">No historical data available yet.</p>';
+        return;
+      }
+      analyticsElements.table.innerHTML = `
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Range</th>
+                <th>Net assets</th>
+                <th>PnL</th>
+                <th>PnL %</th>
+                <th>Realised</th>
+                <th>Unrealised</th>
+                <th>Drawdown</th>
+                <th>Points</th>
+              </tr>
+            </thead>
+            <tbody>${rows.join("")}</tbody>
+          </table>
+        </div>
+      `;
+    };
+
+    const prepareCanvas = (canvas) => {
+      if (!canvas) {
+        return null;
+      }
+      const dpr = window.devicePixelRatio || 1;
+      const width = canvas.clientWidth || canvas.offsetWidth || canvas.width || 600;
+      const height = canvas.clientHeight || canvas.offsetHeight || canvas.height || 240;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        return null;
+      }
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      context.clearRect(0, 0, width, height);
+      return { ctx: context, width, height };
+    };
+
+    const renderNavChart = (series) => {
+      const canvasState = prepareCanvas(analyticsElements.navCanvas);
+      if (!canvasState) {
+        return;
+      }
+      const { ctx, width, height } = canvasState;
+      if (!Array.isArray(series) || series.length === 0) {
+        ctx.fillStyle = "rgba(148, 163, 184, 0.7)";
+        ctx.font = "14px sans-serif";
+        ctx.fillText("No data yet", 12, 24);
+        return;
+      }
+      const padding = 30;
+      const values = series.map((point) => Number(point.nav || 0));
+      let min = Math.min(...values);
+      let max = Math.max(...values);
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        return;
+      }
+      if (min === max) {
+        const delta = min === 0 ? 1 : Math.abs(min) * 0.01;
+        min -= delta;
+        max += delta;
+      }
+      const scaleX = series.length > 1 ? (width - padding * 2) / (series.length - 1) : 0;
+      const range = max - min || 1;
+      const scaleY = (height - padding * 2) / range;
+
+      ctx.beginPath();
+      series.forEach((point, index) => {
+        const value = Number(point.nav || 0);
+        const x = padding + index * scaleX;
+        const y = height - padding - (value - min) * scaleY;
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.lineTo(padding + (series.length - 1) * scaleX, height - padding);
+      ctx.lineTo(padding, height - padding);
+      ctx.closePath();
+      ctx.fillStyle = "rgba(56, 189, 248, 0.15)";
+      ctx.fill();
+
+      ctx.beginPath();
+      series.forEach((point, index) => {
+        const value = Number(point.nav || 0);
+        const x = padding + index * scaleX;
+        const y = height - padding - (value - min) * scaleY;
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.strokeStyle = "rgba(56, 189, 248, 0.9)";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      ctx.fillStyle = "rgba(148, 163, 184, 0.6)";
+      ctx.font = "12px sans-serif";
+      const last = series[series.length - 1];
+      ctx.fillText(formatCurrency(last?.nav || 0), padding + 4, padding + 12);
+    };
+
+    const drawSeriesLine = (ctx, series, key, options) => {
+      const { padding, scaleX, scaleY, min, height, color, width } = options;
+      ctx.beginPath();
+      series.forEach((point, index) => {
+        const value = Number(point[key] || 0);
+        const x = padding + index * scaleX;
+        const y = height - padding - (value - min) * scaleY;
+        if (index === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.strokeStyle = color;
+      ctx.lineWidth = width || 1.5;
+      ctx.stroke();
+    };
+
+    const renderPnlChart = (series) => {
+      const canvasState = prepareCanvas(analyticsElements.pnlCanvas);
+      if (!canvasState) {
+        return;
+      }
+      const { ctx, width, height } = canvasState;
+      if (!Array.isArray(series) || series.length === 0) {
+        ctx.fillStyle = "rgba(148, 163, 184, 0.7)";
+        ctx.font = "14px sans-serif";
+        ctx.fillText("No data yet", 12, 24);
+        return;
+      }
+      const padding = 30;
+      const values = series.flatMap((point) => [
+        Number(point.realized || 0),
+        Number(point.unrealized || 0),
+        Number(point.pnl || 0),
+      ]);
+      let min = Math.min(...values);
+      let max = Math.max(...values);
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        return;
+      }
+      if (min === max) {
+        const delta = min === 0 ? 1 : Math.abs(min) * 0.01;
+        min -= delta;
+        max += delta;
+      }
+      const range = max - min || 1;
+      const scaleX = series.length > 1 ? (width - padding * 2) / (series.length - 1) : 0;
+      const scaleY = (height - padding * 2) / range;
+      const zeroY = height - padding - (0 - min) * scaleY;
+
+      ctx.strokeStyle = "rgba(148, 163, 184, 0.4)";
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(padding, zeroY);
+      ctx.lineTo(width - padding, zeroY);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      drawSeriesLine(ctx, series, "pnl", {
+        padding,
+        scaleX,
+        scaleY,
+        min,
+        height,
+        color: "rgba(56, 189, 248, 0.9)",
+        width: 2,
+      });
+      drawSeriesLine(ctx, series, "realized", {
+        padding,
+        scaleX,
+        scaleY,
+        min,
+        height,
+        color: "rgba(34, 197, 94, 0.9)",
+        width: 1.5,
+      });
+      drawSeriesLine(ctx, series, "unrealized", {
+        padding,
+        scaleX,
+        scaleY,
+        min,
+        height,
+        color: "rgba(248, 113, 113, 0.9)",
+        width: 1.5,
+      });
+    };
+
+    const renderAnalytics = (payload) => {
+      const summary = payload?.summary;
+      const series = Array.isArray(payload?.series) ? payload.series : [];
+      const available = Array.isArray(payload?.available_timeframes)
+        ? payload.available_timeframes
+        : [];
+      const comparisons = payload?.comparisons || {};
+
+      populateAnalyticsOptions(available, payload?.timeframe || analyticsRange);
+
+      if (!summary || series.length === 0) {
+        if (analyticsElements.metrics) {
+          analyticsElements.metrics.innerHTML = '<div class="analytics-empty">Not enough data to compute analytics yet.</div>';
+        }
+        if (analyticsElements.table) {
+          analyticsElements.table.innerHTML = '';
+        }
+        if (analyticsElements.empty) {
+          analyticsElements.empty.hidden = false;
+        }
+        renderNavChart([]);
+        renderPnlChart([]);
+        return;
+      }
+
+      if (analyticsElements.empty) {
+        analyticsElements.empty.hidden = true;
+      }
+      renderAnalyticsMetrics(summary);
+      renderNavChart(series);
+      renderPnlChart(series);
+      renderAnalyticsTable(comparisons, available, payload?.timeframe || analyticsRange);
+    };
+
+    const fetchAnalytics = async (range = analyticsRange, { force = false } = {}) => {
+      const target = range || analyticsRange || ANALYTICS_DEFAULT_RANGE;
+      if (!force) {
+        const cached = analyticsCache.get(target);
+        if (cached && Date.now() - cached.timestamp < ANALYTICS_REFRESH_MS) {
+          renderAnalytics(cached.data);
+          return;
+        }
+      }
+      try {
+        const response = await fetch(`/api/analytics?timeframe=${encodeURIComponent(target)}`, {
+          credentials: "include",
+        });
+        if (!response.ok) {
+          throw new Error(`Analytics request failed (${response.status})`);
+        }
+        const payload = await response.json();
+        analyticsCache.set(target, { data: payload, timestamp: Date.now() });
+        analyticsRange = payload.timeframe || target;
+        renderAnalytics(payload);
+        lastAnalyticsFetch = Date.now();
+      } catch (error) {
+        console.error("Failed to load analytics", error);
+        if (analyticsElements.metrics) {
+          analyticsElements.metrics.innerHTML = `<div class="analytics-empty">Analytics unavailable: ${error.message}</div>`;
+        }
+        if (analyticsElements.empty) {
+          analyticsElements.empty.hidden = false;
+        }
+        lastAnalyticsFetch = Date.now();
+      }
+    };
+
+    const maybeRefreshAnalytics = async (force = false) => {
+      const now = Date.now();
+      if (!force && now - lastAnalyticsFetch < ANALYTICS_REFRESH_MS) {
+        return;
+      }
+      await fetchAnalytics(analyticsRange, { force: true });
     };
 
     const renderPortfolio = (snapshot) => {
@@ -1082,6 +1646,14 @@
       }
     };
 
+    if (analyticsElements.rangeSelect) {
+      analyticsElements.rangeSelect.addEventListener("change", (event) => {
+        const nextRange = event.target.value || ANALYTICS_DEFAULT_RANGE;
+        analyticsRange = nextRange;
+        fetchAnalytics(nextRange, { force: true });
+      });
+    }
+
     const renderAlerts = (snapshot) => {
       const alertsContainer = document.querySelector(
         '[data-page-section="alerts"] [data-alerts]'
@@ -1159,6 +1731,7 @@
         }
         const snapshot = await response.json();
         renderSnapshot(snapshot);
+        await maybeRefreshAnalytics();
       } catch (error) {
         console.error("Failed to refresh snapshot", error);
       }

--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Iterable as IterableABC
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
-from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request, status
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -18,6 +18,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from urllib.parse import quote, urljoin
 
 from .configuration import RealtimeConfig
+from .analytics import PortfolioHistory, TIMEFRAMES
 from .realtime import RealtimeDataFetcher
 from .reporting import ReportManager
 from .snapshot_utils import build_presentable_snapshot
@@ -53,11 +54,58 @@ class AuthManager:
 class RiskDashboardService:
     """Wrap a realtime fetcher to expose snapshot data."""
 
-    def __init__(self, fetcher: RealtimeDataFetcher) -> None:
+    def __init__(
+        self,
+        fetcher: RealtimeDataFetcher,
+        *,
+        history: Optional[PortfolioHistory] = None,
+    ) -> None:
         self._fetcher = fetcher
+        self._history = history or PortfolioHistory()
+        self._latest_view: Optional[Dict[str, Any]] = None
 
     async def fetch_snapshot(self) -> Dict[str, Any]:
-        return await self._fetcher.fetch_snapshot()
+        raw = await self._fetcher.fetch_snapshot()
+        view = build_presentable_snapshot(raw)
+        self._history.record_snapshot(view)
+        self._inject_derived_daily_realized(view)
+        self._latest_view = view
+        return view
+
+    def _inject_derived_daily_realized(self, view: Dict[str, Any]) -> None:
+        portfolio = view.get("portfolio")
+        if not isinstance(portfolio, Mapping):
+            return
+        try:
+            portfolio_summary = self._history.portfolio_summary("24h", include_series=False)
+        except ValueError:
+            return
+        daily_summary = portfolio_summary.get("summary", {}) if isinstance(portfolio_summary, Mapping) else {}
+        derived_realized = float(daily_summary.get("realized_change", 0.0)) if isinstance(daily_summary, Mapping) else 0.0
+        existing_portfolio_realized = float(portfolio.get("daily_realized_pnl", 0.0))
+        if abs(existing_portfolio_realized) < 1e-9 and abs(derived_realized) > 0:
+            portfolio["daily_realized_pnl"] = derived_realized
+        accounts = view.get("accounts")
+        if not isinstance(accounts, list):
+            return
+        for account in accounts:
+            if not isinstance(account, dict):
+                continue
+            existing = float(account.get("daily_realized_pnl", 0.0))
+            if abs(existing) >= 1e-9:
+                continue
+            name = account.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            account_summary = self._history.account_summary(name, "24h", include_series=False)
+            if not account_summary or not isinstance(account_summary, Mapping):
+                continue
+            account_summary_data = account_summary.get("summary")
+            if not isinstance(account_summary_data, Mapping):
+                continue
+            derived_account_realized = float(account_summary_data.get("realized_change", 0.0))
+            if abs(derived_account_realized) > 0:
+                account["daily_realized_pnl"] = derived_account_realized
 
     async def close(self) -> None:
         await self._fetcher.close()
@@ -115,6 +163,26 @@ class RiskDashboardService:
 
     async def clear_portfolio_stop_loss(self) -> None:
         await self._fetcher.clear_portfolio_stop_loss()
+
+    def get_portfolio_analytics(self, timeframe: str) -> Dict[str, Any]:
+        payload = self._history.portfolio_summary(timeframe)
+        available = self._history.available_timeframes()
+        payload["available_timeframes"] = available
+        payload["comparisons"] = self._history.portfolio_overview(
+            [identifier for identifier, *_ in TIMEFRAMES]
+        )
+        latest = self._latest_view or {}
+        payload["latest_snapshot"] = (
+            latest.get("generated_at") if isinstance(latest, Mapping) else None
+        )
+        return payload
+
+    def get_account_analytics(
+        self, account_name: str, timeframes: Optional[Sequence[str]] = None
+    ) -> Dict[str, Dict[str, Any]]:
+        if timeframes is None:
+            timeframes = [identifier for identifier, *_ in TIMEFRAMES]
+        return self._history.account_overview(account_name, timeframes)
 
 
 def _format_kill_switch_failure(account: str, action: str, payload: Mapping[str, Any]) -> str:
@@ -310,8 +378,7 @@ def create_app(
         user = request.session.get("user")
         if not user:
             return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
-        snapshot = await service.fetch_snapshot()
-        view_model = build_presentable_snapshot(snapshot)
+        view_model = await service.fetch_snapshot()
         grafana_context: dict[str, Any] = request.app.state.grafana_context
         return templates.TemplateResponse(
             "dashboard.html",
@@ -331,8 +398,7 @@ def create_app(
         user = request.session.get("user")
         if not user:
             return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
-        snapshot = await service.fetch_snapshot()
-        view_model = build_presentable_snapshot(snapshot)
+        view_model = await service.fetch_snapshot()
         grafana_context: dict[str, Any] = request.app.state.grafana_context
         return templates.TemplateResponse(
             "trading_panel.html",
@@ -351,9 +417,20 @@ def create_app(
         service: RiskDashboardService = Depends(get_service),
         _: str = Depends(require_user),
     ) -> JSONResponse:
-        snapshot = await service.fetch_snapshot()
-        view_model = build_presentable_snapshot(snapshot)
+        view_model = await service.fetch_snapshot()
         return JSONResponse(view_model)
+
+    @app.get("/api/analytics", response_class=JSONResponse)
+    async def api_portfolio_analytics(
+        timeframe: str = Query("24h"),
+        service: RiskDashboardService = Depends(get_service),
+        _: str = Depends(require_user),
+    ) -> JSONResponse:
+        try:
+            analytics = service.get_portfolio_analytics(timeframe)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        return JSONResponse(analytics)
 
     @app.get(
         "/api/trading/accounts/{account_name}/order-types",
@@ -595,10 +672,14 @@ def create_app(
         manager: ReportManager = Depends(get_report_manager),
         _: str = Depends(require_user),
     ) -> JSONResponse:
-        snapshot = await service.fetch_snapshot()
-        view_model = build_presentable_snapshot(snapshot)
+        view_model = await service.fetch_snapshot()
+        account_analytics = service.get_account_analytics(account_name)
         try:
-            report = await manager.create_account_report(account_name, view_model)
+            report = await manager.create_account_report(
+                account_name,
+                view_model,
+                analytics=account_analytics,
+            )
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         data = report.to_view()

--- a/tests/test_risk_management_analytics.py
+++ b/tests/test_risk_management_analytics.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from passivbot.risk_management.analytics import PortfolioHistory
+
+
+def _snapshot(at: datetime, balance: float, unrealized: float) -> dict:
+    return {
+        "generated_at": at.isoformat(),
+        "portfolio": {
+            "balance": balance,
+            "gross_exposure": 0.0,
+            "net_exposure": 0.0,
+        },
+        "accounts": [
+            {
+                "name": "Primary",
+                "balance": balance,
+                "unrealized_pnl": unrealized,
+                "gross_exposure_notional": 0.0,
+                "net_exposure_notional": 0.0,
+            }
+        ],
+    }
+
+
+def test_portfolio_history_summaries() -> None:
+    history = PortfolioHistory(min_interval=timedelta(seconds=0))
+    base = datetime(2025, 5, 1, tzinfo=timezone.utc)
+    history.record_snapshot(_snapshot(base - timedelta(hours=6), 1_000.0, 50.0))
+    history.record_snapshot(_snapshot(base - timedelta(hours=3), 1_100.0, 40.0))
+    history.record_snapshot(_snapshot(base, 1_200.0, 70.0))
+
+    summary_payload = history.portfolio_summary("6h", include_series=False)
+    summary = summary_payload["summary"]
+    assert pytest.approx(summary["nav_change"], rel=1e-9) == 200.0
+    assert pytest.approx(summary["unrealized_change"], rel=1e-9) == 20.0
+    assert pytest.approx(summary["realized_change"], rel=1e-9) == 180.0
+    assert summary["points"] == 3
+
+    account_payload = history.account_summary("Primary", "6h", include_series=False)
+    assert account_payload is not None
+    account_summary = account_payload["summary"]
+    assert pytest.approx(account_summary["nav_change"], rel=1e-9) == 200.0
+    assert pytest.approx(account_summary["unrealized_change"], rel=1e-9) == 20.0
+
+    overview = history.portfolio_overview(["1h", "6h"])
+    assert overview["6h"]["label"] == "Last 6 hours"
+    assert "summary" in overview["6h"]
+
+    account_overview = history.account_overview("Primary", ["1h", "6h"])
+    assert account_overview["1h"]["label"] == "Last 1 hour"
+    assert "summary" in account_overview["6h"]


### PR DESCRIPTION
## Summary
- add a PortfolioHistory analytics engine that tracks NAV, realised/unrealised movements, and per-account performance snapshots
- extend the FastAPI service and reporting to expose /api/analytics, derive daily realised PnL when missing, and include timeframe summaries in CSV exports
- refresh the dashboard UI with a timeframe selector, NAV/PnL charts, analytics tables, documentation updates, and new regression tests

## Testing
- pytest -q *(fails: missing optional dependencies numpy, hjson, ccxt in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68fefa039adc8323b53c048bfae451d1