### PR TITLE
Improve production CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,59 @@
-name: CI
-on: [push]
+name: Production CI/CD
+
+on:
+  push:
+    branches:
+      - prod
+    tags:
+      - 'v*'
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '**/*.md'
+      - 'changelog.md'
+  workflow_dispatch:
+
+concurrency:
+  group: prod-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  quality-checks:
+    name: Quality checks
     runs-on: ubuntu-latest
     steps:
-      - run: 'true'
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-live.txt
+            requirements-rust.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run pytest suite
+        run: pytest
+
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    needs: quality-checks
+    if: github.ref == 'refs/heads/prod' || startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deployment step
+        run: |
+          echo "Replace this step with the production deployment commands."


### PR DESCRIPTION
## Summary
- restrict the CI workflow to prod pushes and release tags with useful path filters
- add cached Python setup and pytest quality checks before deployment
- add a gated deployment job targeting the production environment

## Testing
- not run (yaml-only change)


------
https://chatgpt.com/codex/tasks/task_b_68ff5069eb648323bb8a92e791957a61