### PR TITLE
Ensure risk management can locate custom endpoint overrides

### DIFF
--- a/risk_management/__init__.py
+++ b/risk_management/__init__.py
@@ -8,7 +8,27 @@ can run inside the sandboxed execution environment used for the exercises.
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
 __all__ = ["__version__"]
 
 __version__ = "0.1.0"
+
+
+def _ensure_src_on_path() -> None:
+    """Expose the repository ``src`` directory for local executions."""
+
+    package_root = Path(__file__).resolve().parent
+    src_dir = package_root.parent / "src"
+    if not src_dir.is_dir():
+        return
+
+    src_path = str(src_dir)
+    if src_path not in sys.path:
+        # Prepend so that an editable install still takes precedence when present.
+        sys.path.insert(0, src_path)
+
+
+_ensure_src_on_path()
 


### PR DESCRIPTION
## Summary
- prepend the repository src directory to sys.path when the risk_management package is imported so local executions can resolve custom_endpoint_overrides

## Testing
- python -m risk_management.web_server --config risk_management/realtime_config.json --host 0.0.0.0 --port 8000 *(fails: requires api-keys.json which is absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ff4635c3908323b8f19c4a8a3ce7d9