### PR TITLE
Refactor risk management helpers into shared utilities

### DIFF
--- a/risk_management/_notifications.py
+++ b/risk_management/_notifications.py
@@ -1,0 +1,145 @@
+"""Notification helpers for realtime risk monitoring."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time, timezone
+from typing import Any, Mapping, Optional, Sequence
+from zoneinfo import ZoneInfo
+
+from .configuration import RealtimeConfig
+from .dashboard import evaluate_alerts, parse_snapshot
+from .email_notifications import EmailAlertSender
+from .telegram_notifications import TelegramNotifier
+
+__all__ = [
+    "NotificationCoordinator",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationCoordinator:
+    """Coordinate email and telegram notifications for realtime snapshots."""
+
+    def __init__(self, config: RealtimeConfig) -> None:
+        self._email_sender = EmailAlertSender(config.email) if config.email else None
+        self._email_recipients = self._extract_email_recipients(config.notification_channels)
+        self._telegram_targets = self._extract_telegram_targets(config.notification_channels)
+        self._telegram_notifier = TelegramNotifier() if self._telegram_targets else None
+        self._active_alerts: set[str] = set()
+        self._daily_snapshot_tz = ZoneInfo("America/New_York")
+        self._daily_snapshot_sent_date: Optional[date] = None
+
+    @staticmethod
+    def _extract_email_recipients(channels: Sequence[Any]) -> list[str]:
+        recipients: list[str] = []
+        for channel in channels:
+            if not isinstance(channel, str):
+                continue
+            if channel.lower().startswith("email:"):
+                address = channel.split(":", 1)[1].strip()
+                if address:
+                    recipients.append(address)
+        return recipients
+
+    @staticmethod
+    def _extract_telegram_targets(channels: Sequence[Any]) -> list[tuple[str, str]]:
+        targets: list[tuple[str, str]] = []
+        for channel in channels:
+            if not isinstance(channel, str):
+                continue
+            if not channel.lower().startswith("telegram:"):
+                continue
+            payload = channel.split(":", 1)[1]
+            token = ""
+            chat_id = ""
+            if "@" in payload:
+                token, _, chat_id = payload.partition("@")
+            elif "/" in payload:
+                token, _, chat_id = payload.partition("/")
+            else:
+                parts = payload.split(":", 1)
+                if len(parts) == 2:
+                    token, chat_id = parts
+            token = token.strip()
+            chat_id = chat_id.strip()
+            if token and chat_id:
+                targets.append((token, chat_id))
+        return targets
+
+    def send_daily_snapshot(self, snapshot: Mapping[str, Any], portfolio_balance: float) -> None:
+        if not self._email_sender or not self._email_recipients:
+            return
+        now_ny = datetime.now(self._daily_snapshot_tz)
+        current_date = now_ny.date()
+        if self._daily_snapshot_sent_date and current_date > self._daily_snapshot_sent_date:
+            self._daily_snapshot_sent_date = None
+        if now_ny.time() < time(16, 0):
+            return
+        if self._daily_snapshot_sent_date == current_date:
+            return
+        accounts = snapshot.get("accounts", [])
+        lines = [
+            f"Daily portfolio snapshot ({now_ny.strftime('%Y-%m-%d')} 16:00 ET)",
+            f"Total balance: ${portfolio_balance:,.2f}",
+            "",
+            "Accounts:",
+        ]
+        for account in accounts or []:
+            if not isinstance(account, Mapping):
+                continue
+            name = str(account.get("name", "unknown"))
+            balance = float(account.get("balance", 0.0))
+            realised = float(account.get("daily_realized_pnl", 0.0))
+            lines.append(
+                f"- {name}: balance ${balance:,.2f}, daily realised PnL ${realised:,.2f}"
+            )
+        body = "\n".join(lines)
+        subject = "Daily portfolio balance snapshot"
+        self._email_sender.send(subject, body, self._email_recipients)
+        self._daily_snapshot_sent_date = current_date
+
+    def dispatch_alerts(self, snapshot: Mapping[str, Any]) -> None:
+        if not (self._email_sender or self._telegram_notifier):
+            return
+        try:
+            _, accounts, thresholds, _ = parse_snapshot(dict(snapshot))
+            alerts = evaluate_alerts(accounts, thresholds)
+        except Exception as exc:  # pragma: no cover - snapshot parsing errors are logged for diagnostics
+            logger.debug("Skipping email alert dispatch due to parsing error: %s", exc, exc_info=True)
+            return
+        alerts_set = set(alerts)
+        new_alerts = [alert for alert in alerts if alert not in self._active_alerts]
+        self._active_alerts = alerts_set
+        if not new_alerts:
+            return
+        generated_at = snapshot.get("generated_at")
+        timestamp = (
+            generated_at
+            if isinstance(generated_at, str)
+            else datetime.now(timezone.utc).isoformat()
+        )
+        lines = [f"Exposure thresholds were exceeded at {timestamp}.", "", "Alerts:"]
+        lines.extend(f"- {alert}" for alert in new_alerts)
+        body = "\n".join(lines)
+        subject = "Risk alert: exposure threshold breached"
+        if self._email_sender and self._email_recipients:
+            self._email_sender.send(subject, body, self._email_recipients)
+        if self._telegram_notifier and self._telegram_targets:
+            message = f"Exposure alert at {timestamp}\n" + "\n".join(new_alerts)
+            for token, chat_id in self._telegram_targets:
+                self._telegram_notifier.send(token, chat_id, message)
+
+    @property
+    def email_sender(self) -> Optional[EmailAlertSender]:
+        return self._email_sender
+
+    @property
+    def email_recipients(self) -> Sequence[str]:
+        return tuple(self._email_recipients)
+
+    @property
+    def telegram_targets(self) -> Sequence[tuple[str, str]]:
+        return tuple(self._telegram_targets)
+

--- a/risk_management/_parsing.py
+++ b/risk_management/_parsing.py
@@ -1,0 +1,264 @@
+"""Helpers for parsing exchange payloads into dashboard-friendly structures."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Optional
+
+from ._utils import first_float
+
+__all__ = ["extract_balance", "parse_position", "parse_order"]
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_balance(balance: Mapping[str, Any], settle_currency: str) -> float:
+    """Extract a numeric balance from ccxt balance payloads."""
+
+    if not isinstance(balance, Mapping):
+        return 0.0
+
+    aggregate_keys = (
+        "totalMarginBalance",
+        "totalEquity",
+        "totalWalletBalance",
+        "marginBalance",
+        "totalBalance",
+    )
+
+    def _find_nested_aggregate(value: Any) -> Optional[float]:
+        if isinstance(value, Mapping):
+            for key in aggregate_keys:
+                candidate = _to_float(value.get(key))
+                if candidate is not None:
+                    return candidate
+            for child in value.values():
+                result = _find_nested_aggregate(child)
+                if result is not None:
+                    return result
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                result = _find_nested_aggregate(child)
+                if result is not None:
+                    return result
+        return None
+
+    for key in (*aggregate_keys, "equity"):
+        candidate = _to_float(balance.get(key))
+        if candidate is not None:
+            return candidate
+
+    info = balance.get("info")
+    if isinstance(info, Mapping):
+        for key in (*aggregate_keys, "equity"):
+            candidate = _to_float(info.get(key))
+            if candidate is not None:
+                return candidate
+        nested = _find_nested_aggregate(info)
+        if nested is not None:
+            return nested
+
+    total = balance.get("total")
+    if isinstance(total, Mapping) and total:
+        if settle_currency in total:
+            candidate = _to_float(total.get(settle_currency))
+            if candidate is not None:
+                return candidate
+        summed = 0.0
+        found_value = False
+        for value in total.values():
+            candidate = _to_float(value)
+            if candidate is None:
+                continue
+            summed += candidate
+            found_value = True
+        if found_value:
+            return summed
+
+    for currency_key in (settle_currency, "USDT"):
+        entry = balance.get(currency_key)
+        if isinstance(entry, Mapping):
+            for key in ("total", "free", "used"):
+                candidate = _to_float(entry.get(key))
+                if candidate is not None:
+                    return candidate
+        else:
+            candidate = _to_float(entry)
+            if candidate is not None:
+                return candidate
+
+    return 0.0
+
+
+def parse_position(position: Mapping[str, Any], balance: float) -> Optional[Dict[str, Any]]:
+    size = first_float(
+        position.get("contracts"),
+        position.get("size"),
+        position.get("amount"),
+        position.get("info", {}).get("positionAmt") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("positionAmt")
+        if isinstance(position.get("info"), Mapping) and position["info"].get("positionAmt") not in (None, "")
+        else None,
+    ) or 0.0
+    entry_price = first_float(
+        position.get("entryPrice"),
+        position.get("entry_price"),
+        position.get("avgPrice"),
+        position.get("info", {}).get("entryPrice") if isinstance(position.get("info"), Mapping) else None,
+    )
+    mark_price = first_float(
+        position.get("markPrice"),
+        position.get("mark_price"),
+        position.get("info", {}).get("markPrice") if isinstance(position.get("info"), Mapping) else None,
+    )
+    liquidation_price = first_float(
+        position.get("liquidationPrice"),
+        position.get("liq_price"),
+        position.get("liquidation_price"),
+        position.get("info", {}).get("liquidationPrice") if isinstance(position.get("info"), Mapping) else None,
+    )
+    side = str(position.get("side") or "").upper()
+    if not side:
+        side = str(position.get("positionSide") or position.get("position_side") or "").upper()
+        if not side:
+            side = "LONG" if size >= 0 else "SHORT"
+    unrealized = first_float(
+        position.get("unrealizedPnl"),
+        position.get("unrealized_pnl"),
+        position.get("info", {}).get("unrealisedPnl") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("unrealizedPnl") if isinstance(position.get("info"), Mapping) else None,
+    ) or 0.0
+    realized = first_float(
+        position.get("realizedPnl"),
+        position.get("realized_pnl"),
+        position.get("info", {}).get("realisedPnl") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("realizedPnl") if isinstance(position.get("info"), Mapping) else None,
+        position.get("daily_realized_pnl"),
+    ) or 0.0
+    mark_price = mark_price or entry_price or 0.0
+    contract_size = first_float(
+        position.get("contractSize"),
+        position.get("info", {}).get("contractSize") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("ctVal") if isinstance(position.get("info"), Mapping) else None,
+    ) or 1.0
+    notional = first_float(
+        position.get("notional"),
+        position.get("notionalValue"),
+        position.get("info", {}).get("notionalValue") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("notionalUsd") if isinstance(position.get("info"), Mapping) else None,
+    )
+    if notional is None:
+        reference_price = mark_price or entry_price or 0.0
+        notional = abs(size) * contract_size * reference_price
+    notional_value = float(notional or 0.0)
+    if size < 0 and notional_value > 0:
+        signed_notional = -abs(notional_value)
+    elif size > 0 and notional_value < 0:
+        signed_notional = abs(notional_value)
+    else:
+        signed_notional = notional_value
+    abs_notional = abs(signed_notional)
+    take_profit = first_float(
+        position.get("takeProfitPrice"),
+        position.get("tpPrice"),
+        position.get("info", {}).get("takeProfitPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("tpTriggerPx") if isinstance(position.get("info"), Mapping) else None,
+    )
+    stop_loss = first_float(
+        position.get("stopLossPrice"),
+        position.get("slPrice"),
+        position.get("info", {}).get("stopLossPrice") if isinstance(position.get("info"), Mapping) else None,
+        position.get("info", {}).get("slTriggerPx") if isinstance(position.get("info"), Mapping) else None,
+    )
+    wallet_exposure = None
+    if balance:
+        wallet_exposure = abs_notional / balance if balance else None
+    return {
+        "symbol": str(position.get("symbol") or position.get("id") or "unknown"),
+        "side": side,
+        "notional": abs_notional,
+        "entry_price": float(entry_price or 0.0),
+        "mark_price": float(mark_price or 0.0),
+        "liquidation_price": float(liquidation_price) if liquidation_price is not None else None,
+        "wallet_exposure_pct": float(wallet_exposure) if wallet_exposure is not None else None,
+        "unrealized_pnl": float(unrealized),
+        "daily_realized_pnl": float(realized),
+        "max_drawdown_pct": None,
+        "take_profit_price": float(take_profit) if take_profit is not None else None,
+        "stop_loss_price": float(stop_loss) if stop_loss is not None else None,
+        "size": float(size),
+        "signed_notional": signed_notional,
+    }
+
+
+def parse_order(order: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    if not isinstance(order, Mapping):
+        return None
+    symbol = order.get("symbol") or order.get("id")
+    if not symbol:
+        return None
+    price = first_float(
+        order.get("price"),
+        order.get("triggerPrice"),
+        order.get("stopPrice"),
+        order.get("info", {}).get("price") if isinstance(order.get("info"), Mapping) else None,
+    )
+    amount = first_float(
+        order.get("amount"),
+        order.get("contracts"),
+        order.get("size"),
+        order.get("info", {}).get("origQty") if isinstance(order.get("info"), Mapping) else None,
+    )
+    if amount is None:
+        return None
+    remaining = first_float(
+        order.get("remaining"),
+        order.get("remainingAmount"),
+        order.get("info", {}).get("leavesQty") if isinstance(order.get("info"), Mapping) else None,
+    )
+    reduce_only_raw = order.get("reduceOnly")
+    if isinstance(order.get("info"), Mapping):
+        reduce_only_raw = reduce_only_raw or order["info"].get("reduceOnly")
+    reduce_only = bool(reduce_only_raw)
+    stop_price = first_float(
+        order.get("stopPrice"),
+        order.get("triggerPrice"),
+        order.get("info", {}).get("stopPrice") if isinstance(order.get("info"), Mapping) else None,
+    )
+    timestamp_raw = order.get("timestamp")
+    created_at = None
+    if isinstance(timestamp_raw, (int, float)):
+        created_at = datetime.fromtimestamp(float(timestamp_raw) / 1000, timezone.utc).isoformat()
+    else:
+        datetime_str = order.get("datetime")
+        if isinstance(datetime_str, str) and datetime_str:
+            created_at = datetime_str
+    notional = price * amount if price is not None else None
+    return {
+        "order_id": str(order.get("id") or order.get("clientOrderId") or ""),
+        "symbol": str(symbol),
+        "side": str(order.get("side") or "").lower(),
+        "type": str(order.get("type") or "").lower(),
+        "price": price,
+        "amount": amount,
+        "remaining": remaining,
+        "status": str(order.get("status") or ""),
+        "reduce_only": reduce_only,
+        "stop_price": stop_price,
+        "notional": notional,
+        "created_at": created_at,
+    }
+

--- a/risk_management/_utils.py
+++ b/risk_management/_utils.py
@@ -1,0 +1,146 @@
+"""Shared helper utilities for risk management modules."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional, Tuple
+
+__all__ = [
+    "json_default",
+    "stringify_payload",
+    "first_float",
+    "coerce_float",
+    "coerce_int",
+    "normalize_position_side",
+    "extract_position_details",
+]
+
+
+def json_default(value: Any) -> Any:
+    """Coerce non-serialisable objects into JSON-compatible types."""
+
+    if isinstance(value, (set, frozenset, tuple)):
+        return list(value)
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def stringify_payload(payload: Any) -> str:
+    """Return a JSON string representation for logging purposes."""
+
+    try:
+        return json.dumps(payload, ensure_ascii=False, default=json_default, sort_keys=True)
+    except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+        return repr(payload)
+
+
+def first_float(*values: Any) -> Optional[float]:
+    """Return the first value that can be coerced into ``float``."""
+
+    for value in values:
+        candidate = value
+        if candidate is None:
+            continue
+        if isinstance(candidate, (list, tuple)) and candidate:
+            candidate = candidate[0]
+        try:
+            return float(candidate)
+        except (TypeError, ValueError):
+            if isinstance(candidate, str):
+                try:
+                    return float(candidate.strip())
+                except (TypeError, ValueError):
+                    continue
+            continue
+    return None
+
+
+def coerce_float(value: Any) -> Optional[float]:
+    """Return ``value`` converted to ``float`` when possible."""
+
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        if isinstance(value, str):
+            try:
+                return float(value.strip())
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def coerce_int(value: Any) -> Optional[int]:
+    """Return ``value`` converted to ``int`` when possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        if isinstance(value, str):
+            try:
+                return int(float(value.strip()))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def normalize_position_side(value: Any) -> Optional[str]:
+    """Return the normalised hedge-mode side when available."""
+
+    if isinstance(value, str):
+        candidate = value.strip().upper()
+        if candidate in {"LONG", "SHORT", "BOTH"}:
+            return candidate
+    return None
+
+
+def extract_position_details(position: Mapping[str, Any]) -> Tuple[Optional[str], Optional[int], bool]:
+    """Return the detected hedge side, index, and whether the side was explicit."""
+
+    position_side = normalize_position_side(position.get("positionSide"))
+    side_explicit = position_side is not None
+    if position_side is None:
+        alt_side = normalize_position_side(position.get("position_side"))
+        if alt_side is not None:
+            position_side = alt_side
+            side_explicit = True
+
+    def _position_idx_from(obj: Any) -> Optional[int]:
+        if not isinstance(obj, Mapping):
+            return None
+        raw_idx = obj.get("positionIdx", obj.get("position_idx"))
+        if raw_idx is None:
+            return None
+        try:
+            value = int(float(raw_idx))
+        except (TypeError, ValueError):
+            return None
+        if value in {0, 1, 2}:
+            return value
+        return None
+
+    position_idx = _position_idx_from(position)
+    info = position.get("info")
+    if position_idx is None and isinstance(info, Mapping):
+        position_idx = _position_idx_from(info)
+
+    if position_side is None and isinstance(info, Mapping):
+        info_side = normalize_position_side(info.get("positionSide") or info.get("position_side"))
+        if info_side is not None:
+            position_side = info_side
+            side_explicit = True
+
+    if position_side is None and position_idx in {1, 2}:
+        position_side = "LONG" if position_idx == 1 else "SHORT"
+
+    return position_side, position_idx, side_explicit
+

--- a/risk_management/realized_pnl.py
+++ b/risk_management/realized_pnl.py
@@ -14,62 +14,13 @@ except Exception:  # pragma: no cover - fallback when ccxt is missing
         pass
 
 
+from ._utils import (
+    coerce_float as _coerce_float,
+    coerce_int as _coerce_int,
+    first_float as _first_float,
+)
+
 logger = logging.getLogger(__name__)
-
-
-def _first_float(*values: Any) -> Optional[float]:
-    """Return the first value that can be coerced into ``float``."""
-
-    for value in values:
-        candidate = value
-        if candidate is None:
-            continue
-        if isinstance(candidate, (list, tuple)) and candidate:
-            candidate = candidate[0]
-        try:
-            return float(candidate)
-        except (TypeError, ValueError):
-            if isinstance(candidate, str):
-                try:
-                    return float(candidate.strip())
-                except (TypeError, ValueError):
-                    continue
-            continue
-    return None
-
-
-def _coerce_float(value: Any) -> Optional[float]:
-    """Return ``value`` converted to ``float`` when possible."""
-
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        if isinstance(value, str):
-            try:
-                return float(value.strip())
-            except (TypeError, ValueError):
-                return None
-    return None
-
-
-def _coerce_int(value: Any) -> Optional[int]:
-    """Return ``value`` converted to ``int`` when possible."""
-
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return int(value)
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        if isinstance(value, str):
-            try:
-                return int(float(value.strip()))
-            except (TypeError, ValueError):
-                return None
-    return None
 
 
 def _dedupe_symbols(symbols: Optional[Sequence[Optional[str]]]) -> Sequence[Optional[str]]:


### PR DESCRIPTION
## Summary
- extract shared serialization and numeric helpers into `risk_management/_utils.py`
- centralize balance, position, and order parsing in `risk_management/_parsing.py` and reuse them across account clients and realtime consumers
- introduce a `NotificationCoordinator` to encapsulate email and telegram dispatch logic in realtime data fetching
- update existing modules to rely on the new helpers while preserving public compatibility

## Testing
- pytest tests/risk_management/test_balance_extraction.py
- pytest *(fails: missing optional dependencies such as numpy, hjson, ccxt)*

------
https://chatgpt.com/codex/tasks/task_b_68ff9af479008323b544f1aee8e0a5ad