### PR TITLE
Add percentage change to performance tracking

### DIFF
--- a/risk_management/performance.py
+++ b/risk_management/performance.py
@@ -230,8 +230,15 @@ class PerformanceTracker:
             if reference is None:
                 continue
             reference_balance = float(reference["balance"])
+            pnl = float(current_balance) - reference_balance
+            pct_change: Optional[float]
+            if reference_balance == 0:
+                pct_change = None
+            else:
+                pct_change = (pnl / reference_balance) * 100.0
             summary[label] = {
-                "pnl": float(current_balance) - reference_balance,
+                "pnl": pnl,
+                "pct_change": pct_change,
                 "since": reference["date"],
                 "reference_balance": reference_balance,
             }

--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -439,6 +439,9 @@ def _normalise_performance(data: Any) -> Dict[str, Any]:
         "daily": None,
         "weekly": None,
         "monthly": None,
+        "daily_pct": None,
+        "weekly_pct": None,
+        "monthly_pct": None,
     }
     latest = data.get("latest_snapshot")
     if isinstance(latest, Mapping):
@@ -453,18 +456,19 @@ def _normalise_performance(data: Any) -> Dict[str, Any]:
         change = data.get(key)
         if isinstance(change, Mapping):
             pnl = change.get("pnl")
-            if pnl is not None:
-                summary[key] = float(pnl)
-                if change.get("since") is not None:
-                    since_map[key] = change.get("since")
-                if change.get("reference_balance") is not None:
-                    reference_balances[key] = float(change.get("reference_balance"))
-            else:
-                summary[key] = None
+            pct = change.get("pct_change")
+            summary[key] = float(pnl) if pnl is not None else None
+            summary[f"{key}_pct"] = float(pct) if pct is not None else None
+            if change.get("since") is not None:
+                since_map[key] = change.get("since")
+            if change.get("reference_balance") is not None:
+                reference_balances[key] = float(change.get("reference_balance"))
         elif isinstance(change, (int, float)):
             summary[key] = float(change)
+            summary[f"{key}_pct"] = None
         else:
             summary[key] = None
+            summary[f"{key}_pct"] = None
     if since_map:
         summary["since"] = since_map
     if reference_balances:


### PR DESCRIPTION
## Summary
- compute percentage change for portfolio and account summaries using stored reference balances
- expose percentage change fields in normalised performance payloads for dashboards
- extend performance tracker tests to cover percentage calculations and zero baseline handling

## Testing
- pytest tests/risk_management/test_performance.py

------
https://chatgpt.com/codex/tasks/task_b_69018eb696f48323a436cbf812969447