### PR TITLE
Extract realized PnL helper for risk accounts

### DIFF
--- a/risk_management/realized_pnl.py
+++ b/risk_management/realized_pnl.py
@@ -1,0 +1,242 @@
+"""Helpers for computing realized PnL history across exchanges."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional, Sequence
+
+try:  # pragma: no cover - optional dependency in some environments
+    from ccxt.base.errors import BaseError  # type: ignore
+except Exception:  # pragma: no cover - fallback when ccxt is missing
+    class BaseError(Exception):
+        """Fallback error when ccxt is unavailable."""
+
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+
+def _first_float(*values: Any) -> Optional[float]:
+    """Return the first value that can be coerced into ``float``."""
+
+    for value in values:
+        candidate = value
+        if candidate is None:
+            continue
+        if isinstance(candidate, (list, tuple)) and candidate:
+            candidate = candidate[0]
+        try:
+            return float(candidate)
+        except (TypeError, ValueError):
+            if isinstance(candidate, str):
+                try:
+                    return float(candidate.strip())
+                except (TypeError, ValueError):
+                    continue
+            continue
+    return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    """Return ``value`` converted to ``float`` when possible."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        if isinstance(value, str):
+            try:
+                return float(value.strip())
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    """Return ``value`` converted to ``int`` when possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        if isinstance(value, str):
+            try:
+                return int(float(value.strip()))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _dedupe_symbols(symbols: Optional[Sequence[Optional[str]]]) -> Sequence[Optional[str]]:
+    if not symbols:
+        return [None]
+    unique: list[Optional[str]] = []
+    seen: set[Optional[str]] = set()
+    for symbol in symbols:
+        if symbol is None:
+            if None not in seen:
+                seen.add(None)
+                unique.append(None)
+            continue
+        if isinstance(symbol, str):
+            stripped = symbol.strip()
+            if not stripped or stripped in seen:
+                continue
+            seen.add(stripped)
+            unique.append(stripped)
+    return unique or [None]
+
+
+async def fetch_realized_pnl_history(
+    exchange_id: str,
+    client: Any,
+    *,
+    since: int,
+    until: int,
+    params: Optional[Mapping[str, Any]] = None,
+    limit: Optional[int] = None,
+    symbols: Optional[Sequence[Optional[str]]] = None,
+    account_name: Optional[str] = None,
+    log: Optional[logging.Logger] = None,
+    debug_api_payloads: bool = False,
+) -> Optional[float]:
+    """Return realised PnL from exchange history endpoints when available."""
+
+    logger_instance = log or logger
+    identifier = account_name or exchange_id
+
+    if since >= until:
+        return 0.0
+
+    params_base = dict(params or {})
+
+    try:
+        if exchange_id in {"binanceusdm", "binancecoinm", "binancecm"}:
+            fetch_income = getattr(client, "fetch_income", None)
+            if fetch_income is None:
+                return None
+            request = dict(params_base)
+            request.setdefault("incomeType", "REALIZED_PNL")
+            request.setdefault("startTime", since)
+            request.setdefault("endTime", until)
+            limit_value = _coerce_int(limit)
+            if limit_value and limit_value > 0:
+                request.setdefault("limit", limit_value)
+            incomes = await fetch_income(params=request)
+            total = 0.0
+            for entry in incomes or []:
+                amount = _coerce_float(entry.get("amount"))
+                if amount is None and isinstance(entry.get("info"), Mapping):
+                    info = entry["info"]
+                    amount = _first_float(
+                        info.get("amount"),
+                        info.get("income"),
+                        info.get("realizedPnl"),
+                        info.get("realisedPnl"),
+                    )
+                if amount is None:
+                    continue
+                total += float(amount)
+            return total
+
+        if exchange_id == "bybit":
+            fetch_closed_pnl = getattr(client, "private_get_v5_position_closed_pnl", None)
+            if fetch_closed_pnl is None:
+                return None
+            limit_value = _coerce_int(limit)
+            if limit_value is None or limit_value <= 0:
+                limit_value = 200
+            total = 0.0
+            cursor: Optional[str] = None
+            while True:
+                request = dict(params_base)
+                request.setdefault("startTime", since)
+                request.setdefault("endTime", until)
+                request.setdefault("limit", limit_value)
+                if cursor:
+                    request["cursor"] = cursor
+                response = await fetch_closed_pnl(request)
+                result = response.get("result") if isinstance(response, Mapping) else None
+                rows = result.get("list") if isinstance(result, Mapping) else None
+                entries = rows or []
+                for entry in entries:
+                    pnl = _first_float(entry.get("pnl"), entry.get("closedPnl"))
+                    if pnl is None:
+                        continue
+                    total += float(pnl)
+                cursor = (
+                    result.get("nextPageCursor") if isinstance(result, Mapping) else None
+                )
+                if not cursor or not entries:
+                    break
+            return total
+
+        if exchange_id == "okx":
+            fetch_trades = getattr(client, "fetch_my_trades", None)
+            if fetch_trades is None:
+                return None
+            limit_value = _coerce_int(limit)
+            if limit_value is None or limit_value <= 0:
+                limit_value = 200
+            params_base.setdefault("until", until)
+            total = 0.0
+            for symbol in _dedupe_symbols(symbols):
+                request = dict(params_base)
+                try:
+                    trades = await fetch_trades(
+                        symbol,
+                        since=since,
+                        limit=limit_value,
+                        params=request,
+                    )
+                except BaseError as exc:
+                    logger_instance.debug(
+                        "[%s] fetch_my_trades failed for %s: %s",
+                        identifier,
+                        symbol or "*",
+                        exc,
+                        exc_info=debug_api_payloads,
+                    )
+                    continue
+                if not trades:
+                    continue
+                for trade in trades:
+                    pnl = _first_float(
+                        trade.get("pnl"),
+                        trade.get("realizedPnl"),
+                        trade.get("realisedPnl"),
+                    )
+                    info = trade.get("info") if isinstance(trade.get("info"), Mapping) else None
+                    if pnl is None and info:
+                        pnl = _first_float(
+                            info.get("fillPnl"),
+                            info.get("pnl"),
+                            info.get("realizedPnl"),
+                            info.get("realisedPnl"),
+                        )
+                    if pnl is None:
+                        continue
+                    total += float(pnl)
+            return total
+
+    except BaseError as exc:
+        logger_instance.debug(
+            "[%s] Failed to fetch realised PnL via history: %s",
+            identifier,
+            exc,
+            exc_info=debug_api_payloads,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger_instance.debug(
+            "[%s] Unexpected error while fetching realised PnL: %s",
+            identifier,
+            exc,
+            exc_info=debug_api_payloads,
+        )
+
+    return None

--- a/tests/risk_management/test_account_clients.py
+++ b/tests/risk_management/test_account_clients.py
@@ -1,12 +1,19 @@
+import asyncio
 import sys
 from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from custom_endpoint_overrides import ResolvedEndpointOverride
+from risk_management import account_clients as module
 from risk_management.account_clients import _apply_credentials, _instantiate_ccxt_client
+from risk_management.configuration import AccountConfig
+from risk_management.realized_pnl import fetch_realized_pnl_history
 
 
 class DummyClient:
@@ -52,8 +59,6 @@ def test_apply_credentials_formats_header_placeholders() -> None:
 
 
 def test_instantiate_ccxt_client_applies_custom_endpoints(monkeypatch) -> None:
-    from risk_management import account_clients as module
-
     class DummyExchange:
         def __init__(self, params):
             self.params = params
@@ -89,3 +94,179 @@ def test_instantiate_ccxt_client_applies_custom_endpoints(monkeypatch) -> None:
 
     assert client.urls["api"]["public"] == "https://proxy.example/v5"
     assert client.urls["host"] == "https://proxy.example"
+
+
+def test_fetch_realized_pnl_history_binance_uses_income_endpoint(monkeypatch) -> None:
+    class DummyIncomeClient:
+        def __init__(self) -> None:
+            self.calls: list[Mapping[str, Any]] = []
+
+        async def fetch_income(self, params=None):  # type: ignore[override]
+            self.calls.append(dict(params or {}))
+            return [
+                {"amount": "1.5"},
+                {"info": {"income": "0.5"}},
+            ]
+
+    dummy = DummyIncomeClient()
+
+    realized = asyncio.run(
+        fetch_realized_pnl_history(
+            "binanceusdm",
+            dummy,
+            since=940_000,
+            until=1_000_000,
+        )
+    )
+
+    assert realized == pytest.approx(2.0)
+    assert dummy.calls, "fetch_income should have been called"
+    params = dummy.calls[-1]
+    assert params["incomeType"] == "REALIZED_PNL"
+    assert params["startTime"] == 940_000
+    assert params["endTime"] == 1_000_000
+
+
+def test_fetch_realized_pnl_history_bybit_paginates_closed_pnl() -> None:
+    class DummyBybitClient:
+        def __init__(self) -> None:
+            self.calls: list[Mapping[str, Any]] = []
+            self._responses = [
+                {
+                    "result": {
+                        "list": [{"pnl": "1.2"}, {"closedPnl": "-0.2"}],
+                        "nextPageCursor": "cursor123",
+                    }
+                },
+                {"result": {"list": [{"pnl": "0.3"}]}}
+            ]
+
+        async def private_get_v5_position_closed_pnl(self, params=None):  # type: ignore[override]
+            self.calls.append(dict(params or {}))
+            return self._responses.pop(0)
+
+    dummy = DummyBybitClient()
+
+    realized = asyncio.run(
+        fetch_realized_pnl_history(
+            "bybit",
+            dummy,
+            since=1_940_000,
+            until=2_000_000,
+            limit=100,
+        )
+    )
+
+    assert realized == pytest.approx(1.3)
+    assert len(dummy.calls) == 2
+    assert dummy.calls[0]["limit"] == 100
+    assert dummy.calls[1]["cursor"] == "cursor123"
+
+
+def test_fetch_realized_pnl_history_okx_sums_trade_pnl(monkeypatch) -> None:
+    class DummyOkxClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, Any, Any, Mapping[str, Any]]] = []
+
+        async def fetch_my_trades(self, symbol=None, since=None, limit=None, params=None):  # type: ignore[override]
+            params = dict(params or {})
+            self.calls.append((symbol, since, limit, params))
+            return [
+                {"pnl": "0.5"},
+                {"info": {"fillPnl": "-0.2"}},
+            ]
+
+    dummy = DummyOkxClient()
+
+    realized = asyncio.run(
+        fetch_realized_pnl_history(
+            "okx",
+            dummy,
+            since=500_000,
+            until=600_000,
+            symbols=["BTC/USDT:USDT", "ETH/USDT:USDT"],
+            limit=50,
+        )
+    )
+
+    assert realized == pytest.approx(0.6)
+    assert len(dummy.calls) == 2
+    first_call = dummy.calls[0]
+    assert first_call[0] == "BTC/USDT:USDT"
+    assert first_call[1] == 500_000
+    assert first_call[2] == 50
+    assert first_call[3]["until"] == 600_000
+
+
+def test_account_fetch_uses_realized_history_when_requested(monkeypatch) -> None:
+    class DummyExchange:
+        def __init__(self) -> None:
+            self.markets = {}
+            self.options = {}
+
+        async def load_markets(self):  # type: ignore[override]
+            self.markets = {"BTCUSDT": {}}
+
+        async def fetch_balance(self, params=None):  # type: ignore[override]
+            return {"total": {"USDT": 1_000}, "info": {"totalWalletBalance": "1000"}}
+
+        async def fetch_positions(self, params=None):  # type: ignore[override]
+            return [
+                {
+                    "symbol": "BTCUSDT",
+                    "contracts": "1",
+                    "entryPrice": "100",
+                    "markPrice": "110",
+                    "unrealizedPnl": "10",
+                    "dailyRealizedPnl": "0",
+                }
+            ]
+
+        async def fetch_open_orders(self, symbol=None, params=None):  # type: ignore[override]
+            return []
+
+        async def close(self):  # type: ignore[override]
+            return None
+
+    dummy_client = DummyExchange()
+
+    def fake_instantiate(exchange: str, credentials: Mapping[str, Any]):
+        assert exchange == "bybit"
+        return dummy_client
+
+    monkeypatch.setattr(module, "_instantiate_ccxt_client", fake_instantiate)
+
+    async def fake_collect(self, symbols):  # type: ignore[override]
+        return {}
+
+    monkeypatch.setattr(module.CCXTAccountClient, "_collect_symbol_metrics", fake_collect)
+
+    async def fake_fetch_realized(exchange_id, client, **kwargs):  # type: ignore[override]
+        assert exchange_id == "bybit"
+        assert kwargs["account_name"] == "Bybit"
+        assert kwargs["since"] == 1_940_000
+        assert kwargs["until"] == 2_000_000
+        return 7.5
+
+    monkeypatch.setattr(module, "fetch_realized_pnl_history", fake_fetch_realized)
+
+    config = AccountConfig(
+        name="Bybit",
+        exchange="bybit",
+        settle_currency="USDT",
+        credentials={},
+        params={
+            "realized_pnl": {
+                "mode": "always",
+                "lookback_ms": 60_000,
+                "since_ms": 1_940_000,
+                "until_ms": 2_000_000,
+            }
+        },
+    )
+
+    client = module.CCXTAccountClient(config)
+    result = asyncio.run(client.fetch())
+
+    assert result["daily_realized_pnl"] == pytest.approx(7.5)
+    assert result["positions"][0]["daily_realized_pnl"] == 0.0


### PR DESCRIPTION
## Summary
- extract the exchange-specific realized PnL aggregation into a dedicated helper module
- wire the realtime CCXT account client to delegate realized PnL lookups to the helper when configured
- expand the account client tests to cover the helper flows and override behaviour

## Testing
- python -m pytest tests/risk_management/test_account_clients.py

------
https://chatgpt.com/codex/tasks/task_b_68ff678b68748323a59d6ac829c981da