### PR TITLE
Add risk management architecture and interface documentation

### DIFF
--- a/docs/risk_management_architecture.md
+++ b/docs/risk_management_architecture.md
@@ -1,0 +1,75 @@
+# Risk management architecture notes
+
+## Overview
+This document summarises how the risk management services are composed across the
+terminal dashboard, FastAPI web UI, realtime data fetcher, and performance tracking
+helpers. It focuses on their primary data structures, asynchronous entry points,
+and how runtime configuration is consumed.
+
+## `risk_management.dashboard`
+- **Data structures**: Defines the `Position`, `Order`, `Account`, and `AlertThresholds`
+dataclasses that represent snapshot payloads parsed from disk or realtime
+requests. These structures expose helper methods (for example `Account.exposure_pct`
+and `Position.exposure_relative_to`) used when rendering alerts and aggregations.
+- **Parsing and transformation**: `parse_snapshot()` normalises inbound JSON into
+the dataclasses, while `evaluate_alerts()` inspects the parsed accounts against
+threshold rules, and `render_dashboard()` composes a printable terminal view.
+- **Async entry points**: The CLI is orchestrated through `main()` which delegates
+to the asynchronous `_run_cli()` helper. `_run_cli()` optionally instantiates a
+`RealtimeDataFetcher` when a realtime configuration is supplied and performs
+periodic calls to `fetch_snapshot()` before rendering the dashboard.
+- **Configuration touch points**: `main()` accepts command line overrides for
+snapshot paths, realtime configuration files, polling intervals, and custom
+endpoint behaviour. When realtime mode is enabled it loads configuration via
+`load_realtime_config()` and rewrites `CustomEndpointSettings` based on CLI
+flags before building the fetcher.
+
+## `risk_management.web`
+- **Data structures**: Wraps realtime access in `RiskDashboardService`, exposing
+methods for fetching snapshots, placing orders, cancelling orders, closing
+positions, executing kill switches, and managing portfolio or account stop-loss
+state. An `AuthManager` encapsulates credential storage and password validation.
+- **Async entry points**: `create_app()` wires dependencies and defines every
+FastAPI coroutine handler. Key asynchronous handlers include `/api/snapshot`,
+all `/api/trading/...` order and stop-loss routes, kill switch endpoints, and
+report generation or download helpers that interact with `RiskDashboardService`
+and `ReportManager`.
+- **Configuration touch points**: `create_app()` consumes `RealtimeConfig`
+attributes for authentication, Grafana embedding, reporting directories, and
+LetsEncrypt challenge serving. It also persists the instantiated
+`RiskDashboardService` on `app.state` so handlers can reuse the configured
+`RealtimeDataFetcher` and respect any custom endpoint overrides established in
+the runtime configuration.
+
+## `risk_management.realtime`
+- **Data structures**: `RealtimeDataFetcher` maintains per-account
+`AccountClientProtocol` instances, a `PerformanceTracker`, and mutable state for
+portfolio and account stop-loss records (including baseline balances, drawdown
+percentages, and trigger timestamps). It emits snapshot dictionaries mirroring
+what the dashboard expects, enriched with messages, notifications, and
+performance summaries.
+- **Async entry points**: The fetcher exposes coroutine methods including
+`fetch_snapshot()`, `close()`, `execute_kill_switch()`, `set_portfolio_stop_loss()`,
+`clear_portfolio_stop_loss()`, `set_account_stop_loss()`, `clear_account_stop_loss()`,
+`place_order()`, `cancel_order()`, `cancel_all_orders()`, `close_position()`, and
+`close_all_positions()`. These power both the CLI refresh loop and FastAPI
+routes.
+- **Configuration touch points**: Upon initialisation the fetcher applies
+`CustomEndpointSettings` discovery, instantiates `CCXTAccountClient` instances
+for every `RealtimeConfig.accounts` entry, seeds notification channels, and
+configures `PerformanceTracker` output directories. Runtime kill switch, order,
+and stop-loss commands reference `_resolve_account_client()` to ensure the
+requested account exists in the active configuration.
+
+## `risk_management.performance`
+- **Data structures**: Provides the `PerformanceSnapshot` dataclass to capture a
+single day's balance and timestamp and the `PerformanceTracker` class which
+stores `portfolio` history and an `accounts` mapping inside `daily_balances.json`.
+- **Async entry points**: The tracker is synchronous but is invoked from async
+callers; `RealtimeDataFetcher.fetch_snapshot()` awaits performance summaries by
+calling the synchronous `record()` method inside the event loop thread, returning
+a mapping of current balances plus daily/weekly/monthly profit deltas.
+- **Configuration touch points**: `PerformanceTracker` is initialised with the
+reports directory derived from realtime configuration (or a default under the
+module path) and respects timezone plus cut-off hour parameters to determine
+when to persist new balance snapshots.

--- a/docs/risk_management_interfaces.md
+++ b/docs/risk_management_interfaces.md
@@ -1,0 +1,44 @@
+# Risk management interfaces inventory
+
+## Command line entry points
+| Command | Module | Description | Key options |
+| --- | --- | --- | --- |
+| `python -m risk_management.dashboard` | [`risk_management/dashboard.py`](../risk_management/dashboard.py) | Renders the terminal dashboard using a static snapshot or realtime feed. | `--config`, `--realtime-config`, `--interval`, `--iterations`, `--custom-endpoints` |
+| `python -m risk_management.web_server` | [`risk_management/web_server.py`](../risk_management/web_server.py) | Launches the FastAPI risk dashboard with optional TLS and Let's Encrypt automation. | `--config`, networking flags, `--custom-endpoints`, TLS parameters, LetsEncrypt options |
+| `python risk_management/scripts/hash_password.py` | [`risk_management/scripts/hash_password.py`](../risk_management/scripts/hash_password.py) | Generates bcrypt password hashes for dashboard authentication records. | Optional `password` positional argument (otherwise uses interactive prompt) |
+
+## HTTP API surface
+All endpoints require an authenticated session unless explicitly noted.
+
+| Method & Path | Description | Backend call |
+| --- | --- | --- |
+| `GET /login` | Render the login form. | Template rendering only |
+| `POST /login` | Authenticate a user and open a session. | `AuthManager.authenticate()` |
+| `POST /logout` | Clear session cookie and redirect to login. | Session middleware |
+| `GET /` | Render the dashboard view model and Grafana embeds. | `RiskDashboardService.fetch_snapshot()` + `build_presentable_snapshot()` |
+| `GET /trading-panel` | Render the order management panel. | `RiskDashboardService.fetch_snapshot()` |
+| `GET /api/snapshot` | Return a JSON snapshot with optional filtering, paging, and sorting. | `RiskDashboardService.fetch_snapshot()` |
+| `GET /api/trading/accounts/{account}/order-types` | List order types supported by a configured account. | `RiskDashboardService.list_order_types()` |
+| `POST /api/trading/accounts/{account}/orders` | Place an order (market/limit/etc.) for a symbol. | `RiskDashboardService.place_order()` |
+| `DELETE /api/trading/accounts/{account}/orders/{order_id}` | Cancel a specific order (optional symbol/params payload). | `RiskDashboardService.cancel_order()` |
+| `POST /api/trading/accounts/{account}/positions/{symbol}/close` | Close a single symbol position. | `RiskDashboardService.close_position()` |
+| `POST /api/trading/accounts/{account}/orders/cancel-all` | Cancel all orders, optionally filtered by symbol. | `RiskDashboardService.cancel_all_orders()` |
+| `POST /api/trading/accounts/{account}/positions/close-all` | Close all open positions, optionally filtered by symbol. | `RiskDashboardService.close_all_positions()` |
+| `POST /api/trading/accounts/{account}/stop-loss` | Create or update an account stop-loss threshold. | `RiskDashboardService.set_account_stop_loss()` |
+| `GET /api/trading/accounts/{account}/stop-loss` | Retrieve the current account stop-loss state. | `RiskDashboardService.get_account_stop_loss()` |
+| `DELETE /api/trading/accounts/{account}/stop-loss` | Clear the account stop-loss configuration. | `RiskDashboardService.clear_account_stop_loss()` |
+| `POST /api/trading/portfolio/stop-loss` | Create or update the portfolio-level stop-loss. | `RiskDashboardService.set_portfolio_stop_loss()` |
+| `GET /api/trading/portfolio/stop-loss` | Retrieve the portfolio stop-loss state. | `RiskDashboardService.get_portfolio_stop_loss()` |
+| `DELETE /api/trading/portfolio/stop-loss` | Clear the portfolio stop-loss configuration. | `RiskDashboardService.clear_portfolio_stop_loss()` |
+| `POST /api/kill-switch` | Trigger the global kill switch across all accounts. | `RiskDashboardService.trigger_kill_switch()` |
+| `POST /api/accounts/{account}/kill-switch` | Trigger the kill switch for a specific account (optional `symbol` query). | `RiskDashboardService.trigger_kill_switch()` |
+| `POST /api/accounts/{account}/positions/{symbol}/kill-switch` | Trigger the kill switch for a specific symbol within an account. | `RiskDashboardService.trigger_kill_switch()` |
+| `GET /api/accounts/{account}/reports` | List generated CSV reports for an account. | `ReportManager.list_reports()` |
+| `POST /api/accounts/{account}/reports` | Generate a new CSV snapshot report for an account. | `ReportManager.create_account_report()` |
+| `GET /api/accounts/{account}/reports/{report_id}` | Download a report by identifier. | `ReportManager.get_report_path()` |
+
+## Acceptance criteria usage
+The tables above enumerate the external touch points that should be exercised by
+acceptance and regression tests. They cover realtime safety controls (kill
+switches and stop-loss APIs), order lifecycle management, reporting, and the CLI
+tools operators use to drive the system.

--- a/docs/risk_management_realtime_snapshot.schema.json
+++ b/docs/risk_management_realtime_snapshot.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://passivbot/risk_management/realtime_snapshot.schema.json",
+  "title": "Risk management realtime snapshot",
+  "type": "object",
+  "required": ["generated_at", "accounts", "alert_thresholds", "notification_channels"],
+  "properties": {
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "accounts": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/account"}
+    },
+    "alert_thresholds": {
+      "type": "object",
+      "required": [
+        "wallet_exposure_pct",
+        "position_wallet_exposure_pct",
+        "max_drawdown_pct",
+        "loss_threshold_pct"
+      ],
+      "properties": {
+        "wallet_exposure_pct": {"type": "number"},
+        "position_wallet_exposure_pct": {"type": "number"},
+        "max_drawdown_pct": {"type": "number"},
+        "loss_threshold_pct": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "notification_channels": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "account_messages": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "portfolio_stop_loss": {
+      "$ref": "#/definitions/stopLossState"
+    },
+    "account_stop_losses": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/stopLossState"}
+    },
+    "performance": {
+      "type": "object",
+      "properties": {
+        "portfolio": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/definitions/performanceSummary"}
+          ]
+        },
+        "accounts": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {"type": "null"},
+              {"$ref": "#/definitions/performanceSummary"}
+            ]
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "account": {
+      "type": "object",
+      "required": ["name", "balance", "positions"],
+      "properties": {
+        "name": {"type": "string"},
+        "balance": {"type": "number"},
+        "daily_realized_pnl": {"type": ["number", "null"]},
+        "positions": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/position"}
+        },
+        "orders": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/order"}
+        }
+      },
+      "additionalProperties": true
+    },
+    "position": {
+      "type": "object",
+      "required": [
+        "symbol",
+        "side",
+        "notional",
+        "entry_price",
+        "mark_price",
+        "unrealized_pnl"
+      ],
+      "properties": {
+        "symbol": {"type": "string"},
+        "side": {"type": "string"},
+        "notional": {"type": "number"},
+        "entry_price": {"type": "number"},
+        "mark_price": {"type": "number"},
+        "liquidation_price": {"type": ["number", "null"]},
+        "wallet_exposure_pct": {"type": ["number", "null"]},
+        "unrealized_pnl": {"type": "number"},
+        "max_drawdown_pct": {"type": ["number", "null"]},
+        "take_profit_price": {"type": ["number", "null"]},
+        "stop_loss_price": {"type": ["number", "null"]},
+        "size": {"type": ["number", "null"]},
+        "signed_notional": {"type": ["number", "null"]},
+        "volatility": {
+          "type": ["object", "null"],
+          "additionalProperties": {"type": "number"}
+        },
+        "funding_rates": {
+          "type": ["object", "null"],
+          "additionalProperties": {"type": "number"}
+        },
+        "daily_realized_pnl": {"type": ["number", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "order": {
+      "type": "object",
+      "required": ["symbol", "side", "order_type", "status", "reduce_only"],
+      "properties": {
+        "symbol": {"type": "string"},
+        "side": {"type": "string"},
+        "order_type": {"type": "string"},
+        "price": {"type": ["number", "null"]},
+        "amount": {"type": ["number", "null"]},
+        "remaining": {"type": ["number", "null"]},
+        "status": {"type": "string"},
+        "reduce_only": {"type": "boolean"},
+        "stop_price": {"type": ["number", "null"]},
+        "notional": {"type": ["number", "null"]},
+        "order_id": {"type": ["string", "null"]},
+        "created_at": {"type": ["string", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "stopLossState": {
+      "type": "object",
+      "required": ["threshold_pct", "triggered", "active"],
+      "properties": {
+        "threshold_pct": {"type": "number"},
+        "baseline_balance": {"type": ["number", "null"]},
+        "current_balance": {"type": ["number", "null"]},
+        "current_drawdown_pct": {"type": ["number", "null"]},
+        "triggered": {"type": "boolean"},
+        "triggered_at": {"type": ["string", "null"], "format": "date-time"},
+        "active": {"type": "boolean"}
+      },
+      "additionalProperties": true
+    },
+    "performanceSnapshot": {
+      "type": "object",
+      "required": ["date", "balance"],
+      "properties": {
+        "date": {"type": "string"},
+        "balance": {"type": "number"},
+        "timestamp": {"type": ["string", "null"], "format": "date-time"}
+      },
+      "additionalProperties": false
+    },
+    "performanceChange": {
+      "type": "object",
+      "required": ["pnl", "since", "reference_balance"],
+      "properties": {
+        "pnl": {"type": "number"},
+        "since": {"type": "string"},
+        "reference_balance": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "performanceSummary": {
+      "type": "object",
+      "required": ["current_balance", "latest_snapshot", "daily", "weekly", "monthly"],
+      "properties": {
+        "current_balance": {"type": "number"},
+        "latest_snapshot": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/definitions/performanceSnapshot"}
+          ]
+        },
+        "daily": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/definitions/performanceChange"}
+          ]
+        },
+        "weekly": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/definitions/performanceChange"}
+          ]
+        },
+        "monthly": {
+          "anyOf": [
+            {"type": "null"},
+            {"$ref": "#/definitions/performanceChange"}
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/risk_management_realtime_snapshots.md
+++ b/docs/risk_management_realtime_snapshots.md
@@ -1,0 +1,173 @@
+# Realtime snapshot reference
+
+## Sample snapshot with active stop-loss monitoring
+```json
+{
+  "generated_at": "2024-05-04T12:15:30.452817+00:00",
+  "accounts": [
+    {
+      "name": "Binance Futures",
+      "balance": 15234.12,
+      "daily_realized_pnl": 320.55,
+      "positions": [
+        {
+          "symbol": "BTCUSDT",
+          "side": "long",
+          "size": 0.25,
+          "notional": 16950.25,
+          "signed_notional": 16950.25,
+          "entry_price": 67800.0,
+          "mark_price": 67620.5,
+          "liquidation_price": 51250.0,
+          "wallet_exposure_pct": 0.45,
+          "unrealized_pnl": -450.63,
+          "max_drawdown_pct": 0.22,
+          "take_profit_price": 70500.0,
+          "stop_loss_price": 65500.0
+        }
+      ],
+      "orders": [
+        {
+          "symbol": "BTCUSDT",
+          "side": "sell",
+          "order_type": "limit",
+          "price": 70500.0,
+          "amount": 0.25,
+          "remaining": 0.25,
+          "status": "open",
+          "reduce_only": true,
+          "stop_price": null,
+          "notional": 17625.0,
+          "order_id": "abc123",
+          "created_at": "2024-05-04T11:58:12Z"
+        }
+      ]
+    },
+    {
+      "name": "OKX Futures",
+      "balance": 8250.8,
+      "daily_realized_pnl": -120.0,
+      "positions": [],
+      "orders": []
+    }
+  ],
+  "alert_thresholds": {
+    "wallet_exposure_pct": 0.65,
+    "position_wallet_exposure_pct": 0.25,
+    "max_drawdown_pct": 0.25,
+    "loss_threshold_pct": -0.08
+  },
+  "notification_channels": [
+    "email:risk-team@example.com",
+    "slack:#passivbot-risk-alerts"
+  ],
+  "account_messages": {
+    "OKX Futures": "Authentication for OKX Futures restored"
+  },
+  "portfolio_stop_loss": {
+    "threshold_pct": 12.0,
+    "baseline_balance": 25000.0,
+    "current_balance": 23484.92,
+    "current_drawdown_pct": 0.0606,
+    "triggered": false,
+    "triggered_at": null,
+    "active": true
+  },
+  "account_stop_losses": {
+    "Binance Futures": {
+      "threshold_pct": 10.0,
+      "baseline_balance": 16000.0,
+      "current_balance": 15234.12,
+      "current_drawdown_pct": 0.0472,
+      "triggered": false,
+      "triggered_at": null,
+      "active": true
+    },
+    "OKX Futures": {
+      "threshold_pct": 8.0,
+      "baseline_balance": 9000.0,
+      "current_balance": 8250.8,
+      "current_drawdown_pct": 0.0832,
+      "triggered": true,
+      "triggered_at": "2024-05-04T12:10:07.993201+00:00",
+      "active": true
+    }
+  },
+  "performance": {
+    "portfolio": {
+      "current_balance": 23484.92,
+      "latest_snapshot": {
+        "date": "2024-05-04",
+        "balance": 24010.45,
+        "timestamp": "2024-05-04T12:00:00+00:00"
+      },
+      "daily": {
+        "pnl": -215.08,
+        "since": "2024-05-03",
+        "reference_balance": 23700.0
+      },
+      "weekly": null,
+      "monthly": null
+    },
+    "accounts": {
+      "Binance Futures": {
+        "current_balance": 15234.12,
+        "latest_snapshot": {
+          "date": "2024-05-04",
+          "balance": 15800.0,
+          "timestamp": "2024-05-04T11:30:00+00:00"
+        },
+        "daily": null,
+        "weekly": null,
+        "monthly": null
+      },
+      "OKX Futures": {
+        "current_balance": 8250.8,
+        "latest_snapshot": {
+          "date": "2024-05-04",
+          "balance": 8900.0,
+          "timestamp": "2024-05-04T11:50:00+00:00"
+        },
+        "daily": {
+          "pnl": -649.2,
+          "since": "2024-05-03",
+          "reference_balance": 8900.0
+        },
+        "weekly": null,
+        "monthly": null
+      }
+    }
+  }
+}
+```
+
+## Sample snapshot after portfolio stop-loss trigger
+```json
+{
+  "generated_at": "2024-05-04T12:45:02.118903+00:00",
+  "accounts": [],
+  "alert_thresholds": {
+    "wallet_exposure_pct": 0.65,
+    "position_wallet_exposure_pct": 0.25,
+    "max_drawdown_pct": 0.25,
+    "loss_threshold_pct": -0.08
+  },
+  "notification_channels": [],
+  "portfolio_stop_loss": {
+    "threshold_pct": 12.0,
+    "baseline_balance": 25000.0,
+    "current_balance": 21000.0,
+    "current_drawdown_pct": 0.16,
+    "triggered": true,
+    "triggered_at": "2024-05-04T12:44:11.532901+00:00",
+    "active": true
+  }
+}
+```
+
+## JSON schema for regression tests
+The expected payload structure for regression checks is captured in
+[`docs/risk_management_realtime_snapshot.schema.json`](risk_management_realtime_snapshot.schema.json).
+This draft-07 schema includes reusable definitions for accounts, positions,
+orders, stop-loss states, and performance summaries so automated tests can
+validate realtime responses.


### PR DESCRIPTION
## Summary
- add architecture notes for the dashboard, web, realtime, and performance modules
- provide realtime snapshot samples with stop-loss states and a JSON schema for regression validation
- inventory CLI commands and HTTP endpoints for the risk management dashboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69018bd4f2588323a1244e854514c46c