### PR TITLE
Fix risk management imports when running from repository root

### DIFF
--- a/risk_management/__init__.py
+++ b/risk_management/__init__.py
@@ -8,7 +8,48 @@ can run inside the sandboxed execution environment used for the exercises.
 
 from __future__ import annotations
 
+from importlib import import_module
+from pathlib import Path
+import sys
+
 __all__ = ["__version__"]
 
 __version__ = "0.1.0"
+
+
+def _ensure_passivbot_modules_available() -> None:
+    """Ensure the Passivbot source tree is importable when running from the repo.
+
+    The risk management tools live alongside the main Passivbot sources.  When
+    executed from an isolated virtual environment (for example via
+    ``python -m risk_management.web_server``) the interpreter may not know about
+    the sibling ``src`` directory that exposes modules such as
+    :mod:`custom_endpoint_overrides`.  Historically the installer dropped a
+    ``.pth`` file into the environment to bridge the gap, but direct execution
+    outside of that flow regressed after refactoring the custom endpoint
+    loading.
+
+    To keep the developer experience intact we lazily add ``../src`` to
+    ``sys.path`` only when the import fails.  The behaviour mirrors what the
+    installer performs and avoids interfering when Passivbot is installed as a
+    proper package.
+    """
+
+    try:
+        import_module("custom_endpoint_overrides")
+    except ModuleNotFoundError:
+        repo_root = Path(__file__).resolve().parent.parent
+        src_path = repo_root / "src"
+        if src_path.is_dir():
+            sys.path.insert(0, str(src_path))
+            try:
+                import_module("custom_endpoint_overrides")
+            except ModuleNotFoundError as exc:  # pragma: no cover - sanity guard
+                raise ModuleNotFoundError(
+                    "Passivbot modules are unavailable. Install Passivbot or run "
+                    "commands from the repository root so ../src is importable."
+                ) from exc
+
+
+_ensure_passivbot_modules_available()
 


### PR DESCRIPTION
## Summary
- ensure the risk_management package adds the Passivbot src directory to sys.path when custom_endpoint_overrides cannot be imported
- provide a clearer error message when the Passivbot sources are still unavailable after adjusting the path

## Testing
- python -m risk_management.dashboard --config risk_management/dashboard_config.json --iterations 1
- pytest tests/risk_management/test_configuration.py
- PYTHONPATH=. pytest tests/risk_management/test_realtime.py

------
https://chatgpt.com/codex/tasks/task_b_68ff06ac88888323b00e6b03e17d5b3b