### PR TITLE
Fix reduce-only handling when kill switch has explicit position sides

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -1224,16 +1224,13 @@ class CCXTAccountClient(AccountClientProtocol):
                 params["positionIdx"] = position_idx
 
             if side_explicit:
-
-            if position_side in {"LONG", "SHORT"}:
                 params.pop("reduceOnly", None)
                 params.pop("reduceonly", None)
-            elif position_idx in {1, 2}:
-
-                params.pop("reduceOnly", None)
-                params.pop("reduceonly", None)
-            elif "reduceOnly" not in params and "reduceonly" not in params:
-                params["reduceOnly"] = True
+            else:
+                if "reduceonly" in params:
+                    params["reduceOnly"] = params.pop("reduceonly")
+                if "reduceOnly" not in params:
+                    params["reduceOnly"] = True
 
             mark_price = _first_float(
                 position.get("markPrice"),


### PR DESCRIPTION
## Summary
- ensure the kill switch removes reduce-only flags only when the exchange provided an explicit position side
- normalize the reduce-only parameter casing and default when no explicit side is present

## Testing
- pytest *(fails: missing numpy, hjson, ccxt)*

------
https://chatgpt.com/codex/tasks/task_b_68ff8c39c58c8323bdd5cb3d37717b60