### PR TITLE
Restore risk management configuration defaults

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -83,11 +83,6 @@ Copy the template configuration and fill in your details:
 cp risk_management/realtime_config.example.json risk_management/realtime_config.local.json
 ```
 
-The bundled template keeps every sample account disabled and points to
-`api-keys.json.example` so you can run the CLI without real exchange access or
-ccxt installed.  Replace the placeholder credentials with your own keys and set
-`"enabled": true` on each account before attempting to fetch live data.
-
 Update the new file with the following information.
 
 ### Accounts

--- a/risk_management/realtime_config.example.json
+++ b/risk_management/realtime_config.example.json
@@ -1,99 +1,78 @@
 {
-    "api_keys_file": "../api-keys.json.example",
-    "debug_api_payloads": false,
-    "custom_endpoints": {
-        "path": "../configs/custom_endpoints.json.example",
-        "autodiscover": false
+  "custom_endpoints": {
+    "path": "../configs/custom_endpoints.json",
+    "autodiscover": false
+  },
+  "reports_dir": "../risk_reports",
+  "grafana": {
+    "base_url": "https://grafana.example.com/",
+    "default_height": 620,
+    "dashboards": [
+      {
+        "title": "Portfolio overview",
+        "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
+        "description": "NAV, profit rate, and drawdown metrics across the portfolio."
+      },
+      {
+        "title": "Exposure & leverage",
+        "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
+        "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
+      }
+    ]
+  },
+
+  "debug_api_payloads": false,
+  "accounts": [
+    {
+      "name": "Binance Futures",
+      "exchange": "binanceusdm",
+      "api_key_id": "binance_01",
+      "settle_currency": "USDT"
     },
-    "reports_dir": "../risk_reports",
-    "grafana": {
-        "base_url": "https://grafana.example.com/",
-        "default_height": 620,
-        "dashboards": [
-            {
-                "title": "Portfolio overview",
-                "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
-                "description": "NAV, profit rate, and drawdown metrics across the portfolio."
-            },
-            {
-                "title": "Exposure & leverage",
-                "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
-                "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
-            }
-        ]
+    {
+      "name": "OKX Futures",
+      "exchange": "okx",
+      "api_key_id": "okx_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
     },
-    "accounts": [
-        {
-            "name": "Binance Futures (sample)",
-            "exchange": "binanceusdm",
-            "api_key_id": "binance_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        },
-        {
-            "name": "OKX Futures (sample)",
-            "exchange": "okx",
-            "api_key_id": "okx_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        },
-        {
-            "name": "Bybit USDT Perpetuals (sample)",
-            "exchange": "bybit",
-            "api_key_id": "bybit_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        }
-    ],
-    "alert_thresholds": {
-        "wallet_exposure_pct": 0.65,
-        "position_wallet_exposure_pct": 0.25,
-        "max_drawdown_pct": 0.25,
-        "loss_threshold_pct": -0.08
-    },
-    "email": {
-        "host": "smtp.example.com",
-        "port": 587,
-        "username": "alerts@example.com",
-        "password": "replace-with-app-password",
-        "sender": "alerts@example.com",
-        "use_tls": true
-    },
-    "notification_channels": [
-        "email:risk-team@example.com",
-        "telegram:bot-token@chat-id",
-        "slack:#passivbot-risk-alerts"
-    ],
-    "auth": {
-        "secret_key": "replace-with-a-long-random-string",
-        "session_cookie_name": "risk_dashboard_session",
-        "https_only": true,
-        "users": {
-            "admin": "$2b$12$0ZCLkFp6iuhlEFshgPCBz.0dXxmRCV4vcjxHfRh0qKtzc79Pj9c5W"
-        }
+    {
+      "name": "Bybit USDT Perpetuals",
+      "exchange": "bybit",
+      "api_key_id": "bybit_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
     }
+  ],
+  "alert_thresholds": {
+    "wallet_exposure_pct": 0.65,
+    "position_wallet_exposure_pct": 0.25,
+    "max_drawdown_pct": 0.25,
+    "loss_threshold_pct": -0.08
+  },
+  "email": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "username": "alerts@example.com",
+    "password": "replace-with-app-password",
+    "sender": "alerts@example.com",
+    "use_tls": true
+  },
+  "notification_channels": [
+    "email:risk-team@example.com",
+    "slack:#passivbot-risk-alerts"
+  ],
+  "auth": {
+    "secret_key": "replace-me-with-a-long-random-string",
+    "session_cookie_name": "risk_dashboard_session",
+    "users": {
+      "admin": "replace-with-bcrypt-hash"
+    }
+  }
 }

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -1,99 +1,81 @@
 {
-    "api_keys_file": "../api-keys.json.example",
-    "debug_api_payloads": false,
-    "custom_endpoints": {
-        "path": "../configs/custom_endpoints.json.example",
-        "autodiscover": false
+  "api_keys_file": "/root/passivbot/api-keys.json",
+  "debug_api_payloads": false,
+  "custom_endpoints": {
+    "path": "/root/passivbot/configs/custom_endpoints.json",
+    "autodiscover": false
+  },
+  "reports_dir": "../risk_reports",
+  "grafana": {
+    "base_url": "https://108.160.138.76:8001/",
+    "default_height": 620,
+    "dashboards": [
+      {
+        "title": "Portfolio overview",
+        "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
+        "description": "NAV, profit rate, and drawdown metrics across the portfolio."
+      },
+      {
+        "title": "Exposure & leverage",
+        "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
+        "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
+      }
+    ]
+  },
+
+  "accounts": [
+    {
+      "name": "Binance Futures Alpha Mint",
+      "exchange": "binanceusdm",
+      "api_key_id": "binance_01",
+      "settle_currency": "USDT"
     },
-    "reports_dir": "../risk_reports",
-    "grafana": {
-        "base_url": "https://grafana.example.com/",
-        "default_height": 620,
-        "dashboards": [
-            {
-                "title": "Portfolio overview",
-                "url": "d-solo/abc123/portfolio-overview?orgId=1&from=now-7d&to=now&panelId=2&refresh=1m",
-                "description": "NAV, profit rate, and drawdown metrics across the portfolio."
-            },
-            {
-                "title": "Exposure & leverage",
-                "url": "d-solo/def456/portfolio-exposure?orgId=1&from=now-7d&to=now&panelId=6&refresh=1m",
-                "description": "Wallet exposure, leverage ratios, and asset allocation breakdowns."
-            }
-        ]
+    {
+      "name": "OKX Futures",
+      "exchange": "okx",
+      "api_key_id": "okx_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
     },
-    "accounts": [
-        {
-            "name": "Binance Futures (sample)",
-            "exchange": "binanceusdm",
-            "api_key_id": "binance_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        },
-        {
-            "name": "OKX Futures (sample)",
-            "exchange": "okx",
-            "api_key_id": "okx_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        },
-        {
-            "name": "Bybit USDT Perpetuals (sample)",
-            "exchange": "bybit",
-            "api_key_id": "bybit_01",
-            "settle_currency": "USDT",
-            "enabled": false,
-            "params": {
-                "balance": {
-                    "type": "swap"
-                },
-                "positions": {
-                    "type": "swap"
-                }
-            }
-        }
-    ],
-    "alert_thresholds": {
-        "wallet_exposure_pct": 0.65,
-        "position_wallet_exposure_pct": 0.25,
-        "max_drawdown_pct": 0.25,
-        "loss_threshold_pct": -0.08
-    },
-    "email": {
-        "host": "smtp.example.com",
-        "port": 587,
-        "username": "alerts@example.com",
-        "password": "replace-with-app-password",
-        "sender": "alerts@example.com",
-        "use_tls": true
-    },
-    "notification_channels": [
-        "email:risk-team@example.com",
-        "telegram:bot-token@chat-id",
-        "slack:#passivbot-risk-alerts"
-    ],
-    "auth": {
-        "secret_key": "replace-with-a-long-random-string",
-        "session_cookie_name": "risk_dashboard_session",
-        "https_only": true,
-        "users": {
-            "admin": "$2b$12$0ZCLkFp6iuhlEFshgPCBz.0dXxmRCV4vcjxHfRh0qKtzc79Pj9c5W"
-        }
+    {
+      "name": "Bybit USDT Perpetuals The Alter",
+      "exchange": "bybit",
+      "api_key_id": "bybit_01",
+      "settle_currency": "USDT",
+      "params": {
+        "balance": {"type": "swap"},
+        "positions": {"type": "swap"}
+      }
     }
+  ],
+  "alert_thresholds": {
+    "wallet_exposure_pct": 0.65,
+    "position_wallet_exposure_pct": 0.25,
+    "max_drawdown_pct": 0.25,
+    "loss_threshold_pct": -0.08
+  },
+  "email": {
+    "host": "smtppro.zoho.in",
+    "port": 587,
+    "username": "admin@plezna.com",
+    "password": "L4naQ6CKK4Ja",
+    "sender": "admin@plezna.com",
+    "use_tls": true
+  },
+  "notification_channels": [
+    "email:admin@plezna.com",
+    "telegram:8167125177:AAG-dOUQ9rgvAyvYRRZ9m73nnffErz-7ABE-751365364", 
+    "slack:#passivbot-risk-alerts"
+  ],
+  "auth": {
+    "secret_key": "jhgjhguyg^^554$$67CFCGFDGFd",
+    "session_cookie_name": "risk_dashboard_session",
+    "https_only": false,
+    "users": {
+      "admin": "$2b$12$0ZCLkFp6iuhlEFshgPCBz.0dXxmRCV4vcjxHfRh0qKtzc79Pj9c5W"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- restore the risk management README and configuration templates to the last working defaults
- revert realtime_config.example.json to reference local API key discovery and placeholder sample accounts
- revert realtime_config.json to the previously functional configuration values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ff31c5a0c483239948c690df9e4a7c