### PR TITLE
Add portfolio history analytics and cash flow tracking to risk dashboard

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -196,6 +196,7 @@ class RealtimeConfig:
     debug_api_payloads: bool = False
     reports_dir: Optional[Path] = None
     grafana: Optional[GrafanaConfig] = None
+    history_dir: Optional[Path] = None
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
@@ -655,6 +656,11 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
     if reports_dir_value:
         reports_dir = _resolve_path_relative_to(path.parent, reports_dir_value)
 
+    history_dir_value = config.get("history_dir")
+    history_dir: Optional[Path] = None
+    if history_dir_value:
+        history_dir = _resolve_path_relative_to(path.parent, history_dir_value)
+
     if custom_endpoints and custom_endpoints.path:
         resolved_path = _resolve_path_relative_to(path.parent, custom_endpoints.path)
         custom_endpoints = CustomEndpointSettings(
@@ -686,4 +692,5 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
         reports_dir=reports_dir,
         grafana=grafana_settings,
         account_messages=account_messages,
+        history_dir=history_dir,
     )

--- a/risk_management/history.py
+++ b/risk_management/history.py
@@ -1,0 +1,445 @@
+"""Persistent storage for portfolio NAV, equity history, and cash flows."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import sqlite3
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+class PortfolioHistoryStore:
+    """Record portfolio metrics and expose aggregated history windows."""
+
+    _WINDOWS: Dict[str, timedelta] = {
+        "1h": timedelta(hours=1),
+        "6h": timedelta(hours=6),
+        "24h": timedelta(hours=24),
+        "7d": timedelta(days=7),
+        "30d": timedelta(days=30),
+    }
+
+    def __init__(self, directory: Path, *, min_interval_seconds: int = 60) -> None:
+        self.base_dir = Path(directory)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.base_dir / "portfolio_history.sqlite3"
+        self.min_interval = timedelta(seconds=max(1, int(min_interval_seconds)))
+        self._lock = threading.Lock()
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # public API
+
+    def record(self, snapshot: Mapping[str, Any]) -> None:
+        """Persist metrics extracted from ``snapshot``."""
+
+        portfolio = snapshot.get("portfolio") if isinstance(snapshot, Mapping) else None
+        if not isinstance(portfolio, Mapping):
+            return
+
+        generated_at = self._parse_datetime(snapshot.get("generated_at"))
+        nav = self._to_float(portfolio.get("balance"))
+        gross = self._to_float(portfolio.get("gross_exposure"))
+        net = self._to_float(portfolio.get("net_exposure"))
+        realized = self._to_float(portfolio.get("daily_realized_pnl"))
+
+        accounts = snapshot.get("accounts") if isinstance(snapshot, Mapping) else None
+        unrealized_total = 0.0
+        if isinstance(accounts, Iterable):
+            for entry in accounts:
+                if isinstance(entry, Mapping):
+                    unrealized_total += self._to_float(entry.get("unrealized_pnl"))
+
+        equity = nav + unrealized_total
+
+        with self._lock:
+            with self._connect() as conn:
+                last_row = conn.execute(
+                    "SELECT timestamp, high_water_mark FROM nav_history ORDER BY timestamp DESC LIMIT 1"
+                ).fetchone()
+                if last_row is not None:
+                    last_ts = self._parse_datetime(last_row[0])
+                    if generated_at - last_ts < self.min_interval:
+                        # Avoid spamming the history store with near-duplicate points.
+                        return
+                    high_water_mark = float(last_row[1])
+                else:
+                    high_water_mark = nav
+
+                high_water_mark = max(high_water_mark, nav)
+                drawdown = 0.0
+                if high_water_mark > 0:
+                    drawdown = max(0.0, (high_water_mark - nav) / high_water_mark)
+
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO nav_history (
+                        timestamp, nav, equity, realized, unrealized, gross_exposure,
+                        net_exposure, drawdown, high_water_mark
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        generated_at.isoformat(),
+                        nav,
+                        equity,
+                        realized,
+                        unrealized_total,
+                        gross,
+                        net,
+                        drawdown,
+                        high_water_mark,
+                    ),
+                )
+
+    async def record_async(self, snapshot: Mapping[str, Any]) -> None:
+        await asyncio.to_thread(self.record, snapshot)
+
+    def fetch_range(self, window: str) -> Dict[str, Any]:
+        """Return NAV and equity history for ``window``."""
+
+        delta = self._parse_window(window)
+        now = datetime.now(timezone.utc)
+        since = now - delta
+        with self._lock:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT * FROM nav_history WHERE timestamp >= ? ORDER BY timestamp ASC",
+                    (since.isoformat(),),
+                ).fetchall()
+
+        series: List[Dict[str, Any]] = []
+        for row in rows:
+            series.append(
+                {
+                    "timestamp": row["timestamp"],
+                    "nav": float(row["nav"]),
+                    "equity": float(row["equity"]),
+                    "realized": float(row["realized"]),
+                    "unrealized": float(row["unrealized"]),
+                    "gross_exposure": float(row["gross_exposure"]),
+                    "net_exposure": float(row["net_exposure"]),
+                    "drawdown": float(row["drawdown"]),
+                }
+            )
+
+        summary = self._summarise_series(series)
+        cashflow_summary = self._summarise_cashflows(since)
+        summary.update(cashflow_summary)
+
+        return {
+            "range": window,
+            "series": series,
+            "summary": summary,
+            "updated_at": series[-1]["timestamp"] if series else None,
+        }
+
+    async def fetch_range_async(self, window: str) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.fetch_range, window)
+
+    def add_cashflow(
+        self,
+        *,
+        flow_type: str,
+        amount: float,
+        currency: str,
+        timestamp: Optional[datetime] = None,
+        account: Optional[str] = None,
+        note: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Persist a deposit or withdrawal entry."""
+
+        flow_type_normalized = flow_type.strip().lower()
+        if flow_type_normalized not in {"deposit", "withdrawal"}:
+            raise ValueError("flow_type must be 'deposit' or 'withdrawal'")
+        numeric_amount = float(amount)
+        if numeric_amount <= 0:
+            raise ValueError("amount must be greater than zero")
+        currency_value = currency.strip().upper() or "USDT"
+        timestamp_value = self._parse_datetime(timestamp) if timestamp else datetime.now(timezone.utc)
+
+        with self._lock:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO cashflows (timestamp, type, amount, currency, account, note)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        timestamp_value.isoformat(),
+                        flow_type_normalized,
+                        numeric_amount,
+                        currency_value,
+                        account.strip() if account else None,
+                        note.strip() if note else None,
+                    ),
+                )
+                row_id = cursor.lastrowid
+
+        return {
+            "id": row_id,
+            "timestamp": timestamp_value.isoformat(),
+            "type": flow_type_normalized,
+            "amount": numeric_amount,
+            "currency": currency_value,
+            "account": account.strip() if account else None,
+            "note": note.strip() if note else None,
+            "signed_amount": numeric_amount if flow_type_normalized == "deposit" else -numeric_amount,
+        }
+
+    async def add_cashflow_async(self, **kwargs: Any) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.add_cashflow, **kwargs)
+
+    def list_cashflows(self, *, limit: int = 100) -> List[Dict[str, Any]]:
+        """Return the most recent cash flow events."""
+
+        limit_value = max(1, int(limit))
+        with self._lock:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT id, timestamp, type, amount, currency, account, note
+                    FROM cashflows
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                    """,
+                    (limit_value,),
+                ).fetchall()
+
+        records: List[Dict[str, Any]] = []
+        for row in rows:
+            flow_type = str(row["type"])
+            amount = float(row["amount"])
+            signed = amount if flow_type == "deposit" else -amount
+            records.append(
+                {
+                    "id": int(row["id"]),
+                    "timestamp": str(row["timestamp"]),
+                    "type": flow_type,
+                    "amount": amount,
+                    "currency": str(row["currency"]),
+                    "account": row["account"],
+                    "note": row["note"],
+                    "signed_amount": signed,
+                }
+            )
+        return records
+
+    async def list_cashflows_async(self, *, limit: int = 100) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.list_cashflows, limit=limit)
+
+    def build_portfolio_report(self, window: str) -> tuple[str, bytes]:
+        """Return a CSV report containing NAV history for ``window``."""
+
+        snapshot = self.fetch_range(window)
+        series: List[Mapping[str, Any]] = snapshot.get("series", [])  # type: ignore[assignment]
+        summary = snapshot.get("summary", {})
+        now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        filename = f"portfolio_report_{window}_{now}.csv"
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(["Generated at", datetime.now(timezone.utc).isoformat()])
+        writer.writerow(["Window", window])
+        writer.writerow([])
+        writer.writerow(["Summary"])
+        for key in (
+            "nav_start",
+            "nav_end",
+            "nav_change",
+            "nav_change_pct",
+            "equity_start",
+            "equity_end",
+            "equity_change",
+            "equity_change_pct",
+            "realized_start",
+            "realized_end",
+            "realized_change",
+            "max_drawdown",
+            "cashflow_deposits",
+            "cashflow_withdrawals",
+            "cashflow_net",
+        ):
+            writer.writerow([key, summary.get(key)])
+
+        writer.writerow([])
+        writer.writerow([
+            "timestamp",
+            "nav",
+            "equity",
+            "realized",
+            "unrealized",
+            "gross_exposure",
+            "net_exposure",
+            "drawdown",
+        ])
+        for entry in series:
+            writer.writerow(
+                [
+                    entry.get("timestamp"),
+                    entry.get("nav"),
+                    entry.get("equity"),
+                    entry.get("realized"),
+                    entry.get("unrealized"),
+                    entry.get("gross_exposure"),
+                    entry.get("net_exposure"),
+                    entry.get("drawdown"),
+                ]
+            )
+
+        contents = buffer.getvalue().encode("utf-8")
+        return filename, contents
+
+    async def build_portfolio_report_async(self, window: str) -> tuple[str, bytes]:
+        return await asyncio.to_thread(self.build_portfolio_report, window)
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS nav_history (
+                    timestamp TEXT PRIMARY KEY,
+                    nav REAL NOT NULL,
+                    equity REAL NOT NULL,
+                    realized REAL NOT NULL,
+                    unrealized REAL NOT NULL,
+                    gross_exposure REAL NOT NULL,
+                    net_exposure REAL NOT NULL,
+                    drawdown REAL NOT NULL,
+                    high_water_mark REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cashflows (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT NOT NULL,
+                    type TEXT NOT NULL CHECK (type IN ('deposit', 'withdrawal')),
+                    amount REAL NOT NULL,
+                    currency TEXT NOT NULL,
+                    account TEXT,
+                    note TEXT
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_cashflows_timestamp ON cashflows(timestamp)")
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @staticmethod
+    def _to_float(value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def _parse_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate.endswith("Z"):
+                candidate = candidate[:-1] + "+00:00"
+            try:
+                parsed = datetime.fromisoformat(candidate)
+            except ValueError:
+                return datetime.now(timezone.utc)
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        return datetime.now(timezone.utc)
+
+    def _parse_window(self, window: str) -> timedelta:
+        key = window.strip().lower()
+        if key not in self._WINDOWS:
+            raise ValueError(f"Unsupported range '{window}'. Valid options: {', '.join(self._WINDOWS)}")
+        return self._WINDOWS[key]
+
+    @staticmethod
+    def _summarise_series(series: List[Mapping[str, Any]]) -> Dict[str, Any]:
+        if not series:
+            return {
+                "nav_start": 0.0,
+                "nav_end": 0.0,
+                "nav_change": 0.0,
+                "nav_change_pct": 0.0,
+                "equity_start": 0.0,
+                "equity_end": 0.0,
+                "equity_change": 0.0,
+                "equity_change_pct": 0.0,
+                "realized_start": 0.0,
+                "realized_end": 0.0,
+                "realized_change": 0.0,
+                "max_drawdown": 0.0,
+                "range_start": None,
+                "range_end": None,
+            }
+
+        first = series[0]
+        last = series[-1]
+        nav_start = float(first.get("nav", 0.0))
+        nav_end = float(last.get("nav", 0.0))
+        equity_start = float(first.get("equity", 0.0))
+        equity_end = float(last.get("equity", 0.0))
+        realized_start = float(first.get("realized", 0.0))
+        realized_end = float(last.get("realized", 0.0))
+        nav_change = nav_end - nav_start
+        equity_change = equity_end - equity_start
+        nav_change_pct = (nav_change / nav_start) if nav_start else 0.0
+        equity_change_pct = (equity_change / equity_start) if equity_start else 0.0
+        max_drawdown = max(float(entry.get("drawdown", 0.0)) for entry in series)
+
+        return {
+            "nav_start": nav_start,
+            "nav_end": nav_end,
+            "nav_change": nav_change,
+            "nav_change_pct": nav_change_pct,
+            "equity_start": equity_start,
+            "equity_end": equity_end,
+            "equity_change": equity_change,
+            "equity_change_pct": equity_change_pct,
+            "realized_start": realized_start,
+            "realized_end": realized_end,
+            "realized_change": realized_end - realized_start,
+            "max_drawdown": max_drawdown,
+            "range_start": first.get("timestamp"),
+            "range_end": last.get("timestamp"),
+        }
+
+    def _summarise_cashflows(self, since: datetime) -> Dict[str, Any]:
+        with self._lock:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT type, SUM(amount) FROM cashflows WHERE timestamp >= ? GROUP BY type",
+                    (since.isoformat(),),
+                ).fetchall()
+
+        deposits = 0.0
+        withdrawals = 0.0
+        for row in rows:
+            flow_type = str(row[0])
+            total = self._to_float(row[1])
+            if flow_type == "deposit":
+                deposits = total
+            elif flow_type == "withdrawal":
+                withdrawals = total
+
+        return {
+            "cashflow_deposits": deposits,
+            "cashflow_withdrawals": withdrawals,
+            "cashflow_net": deposits - withdrawals,
+        }
+

--- a/risk_management/templates/base.html
+++ b/risk_management/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}Risk Management Dashboard{% endblock %}</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
     <style>
       :root {
         color-scheme: dark;

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -83,6 +83,160 @@
       gap: 0.75rem;
       flex-wrap: wrap;
     }
+
+    .history-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .history-range {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .history-range__button {
+      background: rgba(148, 163, 184, 0.18);
+      color: var(--text);
+      border: 1px solid transparent;
+      border-radius: 999px;
+      padding: 0.4rem 0.9rem;
+      font-size: 0.85rem;
+      font-weight: 600;
+      transition: background 0.15s ease, border-color 0.15s ease;
+    }
+
+    .history-range__button:hover {
+      background: rgba(148, 163, 184, 0.3);
+    }
+
+    .history-range__button.active {
+      background: var(--accent);
+      color: #0f172a;
+    }
+
+    .history-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1rem;
+      margin-top: 1.25rem;
+    }
+
+    .history-summary__item {
+      background: rgba(15, 23, 42, 0.6);
+      border-radius: 0.75rem;
+      padding: 0.85rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .history-summary__item .label {
+      color: var(--muted);
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .history-summary__item .value {
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    .history-summary__item .value.positive {
+      color: var(--success);
+    }
+
+    .history-summary__item .value.negative {
+      color: var(--danger);
+    }
+
+    .history-summary__item .delta {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .history-summary__item .delta.positive {
+      color: var(--success);
+    }
+
+    .history-summary__item .delta.negative {
+      color: var(--danger);
+    }
+
+    .history-chart {
+      margin-top: 1.5rem;
+      position: relative;
+      min-height: 260px;
+    }
+
+    .history-chart canvas {
+      width: 100% !important;
+      height: 100% !important;
+    }
+
+    .history-actions {
+      margin-top: 1.5rem;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .cashflow-form {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .cashflow-form label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+    }
+
+    .cashflow-form input,
+    .cashflow-form select,
+    .cashflow-form textarea {
+      background: rgba(15, 23, 42, 0.6);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 0.75rem;
+      padding: 0.6rem 0.75rem;
+      color: var(--text);
+      font-size: 0.95rem;
+      font-family: inherit;
+    }
+
+    .cashflow-form textarea {
+      min-height: 3rem;
+      resize: vertical;
+    }
+
+    .cashflow-actions {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .cashflow-status {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .cashflow-status.success {
+      color: var(--success);
+    }
+
+    .cashflow-status.error {
+      color: var(--danger);
+    }
   </style>
 {% endblock %}
 
@@ -138,6 +292,15 @@
         Analytics
       </button>
     {% endif %}
+    <button
+      type="button"
+      class="view-nav__button"
+      role="tab"
+      aria-selected="false"
+      data-page-target="cashflows"
+    >
+      Cash flows
+    </button>
   </nav>
 
   <div class="page-sections">
@@ -252,6 +415,61 @@
         {% else %}
           <p style="color: var(--muted); margin-top: 1rem;">No active exposures.</p>
         {% endif %}
+      </section>
+
+      <section class="card history-card" data-history-card>
+        <div class="history-header">
+          <div>
+            <h2 style="margin: 0;">Portfolio performance</h2>
+            <p style="color: var(--muted); margin: 0;" data-history-updated>Last updated —</p>
+          </div>
+          <div class="history-range" role="group" aria-label="History range">
+            {% for window in ["1h", "6h", "24h", "7d", "30d"] %}
+              <button
+                type="button"
+                class="history-range__button{% if window == '24h' %} active{% endif %}"
+                data-history-range="{{ window }}"
+              >
+                {{ window }}
+              </button>
+            {% endfor %}
+          </div>
+        </div>
+        <div class="history-summary" data-history-summary>
+          <div class="history-summary__item">
+            <span class="label">Net asset value</span>
+            <span class="value" data-history-nav>—</span>
+            <span class="delta" data-history-nav-delta>—</span>
+          </div>
+          <div class="history-summary__item">
+            <span class="label">Equity</span>
+            <span class="value" data-history-equity>—</span>
+            <span class="delta" data-history-equity-delta>—</span>
+          </div>
+          <div class="history-summary__item">
+            <span class="label">Realised PnL</span>
+            <span class="value" data-history-realized>—</span>
+            <span class="delta" data-history-realized-delta>—</span>
+          </div>
+          <div class="history-summary__item">
+            <span class="label">Max drawdown</span>
+            <span class="value" data-history-drawdown>—</span>
+            <span class="delta" data-history-drawdown-detail></span>
+          </div>
+          <div class="history-summary__item">
+            <span class="label">Net cash flow</span>
+            <span class="value" data-history-cashflow-net>—</span>
+            <span class="delta" data-history-cashflow-detail>Deposits — · Withdrawals —</span>
+          </div>
+        </div>
+        <div class="history-chart">
+          <canvas data-history-chart></canvas>
+        </div>
+        <div class="history-actions">
+          <button type="button" class="button secondary" data-portfolio-report>
+            Download comprehensive report
+          </button>
+        </div>
       </section>
     </div>
 
@@ -548,6 +766,65 @@
         </section>
       </div>
     {% endif %}
+
+    <div class="page-section" data-page-section="cashflows" hidden>
+      <section class="card">
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap;">
+          <div>
+            <h2 style="margin: 0;">Cash flow journal</h2>
+            <p style="color: var(--muted); margin: 0;">Track deposits and withdrawals across your portfolios.</p>
+          </div>
+        </div>
+        <form class="cashflow-form" data-cashflow-form>
+          <label>
+            Type
+            <select name="type" required>
+              <option value="deposit" selected>Deposit</option>
+              <option value="withdrawal">Withdrawal</option>
+            </select>
+          </label>
+          <label>
+            Amount
+            <input type="number" name="amount" step="0.01" min="0" placeholder="0.00" required />
+          </label>
+          <label>
+            Currency
+            <input type="text" name="currency" value="USDT" maxlength="12" />
+          </label>
+          <label>
+            Account / fund
+            <input type="text" name="account" placeholder="Optional" />
+          </label>
+          <label style="grid-column: 1 / -1;">
+            Note
+            <textarea name="note" placeholder="Optional note"></textarea>
+          </label>
+          <div class="cashflow-actions" style="grid-column: 1 / -1;">
+            <button type="submit">Add entry</button>
+            <span class="cashflow-status" data-cashflow-status hidden></span>
+          </div>
+        </form>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Type</th>
+                <th>Amount</th>
+                <th>Currency</th>
+                <th>Account</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody data-cashflow-rows>
+              <tr>
+                <td colspan="6" style="text-align: center; color: var(--muted);">No cash flow events recorded yet.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
   </div>
 {% endblock %}
 
@@ -559,9 +836,33 @@
     const DEFAULT_PAGE = "overview";
     const STORAGE_KEY = "risk-dashboard.activePage";
     const METRIC_WINDOWS = ["4h", "24h", "3d", "7d"];
+    const HISTORY_WINDOWS = ["1h", "6h", "24h", "7d", "30d"];
+    const DEFAULT_HISTORY_WINDOW = "24h";
+
+    let historyChart = null;
+    let currentHistoryWindow = DEFAULT_HISTORY_WINDOW;
+    let historyFetchInFlight = false;
+    let lastHistoryFetch = 0;
 
     const pageSections = Array.from(document.querySelectorAll("[data-page-section]"));
     const navButtons = Array.from(document.querySelectorAll("[data-page-target]"));
+    const historyRangeButtons = Array.from(document.querySelectorAll("[data-history-range]"));
+    const historyChartCanvas = document.querySelector("[data-history-chart]");
+    const historyUpdatedEl = document.querySelector("[data-history-updated]");
+    const historyNavEl = document.querySelector("[data-history-nav]");
+    const historyNavDeltaEl = document.querySelector("[data-history-nav-delta]");
+    const historyEquityEl = document.querySelector("[data-history-equity]");
+    const historyEquityDeltaEl = document.querySelector("[data-history-equity-delta]");
+    const historyRealizedEl = document.querySelector("[data-history-realized]");
+    const historyRealizedDeltaEl = document.querySelector("[data-history-realized-delta]");
+    const historyDrawdownEl = document.querySelector("[data-history-drawdown]");
+    const historyDrawdownDetailEl = document.querySelector("[data-history-drawdown-detail]");
+    const historyCashflowNetEl = document.querySelector("[data-history-cashflow-net]");
+    const historyCashflowDetailEl = document.querySelector("[data-history-cashflow-detail]");
+    const portfolioReportButton = document.querySelector("[data-portfolio-report]");
+    const cashflowForm = document.querySelector("[data-cashflow-form]");
+    const cashflowRows = document.querySelector("[data-cashflow-rows]");
+    const cashflowStatus = document.querySelector("[data-cashflow-status]");
 
     const setActivePage = (page) => {
       const targetExists = pageSections.some(
@@ -595,6 +896,15 @@
       });
     });
 
+    historyRangeButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const window = button.getAttribute("data-history-range");
+        if (window) {
+          loadHistory(window, true);
+        }
+      });
+    });
+
     try {
       const stored = window.localStorage.getItem(STORAGE_KEY);
       if (stored) {
@@ -605,6 +915,16 @@
     } catch (error) {
       console.debug("Failed to restore active page", error);
       setActivePage(DEFAULT_PAGE);
+    }
+
+    setHistoryRangeActive(DEFAULT_HISTORY_WINDOW);
+    loadHistory(DEFAULT_HISTORY_WINDOW, true);
+    loadCashflows();
+    if (portfolioReportButton) {
+      portfolioReportButton.addEventListener("click", downloadPortfolioReport);
+    }
+    if (cashflowForm) {
+      cashflowForm.addEventListener("submit", submitCashflow);
     }
 
     const formatCurrency = (value) => {
@@ -638,6 +958,353 @@
       const size = number / 1024 ** exponent;
       const precision = exponent === 0 ? 0 : 2;
       return `${size.toFixed(precision)} ${units[exponent]}`;
+    };
+
+    const formatSignedCurrency = (value) => {
+      const number = Number(value || 0);
+      const absolute = formatCurrency(Math.abs(number));
+      if (number > 0) {
+        return `+${absolute}`;
+      }
+      if (number < 0) {
+        return `-${absolute}`;
+      }
+      return absolute;
+    };
+
+    const setHistoryRangeActive = (window) => {
+      historyRangeButtons.forEach((button) => {
+        const value = button.getAttribute("data-history-range");
+        const isActive = value === window;
+        button.classList.toggle("active", isActive);
+        button.setAttribute("aria-pressed", String(isActive));
+      });
+    };
+
+    const updateDeltaElement = (element, changeValue, pctValue, options = {}) => {
+      if (!element) {
+        return;
+      }
+      const { showPct = true } = options;
+      element.classList.remove("positive", "negative");
+      const change = Number(changeValue);
+      const pct = Number(pctValue);
+      const hasChange = Number.isFinite(change) && change !== 0;
+      const hasPct = showPct && Number.isFinite(pct) && pct !== 0;
+      if (!hasChange && !hasPct) {
+        element.textContent = "—";
+        return;
+      }
+      const parts = [];
+      if (hasChange) {
+        parts.push(formatSignedCurrency(change));
+        if (change > 0) {
+          element.classList.add("positive");
+        } else if (change < 0) {
+          element.classList.add("negative");
+        }
+      }
+      if (hasPct) {
+        if (!hasChange && pct !== 0) {
+          if (pct > 0) {
+            element.classList.add("positive");
+          } else if (pct < 0) {
+            element.classList.add("negative");
+          }
+        }
+        parts.push(`(${formatPct(pct)})`);
+      }
+      element.textContent = parts.join(" ").trim() || "—";
+    };
+
+    const safeDateString = (value) => {
+      if (!value) {
+        return "";
+      }
+      try {
+        return new Date(value).toLocaleString();
+      } catch (error) {
+        return String(value);
+      }
+    };
+
+    const updateHistorySummary = (payload) => {
+      const summary = payload && payload.summary ? payload.summary : {};
+      const series = Array.isArray(payload?.series) ? payload.series : [];
+      const hasData = series.length > 0;
+
+      if (historyNavEl) {
+        historyNavEl.textContent = hasData ? formatCurrency(summary.nav_end || 0) : "—";
+      }
+      updateDeltaElement(historyNavDeltaEl, summary.nav_change, summary.nav_change_pct);
+
+      if (historyEquityEl) {
+        historyEquityEl.textContent = hasData ? formatCurrency(summary.equity_end || 0) : "—";
+      }
+      updateDeltaElement(historyEquityDeltaEl, summary.equity_change, summary.equity_change_pct);
+
+      if (historyRealizedEl) {
+        historyRealizedEl.textContent = hasData ? formatCurrency(summary.realized_end || 0) : "—";
+      }
+      updateDeltaElement(historyRealizedDeltaEl, summary.realized_change, undefined, { showPct: false });
+
+      if (historyDrawdownEl) {
+        historyDrawdownEl.textContent = hasData ? formatPct(summary.max_drawdown || 0) : "—";
+      }
+      if (historyDrawdownDetailEl) {
+        const start = summary.range_start ? safeDateString(summary.range_start) : "";
+        const end = summary.range_end ? safeDateString(summary.range_end) : "";
+        historyDrawdownDetailEl.textContent = start && end ? `${start} → ${end}` : "";
+      }
+
+      const deposits = Number(summary.cashflow_deposits || 0);
+      const withdrawals = Number(summary.cashflow_withdrawals || 0);
+      const netFlow = Number(summary.cashflow_net || 0);
+      if (historyCashflowNetEl) {
+        historyCashflowNetEl.textContent = hasData || netFlow !== 0 ? formatSignedCurrency(netFlow) : "—";
+        historyCashflowNetEl.classList.toggle("positive", netFlow > 0);
+        historyCashflowNetEl.classList.toggle("negative", netFlow < 0);
+      }
+      if (historyCashflowDetailEl) {
+        if (!hasData && !deposits && !withdrawals) {
+          historyCashflowDetailEl.textContent = "Deposits — · Withdrawals —";
+        } else {
+          historyCashflowDetailEl.textContent = `Deposits ${formatCurrency(deposits)} · Withdrawals ${formatCurrency(withdrawals)}`;
+        }
+      }
+
+      if (historyUpdatedEl) {
+        historyUpdatedEl.textContent = payload && payload.updated_at
+          ? `Last updated ${safeDateString(payload.updated_at)}`
+          : "Last updated —";
+      }
+    };
+
+    const updateHistoryChart = (series) => {
+      if (!historyChartCanvas || typeof Chart === "undefined") {
+        return;
+      }
+      const labels = Array.isArray(series)
+        ? series.map((entry) => safeDateString(entry.timestamp))
+        : [];
+      const navData = Array.isArray(series)
+        ? series.map((entry) => Number(entry.nav || 0))
+        : [];
+      const equityData = Array.isArray(series)
+        ? series.map((entry) => Number(entry.equity || 0))
+        : [];
+
+      if (!historyChart) {
+        historyChart = new Chart(historyChartCanvas, {
+          type: "line",
+          data: {
+            labels,
+            datasets: [
+              {
+                label: "NAV",
+                data: navData,
+                borderColor: "#38bdf8",
+                backgroundColor: "rgba(56, 189, 248, 0.18)",
+                tension: 0.25,
+                fill: false,
+                borderWidth: 2,
+              },
+              {
+                label: "Equity",
+                data: equityData,
+                borderColor: "#34d399",
+                backgroundColor: "rgba(52, 211, 153, 0.18)",
+                tension: 0.25,
+                fill: false,
+                borderWidth: 2,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                ticks: { color: "rgba(226, 232, 240, 0.7)" },
+                grid: { color: "rgba(148, 163, 184, 0.2)" },
+              },
+              y: {
+                ticks: {
+                  color: "rgba(226, 232, 240, 0.7)",
+                  callback: (value) => {
+                    const number = Number(value);
+                    if (!Number.isFinite(number)) {
+                      return value;
+                    }
+                    if (Math.abs(number) >= 1_000_000) {
+                      return `${(number / 1_000_000).toFixed(1)}M`;
+                    }
+                    if (Math.abs(number) >= 1_000) {
+                      return `${(number / 1_000).toFixed(1)}k`;
+                    }
+                    return number.toFixed(0);
+                  },
+                },
+                grid: { color: "rgba(148, 163, 184, 0.2)" },
+              },
+            },
+            plugins: {
+              legend: {
+                labels: { color: "rgba(226, 232, 240, 0.7)" },
+              },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    const label = context.dataset?.label || "";
+                    return `${label}: ${formatCurrency(context.parsed.y)}`;
+                  },
+                },
+              },
+            },
+          },
+        });
+      } else {
+        historyChart.data.labels = labels;
+        historyChart.data.datasets[0].data = navData;
+        historyChart.data.datasets[1].data = equityData;
+        historyChart.update();
+      }
+    };
+
+    const loadHistory = async (window = currentHistoryWindow, force = false) => {
+      if (!historyChartCanvas) {
+        return;
+      }
+      const now = Date.now();
+      if (!force && historyFetchInFlight && window === currentHistoryWindow) {
+        return;
+      }
+      if (!force && window === currentHistoryWindow && now - lastHistoryFetch < 15000) {
+        return;
+      }
+      historyFetchInFlight = true;
+      try {
+        const response = await fetch(`/api/history/portfolio?window=${encodeURIComponent(window)}`, {
+          credentials: "include",
+        });
+        if (!response.ok) {
+          return;
+        }
+        const payload = await response.json();
+        currentHistoryWindow = window;
+        lastHistoryFetch = now;
+        setHistoryRangeActive(window);
+        updateHistorySummary(payload);
+        updateHistoryChart(payload.series || []);
+      } catch (error) {
+        console.error("Failed to load history", error);
+      } finally {
+        historyFetchInFlight = false;
+      }
+    };
+
+    const renderCashflows = (records) => {
+      if (!cashflowRows) {
+        return;
+      }
+      if (!Array.isArray(records) || records.length === 0) {
+        cashflowRows.innerHTML = `
+          <tr>
+            <td colspan="6" style="text-align: center; color: var(--muted);">No cash flow events recorded yet.</td>
+          </tr>
+        `;
+        return;
+      }
+      const rows = records
+        .map((entry) => {
+          const amount = Number(entry.signed_amount || 0);
+          const amountText = formatSignedCurrency(amount);
+          const type = String(entry.type || "").toUpperCase();
+          const note = entry.note ? String(entry.note) : "-";
+          const account = entry.account ? String(entry.account) : "-";
+          return `
+            <tr>
+              <td>${safeDateString(entry.timestamp)}</td>
+              <td>${type}</td>
+              <td>${amountText}</td>
+              <td>${entry.currency || "-"}</td>
+              <td>${account}</td>
+              <td>${note}</td>
+            </tr>
+          `;
+        })
+        .join("");
+      cashflowRows.innerHTML = rows;
+    };
+
+    const loadCashflows = async () => {
+      if (!cashflowRows) {
+        return;
+      }
+      try {
+        const response = await fetch("/api/history/cashflows?limit=200", { credentials: "include" });
+        if (!response.ok) {
+          return;
+        }
+        const payload = await response.json();
+        renderCashflows(payload.cashflows || []);
+      } catch (error) {
+        console.error("Failed to load cash flows", error);
+      }
+    };
+
+    const submitCashflow = async (event) => {
+      event.preventDefault();
+      if (!cashflowForm) {
+        return;
+      }
+      const formData = new FormData(cashflowForm);
+      const payload = Object.fromEntries(formData.entries());
+      if (cashflowStatus) {
+        cashflowStatus.textContent = "Saving entry...";
+        cashflowStatus.hidden = false;
+        cashflowStatus.classList.remove("error", "success");
+      }
+      try {
+        payload.amount = Number(payload.amount);
+        if (!payload.amount || payload.amount <= 0) {
+          throw new Error("Amount must be greater than zero");
+        }
+        const response = await fetch("/api/history/cashflows", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.detail || `Request failed (${response.status})`);
+        }
+        if (cashflowStatus) {
+          cashflowStatus.textContent = "Entry saved.";
+          cashflowStatus.classList.add("success");
+        }
+        cashflowForm.reset();
+        const currencyField = cashflowForm.querySelector('input[name="currency"]');
+        if (currencyField && currencyField.value.trim() === "") {
+          currencyField.value = "USDT";
+        }
+        await loadCashflows();
+        await loadHistory(currentHistoryWindow, true);
+      } catch (error) {
+        console.error(error);
+        if (cashflowStatus) {
+          cashflowStatus.textContent = `Failed to save entry: ${error.message}`;
+          cashflowStatus.classList.remove("success");
+          cashflowStatus.classList.add("error");
+          cashflowStatus.hidden = false;
+        }
+      }
+    };
+
+    const downloadPortfolioReport = () => {
+      const url = `/api/reports/portfolio?window=${encodeURIComponent(currentHistoryWindow)}`;
+      triggerReportDownload(url);
     };
 
     const renderPortfolio = (snapshot) => {
@@ -1149,6 +1816,7 @@
       renderAccounts(snapshot);
       renderAlerts(snapshot);
       renderNotifications(snapshot);
+      loadHistory(currentHistoryWindow);
     };
 
     async function poll() {


### PR DESCRIPTION
## Summary
- add a PortfolioHistoryStore to capture NAV/equity history and cash flow events for configurable time windows
- expose portfolio history, cash flow, and CSV report APIs while persisting data through the web service
- refresh the dashboard UI with performance charts, time range controls, a cash flow tab, and improved daily PnL extraction

## Testing
- pytest tests/test_risk_management_web.py

------
https://chatgpt.com/codex/tasks/task_b_68ff09f4c620832398f7888b8e04c72f