### PR TITLE
Add account stop loss controls and performance tracking

### DIFF
--- a/risk_management/performance.py
+++ b/risk_management/performance.py
@@ -1,0 +1,253 @@
+"""Helpers for tracking daily balance snapshots and performance summaries."""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+
+from zoneinfo import ZoneInfo
+
+
+@dataclass
+class PerformanceSnapshot:
+    """Description of the latest balance snapshot for an entity."""
+
+    date: str
+    balance: float
+    timestamp: Optional[str]
+
+    def to_dict(self) -> dict[str, Optional[float | str]]:
+        return {"date": self.date, "balance": float(self.balance), "timestamp": self.timestamp}
+
+
+class PerformanceTracker:
+    """Persist daily balance snapshots and derive performance statistics."""
+
+    def __init__(
+        self,
+        base_directory: Path,
+        *,
+        target_hour: int = 16,
+        timezone_name: str = "America/New_York",
+    ) -> None:
+        self.base_directory = Path(base_directory)
+        self.base_directory.mkdir(parents=True, exist_ok=True)
+        self._data_path = self.base_directory / "daily_balances.json"
+        self._lock = threading.Lock()
+        self._target_time = time(hour=max(0, min(23, int(target_hour))), minute=0)
+        self._tz = ZoneInfo(timezone_name)
+
+    # ------------------------------------------------------------------
+    # public API
+
+    def record(
+        self,
+        *,
+        generated_at: Optional[datetime],
+        portfolio_balance: float,
+        account_balances: Mapping[str, float],
+    ) -> Dict[str, Mapping[str, object]]:
+        """Persist daily balances when the 4pm ET window has been reached."""
+
+        timestamp = self._normalise_timestamp(generated_at)
+        with self._lock:
+            data = self._load()
+            changed = False
+
+            if self._should_record(timestamp):
+                record_date = self._to_local(timestamp).date()
+                changed |= self._record_portfolio(data, record_date, portfolio_balance, timestamp)
+                for name, balance in account_balances.items():
+                    changed |= self._record_account(data, str(name), record_date, balance, timestamp)
+                if changed:
+                    data["updated_at"] = timestamp.isoformat()
+                    self._save(data)
+
+            summary = self._build_summary(data, portfolio_balance, account_balances)
+
+        return summary
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _normalise_timestamp(self, value: Optional[datetime]) -> datetime:
+        if value is None:
+            value = datetime.now(timezone.utc)
+        elif value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    def _to_local(self, timestamp: datetime) -> datetime:
+        return timestamp.astimezone(self._tz)
+
+    def _should_record(self, timestamp: datetime) -> bool:
+        local = self._to_local(timestamp)
+        local_time = local.timetz()
+        return local_time >= self._target_time.replace(tzinfo=self._tz)
+
+    def _load(self) -> Dict[str, object]:
+        if not self._data_path.exists():
+            return {"portfolio": [], "accounts": {}}
+        try:
+            payload = json.loads(self._data_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {"portfolio": [], "accounts": {}}
+        portfolio = payload.get("portfolio")
+        accounts = payload.get("accounts")
+        if not isinstance(portfolio, list):
+            portfolio = []
+        if not isinstance(accounts, MutableMapping):
+            accounts = {}
+        normalised_accounts: Dict[str, list[dict[str, object]]] = {}
+        for name, history in accounts.items():
+            if isinstance(history, list):
+                normalised_accounts[str(name)] = [
+                    entry
+                    for entry in history
+                    if isinstance(entry, Mapping) and "date" in entry and "balance" in entry
+                ]
+        return {
+            "portfolio": [
+                entry
+                for entry in portfolio
+                if isinstance(entry, Mapping) and "date" in entry and "balance" in entry
+            ],
+            "accounts": normalised_accounts,
+        }
+
+    def _save(self, data: Mapping[str, object]) -> None:
+        try:
+            self._data_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        except OSError:
+            # I/O errors should not prevent the realtime loop from continuing.
+            pass
+
+    def _record_portfolio(
+        self,
+        data: MutableMapping[str, object],
+        record_date: date,
+        balance: float,
+        timestamp: datetime,
+    ) -> bool:
+        history: list[dict[str, object]] = data.setdefault("portfolio", [])  # type: ignore[assignment]
+        return self._upsert_history_entry(history, record_date, balance, timestamp)
+
+    def _record_account(
+        self,
+        data: MutableMapping[str, object],
+        account_name: str,
+        record_date: date,
+        balance: float,
+        timestamp: datetime,
+    ) -> bool:
+        accounts: MutableMapping[str, list[dict[str, object]]] = data.setdefault("accounts", {})  # type: ignore[assignment]
+        history = accounts.setdefault(account_name, [])
+        return self._upsert_history_entry(history, record_date, balance, timestamp)
+
+    @staticmethod
+    def _upsert_history_entry(
+        history: list[dict[str, object]],
+        record_date: date,
+        balance: float,
+        timestamp: datetime,
+    ) -> bool:
+        date_str = record_date.isoformat()
+        iso_timestamp = timestamp.isoformat()
+        for entry in history:
+            if str(entry.get("date")) == date_str:
+                entry["balance"] = float(balance)
+                entry["timestamp"] = iso_timestamp
+                return True
+        history.append({"date": date_str, "balance": float(balance), "timestamp": iso_timestamp})
+        history.sort(key=lambda item: item.get("date", ""))
+        return True
+
+    def _build_summary(
+        self,
+        data: Mapping[str, object],
+        portfolio_balance: float,
+        account_balances: Mapping[str, float],
+    ) -> Dict[str, Mapping[str, object]]:
+        portfolio_history = data.get("portfolio")
+        summary = {
+            "portfolio": self._summarise_history(
+                portfolio_history if isinstance(portfolio_history, list) else [],
+                portfolio_balance,
+            ),
+            "accounts": {},
+        }
+        accounts_history = data.get("accounts")
+        if isinstance(accounts_history, Mapping):
+            for name, balance in account_balances.items():
+                history = accounts_history.get(str(name))
+                if not isinstance(history, Iterable):
+                    history_list: list[dict[str, object]] = []
+                else:
+                    history_list = [
+                        entry
+                        for entry in history
+                        if isinstance(entry, Mapping) and "date" in entry and "balance" in entry
+                    ]
+                summary["accounts"][str(name)] = self._summarise_history(history_list, balance)
+        return summary
+
+    def _summarise_history(
+        self, history: Iterable[Mapping[str, object]], current_balance: float
+    ) -> Dict[str, object]:
+        entries = [
+            {
+                "date": str(entry["date"]),
+                "balance": float(entry.get("balance", 0.0)),
+                "timestamp": entry.get("timestamp"),
+            }
+            for entry in history
+        ]
+        entries.sort(key=lambda item: item["date"])
+        summary: Dict[str, object] = {
+            "current_balance": float(current_balance),
+            "latest_snapshot": None,
+            "daily": None,
+            "weekly": None,
+            "monthly": None,
+        }
+        if not entries:
+            return summary
+
+        latest_entry = entries[-1]
+        latest_date = date.fromisoformat(latest_entry["date"])
+        summary["latest_snapshot"] = PerformanceSnapshot(
+            date=latest_entry["date"],
+            balance=float(latest_entry["balance"]),
+            timestamp=latest_entry.get("timestamp"),
+        ).to_dict()
+
+        for label, days in ("daily", 1), ("weekly", 7), ("monthly", 30):
+            reference = self._find_reference(entries, latest_date, days)
+            if reference is None:
+                continue
+            reference_balance = float(reference["balance"])
+            summary[label] = {
+                "pnl": float(current_balance) - reference_balance,
+                "since": reference["date"],
+                "reference_balance": reference_balance,
+            }
+
+        return summary
+
+    @staticmethod
+    def _find_reference(
+        entries: Iterable[Mapping[str, object]], anchor_date: date, days: int
+    ) -> Optional[Mapping[str, object]]:
+        target = anchor_date - timedelta(days=days)
+        candidate: Optional[Mapping[str, object]] = None
+        for entry in entries:
+            entry_date = date.fromisoformat(str(entry["date"]))
+            if entry_date <= target:
+                if candidate is None or entry_date > date.fromisoformat(str(candidate["date"])):
+                    candidate = entry
+        return candidate
+

--- a/risk_management/reporting.py
+++ b/risk_management/reporting.py
@@ -195,6 +195,17 @@ class ReportManager:
         balance_share = (
             balance / portfolio_balance if portfolio_balance else None
         )
+        performance = account.get("performance") if isinstance(account, Mapping) else None
+        daily_pnl = None
+        weekly_pnl = None
+        monthly_pnl = None
+        if isinstance(performance, Mapping):
+            daily_value = performance.get("daily")
+            weekly_value = performance.get("weekly")
+            monthly_value = performance.get("monthly")
+            daily_pnl = float(daily_value) if isinstance(daily_value, (int, float)) else None
+            weekly_pnl = float(weekly_value) if isinstance(weekly_value, (int, float)) else None
+            monthly_pnl = float(monthly_value) if isinstance(monthly_value, (int, float)) else None
         rows = [
             [
                 "Account",
@@ -208,6 +219,9 @@ class ReportManager:
                 "Orders",
                 "Alerts",
                 "Portfolio Share",
+                "Daily PnL",
+                "Weekly PnL",
+                "Monthly PnL",
             ],
             [
                 account_name,
@@ -221,6 +235,9 @@ class ReportManager:
                 str(orders_count),
                 alerts_summary,
                 self._format_pct(balance_share) if balance_share is not None else "-",
+                self._format_currency(daily_pnl) if daily_pnl is not None else "-",
+                self._format_currency(weekly_pnl) if weekly_pnl is not None else "-",
+                self._format_currency(monthly_pnl) if monthly_pnl is not None else "-",
             ],
             [],
         ]

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -180,6 +180,35 @@
             <span class="subvalue {% if snapshot.portfolio.net_exposure_pct >= 0 %}gain{% else %}loss{% endif %}">{{ snapshot.portfolio.net_exposure_pct|pct }}</span>
           </div>
         </div>
+        {% set portfolio_performance = snapshot.portfolio.performance if snapshot.portfolio.performance is defined else None %}
+        {% if portfolio_performance %}
+          <div class="metrics" style="margin-top: 1.5rem;">
+            {% set daily = portfolio_performance.daily %}
+            {% set daily_class = 'gain' if daily is not none and daily >= 0 else ('loss' if daily is not none else '') %}
+            <div class="metric">
+              <span class="label">Daily PnL (4pm)</span>
+              <span class="value {{ daily_class }}">{% if daily is not none %}{{ daily|currency }}{% else %}-{% endif %}</span>
+              {% set daily_since = portfolio_performance.since.daily if portfolio_performance.since is defined and portfolio_performance.since %}
+              <span class="subvalue">{% if daily_since %}Since {{ daily_since }}{% else %}&nbsp;{% endif %}</span>
+            </div>
+            {% set weekly = portfolio_performance.weekly %}
+            {% set weekly_class = 'gain' if weekly is not none and weekly >= 0 else ('loss' if weekly is not none else '') %}
+            <div class="metric">
+              <span class="label">Weekly PnL</span>
+              <span class="value {{ weekly_class }}">{% if weekly is not none %}{{ weekly|currency }}{% else %}-{% endif %}</span>
+              {% set weekly_since = portfolio_performance.since.weekly if portfolio_performance.since is defined and portfolio_performance.since %}
+              <span class="subvalue">{% if weekly_since %}Since {{ weekly_since }}{% else %}&nbsp;{% endif %}</span>
+            </div>
+            {% set monthly = portfolio_performance.monthly %}
+            {% set monthly_class = 'gain' if monthly is not none and monthly >= 0 else ('loss' if monthly is not none else '') %}
+            <div class="metric">
+              <span class="label">Monthly PnL</span>
+              <span class="value {{ monthly_class }}">{% if monthly is not none %}{{ monthly|currency }}{% else %}-{% endif %}</span>
+              {% set monthly_since = portfolio_performance.since.monthly if portfolio_performance.since is defined and portfolio_performance.since %}
+              <span class="subvalue">{% if monthly_since %}Since {{ monthly_since }}{% else %}&nbsp;{% endif %}</span>
+            </div>
+          </div>
+        {% endif %}
         {% set portfolio_vol = snapshot.portfolio.volatility if snapshot.portfolio.volatility is defined else {} %}
         {% set portfolio_funding = snapshot.portfolio.funding_rates if snapshot.portfolio.funding_rates is defined else {} %}
         {% if portfolio_vol or portfolio_funding %}
@@ -299,6 +328,51 @@
                 <span class="value {% if account.unrealized_pnl >= 0 %}gain{% else %}loss{% endif %}">{{ account.unrealized_pnl|currency }}</span>
               </div>
             </div>
+            {% set account_performance = account.performance if account.performance is defined else None %}
+            {% if account_performance %}
+              <div class="metrics" style="margin-top: 1.5rem;">
+                {% set daily = account_performance.daily %}
+                {% set daily_class = 'gain' if daily is not none and daily >= 0 else ('loss' if daily is not none else '') %}
+                <div class="metric">
+                  <span class="label">Daily PnL (4pm)</span>
+                  <span class="value {{ daily_class }}">{% if daily is not none %}{{ daily|currency }}{% else %}-{% endif %}</span>
+                  {% set daily_since = account_performance.since.daily if account_performance.since is defined and account_performance.since %}
+                  <span class="subvalue">{% if daily_since %}Since {{ daily_since }}{% else %}&nbsp;{% endif %}</span>
+                </div>
+                {% set weekly = account_performance.weekly %}
+                {% set weekly_class = 'gain' if weekly is not none and weekly >= 0 else ('loss' if weekly is not none else '') %}
+                <div class="metric">
+                  <span class="label">Weekly PnL</span>
+                  <span class="value {{ weekly_class }}">{% if weekly is not none %}{{ weekly|currency }}{% else %}-{% endif %}</span>
+                  {% set weekly_since = account_performance.since.weekly if account_performance.since is defined and account_performance.since %}
+                  <span class="subvalue">{% if weekly_since %}Since {{ weekly_since }}{% else %}&nbsp;{% endif %}</span>
+                </div>
+                {% set monthly = account_performance.monthly %}
+                {% set monthly_class = 'gain' if monthly is not none and monthly >= 0 else ('loss' if monthly is not none else '') %}
+                <div class="metric">
+                  <span class="label">Monthly PnL</span>
+                  <span class="value {{ monthly_class }}">{% if monthly is not none %}{{ monthly|currency }}{% else %}-{% endif %}</span>
+                  {% set monthly_since = account_performance.since.monthly if account_performance.since is defined and account_performance.since %}
+                  <span class="subvalue">{% if monthly_since %}Since {{ monthly_since }}{% else %}&nbsp;{% endif %}</span>
+                </div>
+              </div>
+            {% endif %}
+            {% if account.stop_loss %}
+              {% set sl = account.stop_loss %}
+              <div class="status" style="margin-top: 1rem;">
+                Stop loss {% if sl.triggered %}<strong>triggered</strong>{% else %}active{% endif %} at
+                {% if sl.threshold_pct is not none %}{{ sl.threshold_pct|round(2) }}%{% else %}?%{% endif %}.
+                {% if sl.current_drawdown_pct is not none %}
+                  Current drawdown {{ (sl.current_drawdown_pct * 100)|round(2) }}%.
+                {% endif %}
+                {% if sl.baseline_balance is not none %}
+                  Baseline {{ sl.baseline_balance|currency }}.
+                {% endif %}
+                {% if sl.triggered_at %}
+                  Triggered at {{ sl.triggered_at }}.
+                {% endif %}
+              </div>
+            {% endif %}
             {% set account_vol = account.volatility if account.volatility is defined else {} %}
             {% set account_funding = account.funding_rates if account.funding_rates is defined else {} %}
             {% if account_vol or account_funding %}

--- a/risk_management/templates/trading_panel.html
+++ b/risk_management/templates/trading_panel.html
@@ -165,12 +165,38 @@
         </div>
       </form>
     </section>
+
+    <section class="card" id="account-stop-loss-card">
+      <h3 style="margin-top: 0;">Account stop loss</h3>
+      <p style="color: var(--muted);" id="account-stop-loss-summary"></p>
+      <form id="account-stop-loss-form" style="display: flex; flex-direction: column; gap: 1rem;">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="account-stop-loss-threshold">Drawdown threshold (%)</label>
+            <input
+              id="account-stop-loss-threshold"
+              name="threshold"
+              type="number"
+              step="0.1"
+              min="0"
+              required
+            />
+          </div>
+        </div>
+        <div style="display: flex; gap: 1rem; align-items: center;">
+          <button type="submit" class="button">Set threshold</button>
+          <button type="button" class="button secondary" id="account-stop-loss-clear">Clear</button>
+          <div class="status-message" id="account-stop-loss-status" hidden></div>
+        </div>
+      </form>
+    </section>
   </section>
 
   <section class="card" style="margin-top: 1.5rem;" id="positions-card">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
+    <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
       <h3 style="margin: 0;">Positions</h3>
       <span id="positions-summary" style="color: var(--muted);"></span>
+      <button type="button" class="button secondary small" id="close-all-positions">Close all positions</button>
     </div>
     <div class="table-wrapper">
       <table id="positions-table">
@@ -185,6 +211,9 @@
             <th>Entry</th>
             <th>Mark</th>
             <th>Liq.</th>
+            <th>Max DD</th>
+            <th>TP</th>
+            <th>SL</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -194,9 +223,10 @@
   </section>
 
   <section class="card" style="margin-top: 1.5rem;" id="orders-card">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
+    <div style="display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
       <h3 style="margin: 0;">Open orders</h3>
       <span id="orders-summary" style="color: var(--muted);"></span>
+      <button type="button" class="button secondary small" id="cancel-all-orders">Cancel all orders</button>
     </div>
     <div class="table-wrapper">
       <table id="orders-table">
@@ -237,7 +267,13 @@
     const ordersSummary = document.getElementById("orders-summary");
     const stopLossSummary = document.getElementById("stop-loss-summary");
     const stopLossStatus = document.getElementById("stop-loss-status");
+    const accountStopLossSummary = document.getElementById("account-stop-loss-summary");
+    const accountStopLossStatus = document.getElementById("account-stop-loss-status");
+    const accountStopLossThreshold = document.getElementById("account-stop-loss-threshold");
+    const accountStopLossClear = document.getElementById("account-stop-loss-clear");
     const refreshButton = document.getElementById("refresh-button");
+    const cancelAllOrdersButton = document.getElementById("cancel-all-orders");
+    const closeAllPositionsButton = document.getElementById("close-all-positions");
 
     const formatCurrency = (value) => {
       const number = Number(value);
@@ -315,6 +351,9 @@
               <td>${formatCurrency(position.entry_price)}</td>
               <td>${formatCurrency(position.mark_price)}</td>
               <td>${position.liquidation_price !== null && position.liquidation_price !== undefined ? formatCurrency(position.liquidation_price) : "-"}</td>
+              <td>${position.max_drawdown_pct !== null && position.max_drawdown_pct !== undefined ? formatPct(position.max_drawdown_pct) : "-"}</td>
+              <td>${position.take_profit_price !== null && position.take_profit_price !== undefined ? formatCurrency(position.take_profit_price) : "-"}</td>
+              <td>${position.stop_loss_price !== null && position.stop_loss_price !== undefined ? formatCurrency(position.stop_loss_price) : "-"}</td>
               <td>
                 <div class="actions-column">
                   <button type="button" class="button danger small" data-close-position data-symbol="${position.symbol}">Close</button>
@@ -325,7 +364,7 @@
         })
         .join("");
       if (positions.length === 0) {
-        positionsTableBody.innerHTML = '<tr><td colspan="10" style="text-align: center; color: var(--muted);">No open positions.</td></tr>';
+        positionsTableBody.innerHTML = '<tr><td colspan="13" style="text-align: center; color: var(--muted);">No open positions.</td></tr>';
       }
     };
 
@@ -383,12 +422,46 @@
       }
     };
 
+    const renderAccountStopLoss = () => {
+      if (!accountStopLossSummary) {
+        return;
+      }
+      const accounts = Array.isArray(state.snapshot.accounts) ? state.snapshot.accounts : [];
+      const account = accounts.find((item) => item.name === state.currentAccount);
+      if (!account) {
+        accountStopLossSummary.textContent = "No account selected.";
+        if (accountStopLossThreshold) {
+          accountStopLossThreshold.value = "";
+        }
+        return;
+      }
+      const stopLoss = account.stop_loss || (state.snapshot.account_stop_losses && state.snapshot.account_stop_losses[account.name]);
+      if (!stopLoss) {
+        accountStopLossSummary.textContent = `No active stop loss for ${account.name}.`;
+        if (accountStopLossThreshold) {
+          accountStopLossThreshold.value = "";
+        }
+        return;
+      }
+      const threshold = Number(stopLoss.threshold_pct ?? 0);
+      const baseline = stopLoss.baseline_balance !== undefined && stopLoss.baseline_balance !== null ? formatCurrency(stopLoss.baseline_balance) : "-";
+      const currentBalance = stopLoss.current_balance !== undefined && stopLoss.current_balance !== null ? formatCurrency(stopLoss.current_balance) : formatCurrency(account.balance);
+      const drawdown = Number(stopLoss.current_drawdown_pct ?? NaN);
+      const drawdownStr = Number.isFinite(drawdown) ? `${(drawdown * 100).toFixed(2)}%` : "-";
+      const status = stopLoss.triggered ? "Triggered" : "Active";
+      accountStopLossSummary.textContent = `${account.name}: ${status}. Threshold ${threshold.toFixed(2)}%. Baseline ${baseline}, current ${currentBalance}, drawdown ${drawdownStr}.`;
+      if (!stopLoss.triggered && threshold > 0 && accountStopLossThreshold) {
+        accountStopLossThreshold.value = threshold;
+      }
+    };
+
     const renderAll = () => {
       renderAccountOptions();
       renderOrderTypes();
       renderPositions();
       renderOrders();
       renderStopLoss();
+      renderAccountStopLoss();
     };
 
     const parseParams = (raw) => {
@@ -447,6 +520,7 @@
       renderPositions();
       renderOrders();
       await fetchOrderTypes(state.currentAccount);
+      renderAccountStopLoss();
     };
 
     if (accountSelect) {
@@ -539,6 +613,66 @@
       }
     });
 
+    document.getElementById("account-stop-loss-form").addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!state.currentAccount) {
+        showStatus(accountStopLossStatus, "Select an account first.", "error");
+        return;
+      }
+      const threshold = Number(accountStopLossThreshold.value);
+      if (!Number.isFinite(threshold) || threshold <= 0) {
+        showStatus(accountStopLossStatus, "Threshold must be greater than zero.", "error");
+        return;
+      }
+      showStatus(accountStopLossStatus, "Updating stop loss...");
+      try {
+        const response = await fetch(
+          `/api/trading/accounts/${encodeURIComponent(state.currentAccount)}/stop-loss`,
+          {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ threshold_pct: threshold }),
+          }
+        );
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => ({}));
+          throw new Error(errorPayload.detail || `Update failed (${response.status})`);
+        }
+        showStatus(accountStopLossStatus, "Stop loss updated.", "success");
+        await refreshSnapshot();
+      } catch (error) {
+        console.error(error);
+        showStatus(accountStopLossStatus, error.message, "error");
+      }
+    });
+
+    accountStopLossClear.addEventListener("click", async () => {
+      if (!state.currentAccount) {
+        showStatus(accountStopLossStatus, "Select an account first.", "error");
+        return;
+      }
+      showStatus(accountStopLossStatus, "Clearing stop loss...");
+      try {
+        const response = await fetch(
+          `/api/trading/accounts/${encodeURIComponent(state.currentAccount)}/stop-loss`,
+          {
+            method: "DELETE",
+            credentials: "include",
+          }
+        );
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => ({}));
+          throw new Error(errorPayload.detail || `Unable to clear (${response.status})`);
+        }
+        showStatus(accountStopLossStatus, "Stop loss cleared.", "success");
+        await refreshSnapshot();
+      } catch (error) {
+        console.error(error);
+        showStatus(accountStopLossStatus, error.message, "error");
+      }
+    });
+
     document.addEventListener("click", async (event) => {
       const cancelButton = event.target.closest("[data-cancel-order]");
       if (cancelButton) {
@@ -597,6 +731,66 @@
       await refreshSnapshot();
       showStatus(orderStatus, "Snapshot updated.", "success");
     });
+
+    if (cancelAllOrdersButton) {
+      cancelAllOrdersButton.addEventListener("click", async () => {
+        if (!state.currentAccount) {
+          showStatus(orderStatus, "Select an account first.", "error");
+          return;
+        }
+        showStatus(orderStatus, "Cancelling all orders...");
+        try {
+          const response = await fetch(
+            `/api/trading/accounts/${encodeURIComponent(state.currentAccount)}/orders/cancel-all`,
+            {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({}),
+            }
+          );
+          if (!response.ok) {
+            const errorPayload = await response.json().catch(() => ({}));
+            throw new Error(errorPayload.detail || `Cancel failed (${response.status})`);
+          }
+          showStatus(orderStatus, "All orders cancelled.", "success");
+          await refreshSnapshot();
+        } catch (error) {
+          console.error(error);
+          showStatus(orderStatus, error.message, "error");
+        }
+      });
+    }
+
+    if (closeAllPositionsButton) {
+      closeAllPositionsButton.addEventListener("click", async () => {
+        if (!state.currentAccount) {
+          showStatus(orderStatus, "Select an account first.", "error");
+          return;
+        }
+        showStatus(orderStatus, "Closing all positions...");
+        try {
+          const response = await fetch(
+            `/api/trading/accounts/${encodeURIComponent(state.currentAccount)}/positions/close-all`,
+            {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({}),
+            }
+          );
+          if (!response.ok) {
+            const errorPayload = await response.json().catch(() => ({}));
+            throw new Error(errorPayload.detail || `Close failed (${response.status})`);
+          }
+          showStatus(orderStatus, "Close requests submitted.", "success");
+          await refreshSnapshot();
+        } catch (error) {
+          console.error(error);
+          showStatus(orderStatus, error.message, "error");
+        }
+      });
+    }
 
     renderAll();
     fetchOrderTypes(state.currentAccount);

--- a/tests/risk_management/test_performance.py
+++ b/tests/risk_management/test_performance.py
@@ -1,0 +1,53 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from risk_management.performance import PerformanceTracker
+
+
+def test_performance_tracker_records_daily_snapshots(tmp_path: Path) -> None:
+    tracker = PerformanceTracker(tmp_path)
+
+    first_day = datetime(2024, 3, 1, 21, 0, tzinfo=timezone.utc)
+    summary = tracker.record(
+        generated_at=first_day,
+        portfolio_balance=10_000.0,
+        account_balances={"Demo": 10_000.0},
+    )
+    assert summary["portfolio"]["latest_snapshot"]["balance"] == 10_000.0
+    assert summary["accounts"]["Demo"]["latest_snapshot"]["balance"] == 10_000.0
+
+    # A call before the next recording window should not add a new snapshot
+    midday = datetime(2024, 3, 2, 15, 0, tzinfo=timezone.utc)
+    summary_mid = tracker.record(
+        generated_at=midday,
+        portfolio_balance=10_500.0,
+        account_balances={"Demo": 10_500.0},
+    )
+    assert summary_mid["portfolio"]["daily"] is None
+
+    second_day = datetime(2024, 3, 2, 21, 5, tzinfo=timezone.utc)
+    summary_second = tracker.record(
+        generated_at=second_day,
+        portfolio_balance=11_200.0,
+        account_balances={"Demo": 11_200.0},
+    )
+    daily_change = summary_second["accounts"]["Demo"]["daily"]
+    assert daily_change is not None
+    assert pytest.approx(daily_change["pnl"]) == 1_200.0
+    assert daily_change["since"] == "2024-03-01"
+
+
+def test_performance_tracker_handles_missing_history(tmp_path: Path) -> None:
+    tracker = PerformanceTracker(tmp_path)
+    summary = tracker.record(
+        generated_at=datetime(2024, 3, 3, 21, 0, tzinfo=timezone.utc),
+        portfolio_balance=5_000.0,
+        account_balances={"Demo": 5_000.0},
+    )
+    assert summary["portfolio"]["daily"] is None
+    assert summary["accounts"]["Demo"]["weekly"] is None

--- a/tests/risk_management/test_snapshot_utils.py
+++ b/tests/risk_management/test_snapshot_utils.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from risk_management.snapshot_utils import build_presentable_snapshot
+
+
+def test_snapshot_utils_preserves_position_fields() -> None:
+    snapshot = {
+        "generated_at": "2024-03-02T00:00:00+00:00",
+        "accounts": [
+            {
+                "name": "Demo",
+                "balance": 1_000,
+                "positions": [
+                    {
+                        "symbol": "BTC/USDT",
+                        "side": "long",
+                        "notional": 500,
+                        "entry_price": 100,
+                        "mark_price": 110,
+                        "liquidation_price": 80,
+                        "wallet_exposure_pct": 0.5,
+                        "unrealized_pnl": 50,
+                        "daily_realized_pnl": 10,
+                        "max_drawdown_pct": 0.2,
+                        "take_profit_price": 120,
+                        "stop_loss_price": 90,
+                    }
+                ],
+                "daily_realized_pnl": 10,
+                "open_orders": [],
+            }
+        ],
+        "alert_thresholds": {},
+        "notification_channels": [],
+        "account_stop_losses": {
+            "Demo": {
+                "threshold_pct": 5.0,
+                "baseline_balance": 1_000.0,
+                "current_balance": 950.0,
+                "current_drawdown_pct": 0.05,
+                "triggered": False,
+                "active": True,
+                "triggered_at": None,
+            }
+        },
+        "performance": {
+            "portfolio": {
+                "current_balance": 1_000.0,
+                "latest_snapshot": {
+                    "date": "2024-03-01",
+                    "balance": 980.0,
+                    "timestamp": "2024-03-01T21:00:00+00:00",
+                },
+                "daily": {
+                    "pnl": 20.0,
+                    "since": "2024-03-01",
+                    "reference_balance": 960.0,
+                },
+            },
+            "accounts": {
+                "Demo": {
+                    "current_balance": 1_000.0,
+                    "latest_snapshot": {
+                        "date": "2024-03-01",
+                        "balance": 985.0,
+                        "timestamp": "2024-03-01T21:00:00+00:00",
+                    },
+                    "daily": {
+                        "pnl": 15.0,
+                        "since": "2024-03-01",
+                        "reference_balance": 985.0,
+                    },
+                }
+            },
+        },
+    }
+
+    view = build_presentable_snapshot(snapshot)
+
+    assert view["accounts"][0]["positions"][0]["daily_realized_pnl"] == 10
+    assert view["accounts"][0]["positions"][0]["liquidation_price"] == 80
+    assert view["accounts"][0]["positions"][0]["take_profit_price"] == 120
+    assert view["accounts"][0]["positions"][0]["stop_loss_price"] == 90
+    assert view["accounts"][0]["positions"][0]["max_drawdown_pct"] == 0.2
+
+    stop_loss = view["accounts"][0]["stop_loss"]
+    assert stop_loss["threshold_pct"] == 5.0
+    assert stop_loss["current_balance"] == 950.0
+
+    performance = view["accounts"][0]["performance"]
+    assert performance["daily"] == 15.0
+    assert performance["since"]["daily"] == "2024-03-01"
+
+    portfolio_perf = view["portfolio"]["performance"]
+    assert portfolio_perf["daily"] == 20.0
+    assert portfolio_perf["latest_snapshot"]["balance"] == 980.0
+
+    assert view["account_stop_losses"]["Demo"]["current_balance"] == 950.0

--- a/tests/test_risk_management_realtime.py
+++ b/tests/test_risk_management_realtime.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
 
 import pytest
 
@@ -18,12 +19,49 @@ class StubAccountClient:
         self.balance = balance
         self.positions = positions
         self.closed = False
+        self.config = type("Config", (), {"name": name})()
 
     async def fetch(self) -> dict:
         return {"name": self.name, "balance": self.balance, "positions": list(self.positions)}
 
     async def close(self) -> None:
         self.closed = True
+
+    async def kill_switch(self, symbol: Optional[str] = None) -> dict:
+        return {
+            "cancelled_orders": [],
+            "failed_order_cancellations": [],
+            "closed_positions": [],
+            "failed_position_closures": [],
+        }
+
+    async def create_order(
+        self,
+        symbol: str,
+        order_type: str,
+        side: str,
+        amount: float,
+        price: Optional[float] = None,
+        params: Optional[dict] = None,
+    ) -> Mapping[str, Any]:
+        return {"order": {"symbol": symbol, "type": order_type, "side": side}, "raw": {}}
+
+    async def cancel_order(
+        self, order_id: str, symbol: Optional[str] = None, params: Optional[Mapping[str, Any]] = None
+    ) -> Mapping[str, Any]:
+        return {"cancelled": True}
+
+    async def close_position(self, symbol: str) -> Mapping[str, Any]:
+        return {"closed_positions": [{"symbol": symbol}]}
+
+    async def list_order_types(self) -> Sequence[str]:
+        return ["limit", "market"]
+
+    async def cancel_all_orders(self, symbol: Optional[str] = None) -> Mapping[str, Any]:
+        return {"cancelled_orders": [], "failed_order_cancellations": []}
+
+    async def close_all_positions(self, symbol: Optional[str] = None) -> Mapping[str, Any]:
+        return {"closed_positions": [], "failed_position_closures": []}
 
 
 class FailingAccountClient:
@@ -102,5 +140,43 @@ def test_realtime_fetcher_reports_errors() -> None:
     view = build_presentable_snapshot(snapshot)
     assert view["accounts"] == []
     assert view["hidden_accounts"][0]["name"] == "Problematic"
+
+    asyncio.run(fetcher.close())
+
+
+def test_account_stop_loss_state_updates(tmp_path: Path) -> None:
+    config = RealtimeConfig(
+        accounts=[AccountConfig(name="Demo", exchange="binance", credentials={})],
+        alert_thresholds={},
+        notification_channels=[],
+        reports_dir=tmp_path,
+    )
+    client = StubAccountClient("Demo", 10_000.0, [])
+    fetcher = RealtimeDataFetcher(config, account_clients=[client])
+
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+    assert "account_stop_losses" not in snapshot
+
+    asyncio.run(fetcher.set_account_stop_loss("Demo", 10.0))
+
+    client.balance = 9_200.0
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+    account_states = snapshot.get("account_stop_losses") or {}
+    assert "Demo" in account_states
+    state = account_states["Demo"]
+    assert state["threshold_pct"] == 10.0
+    assert state["current_balance"] == 9_200.0
+    assert state["current_drawdown_pct"] == pytest.approx((10_000.0 - 9_200.0) / 10_000.0)
+    assert not state["triggered"]
+
+    client.balance = 6_000.0
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+    state = snapshot["account_stop_losses"]["Demo"]
+    assert state["triggered"] is True
+    assert state["current_balance"] == 6_000.0
+
+    asyncio.run(fetcher.clear_account_stop_loss("Demo"))
+    snapshot = asyncio.run(fetcher.fetch_snapshot())
+    assert "account_stop_losses" not in snapshot or "Demo" not in snapshot["account_stop_losses"]
 
     asyncio.run(fetcher.close())


### PR DESCRIPTION
## Summary
- add a performance tracker that captures 4pm ET balance snapshots and exposes daily/weekly/monthly PnL across the dashboard and CSV reports
- expose account-level stop loss controls alongside new cancel-all orders and close-all positions actions in the trading panel and HTTP API
- ensure position metrics surface realised PnL, liquidation, drawdown, take-profit and stop-loss values with accompanying automated tests

## Testing
- pytest tests/test_risk_management_realtime.py tests/risk_management/test_performance.py tests/risk_management/test_snapshot_utils.py tests/test_risk_management_web.py

------
https://chatgpt.com/codex/tasks/task_b_6900ea448f2083239e8268113891511a