### PR TITLE
Fix risk custom endpoint preference handling with load helper

### DIFF
--- a/risk_management/README.md
+++ b/risk_management/README.md
@@ -101,6 +101,10 @@ Update the new file with the following information.
   - `enabled`: set to `false` to temporarily disable an account without
     removing the block.
   - `debug_api_payloads`: enable verbose logging for a single account.
+  - `use_custom_endpoints`: override the global proxy discovery on a per-account
+    basis.  Set to `true` to force custom overrides when available, `false` to
+    bypass them (direct-to-exchange), or omit/`"auto"` to inherit the global
+    setting.
   - `credentials.enableRateLimit`: defaults to `true`.  The loader preserves
     ccxt's built-in throttling so API calls respect exchange rate limits unless
     you explicitly opt out.
@@ -149,6 +153,11 @@ the flag raises verbosity to the familiar trading/backtesting format so payloads
 respect `TRACE`/`DEBUG` levels and include timestamps.  Use this sparingly;
 responses include large payloads and secret values are not redacted
 automatically.
+
+Authentication failures and other ccxt exceptions are rewritten into
+human-friendly messages.  When a proxy override is active the warning explicitly
+references the custom endpoint so you can immediately spot mismatched routing
+or stale API credentials.
 
 returned by ccxt.  When enabled the loader now initialises the same logging
 format used by Passivbot's trading and backtesting commands so payloads respect

--- a/src/utils.py
+++ b/src/utils.py
@@ -268,7 +268,12 @@ def normalize_exchange_name(exchange: str) -> str:
     return ex
 
 
-def load_ccxt_instance(exchange_id: str, enable_rate_limit: bool = True):
+def load_ccxt_instance(
+    exchange_id: str,
+    enable_rate_limit: bool = True,
+    *,
+    apply_custom_endpoints: bool = True,
+):
     """
     Return a ccxt async-support exchange instance for the given exchange id.
 
@@ -283,11 +288,12 @@ def load_ccxt_instance(exchange_id: str, enable_rate_limit: bool = True):
         cc.options["defaultType"] = "swap"
     except Exception:
         pass
-    try:
-        override = resolve_custom_endpoint_override(ex)
-        apply_rest_overrides_to_ccxt(cc, override)
-    except Exception as exc:
-        logging.warning("Failed to apply custom endpoint override for %s: %s", ex, exc)
+    if apply_custom_endpoints:
+        try:
+            override = resolve_custom_endpoint_override(ex)
+            apply_rest_overrides_to_ccxt(cc, override)
+        except Exception as exc:
+            logging.warning("Failed to apply custom endpoint override for %s: %s", ex, exc)
     return cc
 
 


### PR DESCRIPTION
## Summary
- add an opt-out flag to `load_ccxt_instance` so callers can skip automatic custom endpoint rewrites
- ensure the risk-management ccxt account client suppresses the helper's rewrites and applies per-account preferences itself
- add regression coverage proving that disabling custom endpoints keeps requests on the direct exchange host

## Testing
- pytest tests/risk_management -q

------
https://chatgpt.com/codex/tasks/task_b_6900d0d11b6c8323b15b29c701a53291