### PR TITLE
Add stress testing scenarios to risk management

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -21,6 +21,8 @@ from typing import (
     Set,
 )
 
+from .domain.models import Scenario, ScenarioShock
+
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +216,7 @@ class RealtimeConfig:
     notification_channels: List[str] = field(default_factory=list)
     auth: Optional[AuthConfig] = None
     account_messages: Dict[str, str] = field(default_factory=dict)
+    scenarios: List[Scenario] = field(default_factory=list)
     custom_endpoints: Optional[CustomEndpointSettings] = None
     email: Optional[EmailSettings] = None
     config_root: Optional[Path] = None
@@ -626,6 +629,102 @@ def _parse_auth(auth_raw: Optional[Mapping[str, Any]]) -> Optional[AuthConfig]:
     )
 
 
+def _parse_scenarios(payload: Any) -> List[Scenario]:
+    if not payload:
+        return []
+
+    if isinstance(payload, Mapping):
+        iterable = payload.values()
+    elif isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+        iterable = payload
+    else:
+        raise TypeError(
+            "Realtime configuration 'scenarios' must be an iterable of scenario definitions.",
+        )
+
+    scenarios: List[Scenario] = []
+    for raw in iterable:
+        if not isinstance(raw, Mapping):
+            raise TypeError("Scenario definitions must be JSON objects.")
+        scenario_id = raw.get("id")
+        name = raw.get("name") or scenario_id
+        if not name:
+            raise ValueError("Scenario definitions must include a 'name' or 'id'.")
+        description_raw = raw.get("description")
+        description = (
+            str(description_raw).strip()
+            if isinstance(description_raw, str) and description_raw.strip()
+            else None
+        )
+        shocks_raw = raw.get("shocks")
+        shocks = _parse_shock_definitions(shocks_raw, str(name))
+        scenarios.append(
+            Scenario(
+                id=str(scenario_id) if scenario_id else None,
+                name=str(name),
+                description=description,
+                shocks=tuple(shocks),
+            )
+        )
+    return scenarios
+
+
+def _parse_shock_definitions(payload: Any, scenario_name: str) -> List[ScenarioShock]:
+    if not payload:
+        raise ValueError(f"Scenario '{scenario_name}' must include at least one shock definition.")
+
+    shocks: List[ScenarioShock] = []
+
+    if isinstance(payload, Mapping):
+        items = payload.items()
+        for symbol, value in items:
+            pct = _coerce_float(value, description=f"Scenario '{scenario_name}' shock for '{symbol}'")
+            shocks.append(ScenarioShock(symbol=str(symbol), price_pct=pct))
+    elif isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+        for raw in payload:
+            if not isinstance(raw, Mapping):
+                raise TypeError(
+                    f"Scenario '{scenario_name}' shock entries must be JSON objects.",
+                )
+            symbol = raw.get("symbol") or raw.get("pair") or raw.get("ticker")
+            if not symbol:
+                raise ValueError(
+                    f"Scenario '{scenario_name}' shock entries must include a 'symbol'.",
+                )
+            pct_raw = (
+                raw.get("price_pct")
+                if raw.get("price_pct") is not None
+                else raw.get("pct")
+                if raw.get("pct") is not None
+                else raw.get("percent")
+            )
+            pct = _coerce_float(
+                pct_raw,
+                description=f"Scenario '{scenario_name}' shock for '{symbol}'",
+            )
+            shocks.append(ScenarioShock(symbol=str(symbol), price_pct=pct))
+    else:
+        raise TypeError(
+            f"Scenario '{scenario_name}' shocks must be provided as a mapping or list of definitions.",
+        )
+
+    if not shocks:
+        raise ValueError(
+            f"Scenario '{scenario_name}' must include at least one shock definition.",
+        )
+
+    return shocks
+
+
+def _coerce_float(value: Any, *, description: str) -> float:
+    if value is None:
+        raise ValueError(f"{description} must be a number.")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{description} must be a number.") from exc
+
+
 def load_realtime_config(path: Path | str) -> RealtimeConfig:
     """Load a realtime configuration file.
 
@@ -733,6 +832,8 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
                 continue
             account_messages[str(name)] = str(message)
 
+    scenarios = _parse_scenarios(config.get("scenarios"))
+
     return RealtimeConfig(
         accounts=accounts,
         alert_thresholds=alert_thresholds,
@@ -745,4 +846,5 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
         reports_dir=reports_dir,
         grafana=grafana_settings,
         account_messages=account_messages,
+        scenarios=scenarios,
     )

--- a/risk_management/dashboard.py
+++ b/risk_management/dashboard.py
@@ -24,10 +24,102 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from .configuration import CustomEndpointSettings, load_realtime_config
-from .domain.models import Account, AlertThresholds, Order, Position
+from .domain.models import (
+    Account,
+    AlertThresholds,
+    Order,
+    Position,
+    Scenario,
+    ScenarioResult,
+    ScenarioShock,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+def _select_configured_scenarios(
+    configured: Sequence[Scenario],
+    requested: Optional[Sequence[str]],
+) -> List[Scenario]:
+    if not configured:
+        if requested:
+            names = ", ".join(str(name) for name in requested)
+            raise ValueError(
+                f"No configured scenarios available to match: {names}",
+            )
+        return []
+
+    if not requested:
+        return list(configured)
+
+    index: Dict[str, Scenario] = {}
+    for scenario in configured:
+        keys = {scenario.name.lower()}
+        if scenario.id:
+            keys.add(scenario.id.lower())
+        for key in keys:
+            index.setdefault(key, scenario)
+
+    selected: List[Scenario] = []
+    missing: List[str] = []
+
+    for entry in requested:
+        key = str(entry).strip().lower()
+        if not key:
+            continue
+        match = index.get(key)
+        if match is None:
+            missing.append(str(entry))
+            continue
+        if match not in selected:
+            selected.append(match)
+
+    if missing:
+        raise ValueError(f"Unknown scenario(s): {', '.join(missing)}")
+
+    return selected
+
+
+def _parse_ad_hoc_scenario(values: Optional[Sequence[str]]) -> Optional[Scenario]:
+    if not values:
+        return None
+
+    shocks: List[ScenarioShock] = []
+    for raw in values:
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if not text:
+            continue
+        if ":" not in text:
+            raise ValueError(
+                "Ad-hoc shocks must use the format SYMBOL:PCT (for example BTCUSDT:-0.10).",
+            )
+        symbol_part, pct_part = text.split(":", 1)
+        symbol = symbol_part.strip().upper()
+        if not symbol:
+            raise ValueError("Shock definitions must include a symbol name before ':'.")
+        try:
+            pct = float(pct_part)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Shock '{text}' must include a numeric percentage change.",
+            ) from exc
+        shocks.append(ScenarioShock(symbol=symbol, price_pct=pct))
+
+    if not shocks:
+        return None
+
+    description = ", ".join(
+        f"{shock.symbol} {shock.price_pct:+.2%}" for shock in shocks
+    )
+    return Scenario(
+        id="adhoc",
+        name="Ad-hoc shock",
+        description=description,
+        shocks=tuple(shocks),
+    )
 
 
 def _format_currency(value: float) -> str:
@@ -236,6 +328,7 @@ def render_dashboard(
     alerts: Sequence[str],
     notifications: Sequence[str],
     account_messages: Optional[Mapping[str, str]] = None,
+    scenario_results: Optional[Sequence[ScenarioResult]] = None,
 ) -> str:
     lines: List[str] = []
     lines.append("=" * 80)
@@ -281,6 +374,52 @@ def render_dashboard(
             lines.append("    No open positions.")
         lines.append("")
 
+    if scenario_results:
+        lines.append("Scenario analysis")
+        lines.append("-" * 80)
+        for result in scenario_results:
+            scenario = result.scenario
+            identifier = scenario.name
+            if scenario.id and scenario.id.lower() != scenario.name.lower():
+                identifier = f"{identifier} [{scenario.id}]"
+            lines.append(identifier)
+            if scenario.description:
+                lines.append(f"  {scenario.description}")
+            if scenario.shocks:
+                shocks_summary = ", ".join(
+                    f"{shock.symbol}: {_format_pct(shock.price_pct)}"
+                    for shock in scenario.shocks
+                )
+                lines.append(f"  Shocks: {shocks_summary}")
+            portfolio = result.portfolio
+            lines.append(
+                "  "
+                + f"Portfolio PnL: {_format_currency(portfolio.pnl)} | "
+                + f"Balance: {_format_currency(portfolio.balance_after)} "
+                + f"(from {_format_currency(portfolio.balance_before)})"
+            )
+            lines.append(
+                "  "
+                + f"Gross exposure: {_format_currency(portfolio.gross_exposure)} "
+                + f"({_format_pct(portfolio.gross_exposure_pct)})"
+            )
+            lines.append(
+                "  "
+                + f"Net exposure: {_format_currency(portfolio.net_exposure)} "
+                + f"({_format_pct(portfolio.net_exposure_pct)})"
+            )
+            top_symbols = list(portfolio.symbols)[:3]
+            if top_symbols:
+                lines.append("  Top exposures:")
+                for symbol in top_symbols:
+                    lines.append(
+                        "    "
+                        + f"{symbol.symbol}: gross {_format_currency(symbol.gross_notional)} "
+                        + f"({_format_pct(symbol.gross_pct)}) net {_format_currency(symbol.net_notional)} "
+                        + f"({_format_pct(symbol.net_pct)}) pnl {_format_currency(symbol.pnl)}"
+                    )
+            lines.append("")
+
     lines.append("Alerts")
     lines.append("-" * 80)
     if alerts:
@@ -307,11 +446,22 @@ def run_dashboard(config_path: Path) -> str:
     return build_dashboard(snapshot)
 
 
-def build_dashboard(snapshot: Dict[str, Any]) -> str:
+def build_dashboard(
+    snapshot: Dict[str, Any],
+    *,
+    scenario_results: Optional[Sequence[ScenarioResult]] = None,
+) -> str:
     generated_at, accounts, thresholds, notifications = parse_snapshot(snapshot)
     alerts = evaluate_alerts(accounts, thresholds)
     account_messages = snapshot.get("account_messages", {}) if isinstance(snapshot, Mapping) else {}
-    return render_dashboard(generated_at, accounts, alerts, notifications, account_messages=account_messages)
+    return render_dashboard(
+        generated_at,
+        accounts,
+        alerts,
+        notifications,
+        account_messages=account_messages,
+        scenario_results=scenario_results,
+    )
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -348,6 +498,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "disable overrides."
         ),
     )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        dest="scenario_names",
+        help=(
+            "Name or ID of a configured scenario to evaluate. Repeat to include multiple scenarios."
+        ),
+    )
+    parser.add_argument(
+        "--shock",
+        action="append",
+        dest="shocks",
+        metavar="SYMBOL:PCT",
+        help=(
+            "Ad-hoc price shock expressed as a decimal percentage. Example: --shock BTCUSDT:-0.10"
+        ),
+    )
 
     args = parser.parse_args(list(argv) if argv is not None else None)
 
@@ -371,6 +538,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
     from .services import RiskService
 
     realtime_service: Optional[RiskService] = None
+    configured_scenarios: Sequence[Scenario] = []
     if args.realtime_config:
         realtime_config = load_realtime_config(Path(args.realtime_config))
         override = args.custom_endpoints
@@ -392,17 +560,35 @@ async def _run_cli(args: argparse.Namespace) -> int:
                     realtime_config.custom_endpoints = CustomEndpointSettings(
                         path=override_normalized, autodiscover=False
                     )
+        configured_scenarios = list(realtime_config.scenarios)
         realtime_service = RiskService.from_config(realtime_config)
         logger.info("Starting realtime dashboard using %s", args.realtime_config)
 
     try:
+        selected_configured = _select_configured_scenarios(
+            configured_scenarios,
+            getattr(args, "scenario_names", None),
+        )
+        ad_hoc = _parse_ad_hoc_scenario(getattr(args, "shocks", None))
+        scenarios_to_run: List[Scenario] = list(selected_configured)
+        if ad_hoc is not None:
+            scenarios_to_run.append(ad_hoc)
+        simulate = None
+        if scenarios_to_run:
+            from .stress import simulate_scenarios
+
+            simulate = simulate_scenarios
+
         iteration = 0
         while True:
             if realtime_service is not None:
                 snapshot = await realtime_service.fetch_snapshot()
             else:
                 snapshot = load_snapshot(Path(args.config))
-            dashboard = build_dashboard(snapshot)
+            scenario_results: Sequence[ScenarioResult] = []
+            if simulate is not None:
+                scenario_results = simulate(snapshot, scenarios_to_run)
+            dashboard = build_dashboard(snapshot, scenario_results=scenario_results)
             print(dashboard)
             iteration += 1
             if args.iterations and iteration >= args.iterations:

--- a/risk_management/domain/models.py
+++ b/risk_management/domain/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Mapping, Optional, Sequence
 
 
@@ -119,9 +119,68 @@ class AlertThresholds:
     loss_threshold_pct: float = -0.12
 
 
+@dataclass(frozen=True)
+class ScenarioShock:
+    """Market shock to apply to a symbol when running stress simulations."""
+
+    symbol: str
+    price_pct: float = 0.0
+
+
+@dataclass
+class Scenario:
+    """Collection of shocks representing a stress test scenario."""
+
+    name: str
+    shocks: Sequence[ScenarioShock] = field(default_factory=tuple)
+    id: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass
+class ScenarioSymbolExposure:
+    """Exposure details for a single symbol under a simulated scenario."""
+
+    symbol: str
+    gross_notional: float
+    net_notional: float
+    gross_pct: float
+    net_pct: float
+    pnl: float
+
+
+@dataclass
+class ScenarioAccountImpact:
+    """Impact of a scenario on an account or the aggregated portfolio."""
+
+    name: str
+    balance_before: float
+    balance_after: float
+    pnl: float
+    gross_exposure: float
+    gross_exposure_pct: float
+    net_exposure: float
+    net_exposure_pct: float
+    symbols: Sequence[ScenarioSymbolExposure] = field(default_factory=tuple)
+
+
+@dataclass
+class ScenarioResult:
+    """Simulation output combining portfolio and account level impacts."""
+
+    scenario: Scenario
+    portfolio: ScenarioAccountImpact
+    accounts: Sequence[ScenarioAccountImpact] = field(default_factory=tuple)
+
+
 __all__ = [
     "Position",
     "Order",
     "Account",
     "AlertThresholds",
+    "ScenarioShock",
+    "Scenario",
+    "ScenarioSymbolExposure",
+    "ScenarioAccountImpact",
+    "ScenarioResult",
 ]

--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -57,6 +57,24 @@
     "max_drawdown_pct": 0.25,
     "loss_threshold_pct": -0.08
   },
+  "scenarios": [
+    {
+      "id": "btc_minus_10",
+      "name": "BTC -10%",
+      "description": "Bitcoin sells off by ten percent.",
+      "shocks": [
+        {"symbol": "BTCUSDT", "price_pct": -0.10}
+      ]
+    },
+    {
+      "id": "eth_minus_15",
+      "name": "ETH -15%",
+      "description": "Ethereum retraces sharply.",
+      "shocks": [
+        {"symbol": "ETHUSDT", "price_pct": -0.15}
+      ]
+    }
+  ],
   "email": {
     "host": "smtppro.zoho.in",
     "port": 587,

--- a/risk_management/stress.py
+++ b/risk_management/stress.py
@@ -1,0 +1,248 @@
+"""Stress testing helpers for the risk management dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence
+
+from .domain.models import (
+    Scenario,
+    ScenarioAccountImpact,
+    ScenarioResult,
+    ScenarioShock,
+    ScenarioSymbolExposure,
+)
+
+
+def simulate_scenarios(
+    snapshot: Mapping[str, Any],
+    scenarios: Sequence[Scenario],
+) -> List[ScenarioResult]:
+    """Return scenario simulation results for ``snapshot``."""
+
+    if not scenarios:
+        return []
+
+    from .snapshot_utils import MAX_ACCOUNTS_PAGE_SIZE, build_presentable_snapshot
+
+    presentable = build_presentable_snapshot(
+        snapshot,
+        page=1,
+        page_size=MAX_ACCOUNTS_PAGE_SIZE,
+    )
+    accounts = presentable.get("accounts", [])
+    if not isinstance(accounts, Sequence):
+        return []
+
+    results: List[ScenarioResult] = []
+    for scenario in scenarios:
+        results.append(_simulate_scenario(accounts, scenario))
+    return results
+
+
+def scenario_results_to_dict(results: Sequence[ScenarioResult]) -> List[Dict[str, Any]]:
+    """Serialise scenario results into dictionaries suitable for JSON payloads."""
+
+    return [asdict(result) for result in results]
+
+
+def _simulate_scenario(
+    accounts: Sequence[Mapping[str, Any]],
+    scenario: Scenario,
+) -> ScenarioResult:
+    shock_lookup = {
+        _normalise_symbol(shock.symbol): shock for shock in scenario.shocks
+    }
+
+    account_results: List[ScenarioAccountImpact] = []
+    portfolio_symbols: Dict[str, MutableMapping[str, float]] = {}
+    portfolio_balance_before = 0.0
+    portfolio_pnl = 0.0
+
+    for account in accounts:
+        impact = _simulate_account(account, shock_lookup)
+        account_results.append(impact)
+        portfolio_balance_before += impact.balance_before
+        portfolio_pnl += impact.pnl
+        for symbol in impact.symbols:
+            entry = portfolio_symbols.setdefault(
+                symbol.symbol,
+                {"gross": 0.0, "net": 0.0, "pnl": 0.0},
+            )
+            entry["gross"] += symbol.gross_notional
+            entry["net"] += symbol.net_notional
+            entry["pnl"] += symbol.pnl
+
+    balance_after = portfolio_balance_before + portfolio_pnl
+    portfolio_symbol_entries: List[ScenarioSymbolExposure] = []
+    portfolio_gross = 0.0
+    portfolio_net = 0.0
+
+    for symbol, values in portfolio_symbols.items():
+        gross = float(values.get("gross", 0.0))
+        net = float(values.get("net", 0.0))
+        pnl = float(values.get("pnl", 0.0))
+        portfolio_gross += gross
+        portfolio_net += net
+        portfolio_symbol_entries.append(
+            ScenarioSymbolExposure(
+                symbol=symbol,
+                gross_notional=gross,
+                net_notional=net,
+                gross_pct=_safe_ratio(gross, balance_after),
+                net_pct=_safe_ratio(net, balance_after),
+                pnl=pnl,
+            )
+        )
+
+    portfolio_symbol_entries.sort(key=lambda entry: entry.gross_notional, reverse=True)
+
+    portfolio_impact = ScenarioAccountImpact(
+        name="Portfolio",
+        balance_before=portfolio_balance_before,
+        balance_after=balance_after,
+        pnl=portfolio_pnl,
+        gross_exposure=portfolio_gross,
+        gross_exposure_pct=_safe_ratio(portfolio_gross, balance_after),
+        net_exposure=portfolio_net,
+        net_exposure_pct=_safe_ratio(portfolio_net, balance_after),
+        symbols=tuple(portfolio_symbol_entries),
+    )
+
+    return ScenarioResult(
+        scenario=scenario,
+        portfolio=portfolio_impact,
+        accounts=tuple(account_results),
+    )
+
+
+def _simulate_account(
+    account: Mapping[str, Any],
+    shock_lookup: Mapping[str, ScenarioShock],
+) -> ScenarioAccountImpact:
+    positions = account.get("positions")
+    if not isinstance(positions, Sequence):
+        positions = []
+
+    balance_before = _to_float(account.get("balance"), 0.0)
+    symbol_impacts: Dict[str, MutableMapping[str, float]] = {}
+    total_pnl = 0.0
+    gross_exposure = 0.0
+    net_exposure = 0.0
+
+    for position in positions:
+        if not isinstance(position, Mapping):
+            continue
+        symbol = _normalise_symbol(position.get("symbol"))
+        shock = shock_lookup.get(symbol)
+        price_factor = 1.0 + (shock.price_pct if shock else 0.0)
+        mark_price = _to_float(position.get("mark_price"), 0.0)
+        entry_price = _to_float(position.get("entry_price"), 0.0)
+        size = _resolve_position_size(position, mark_price)
+        if size <= 0.0:
+            continue
+        direction = _resolve_direction(position)
+
+        new_mark_price = mark_price * price_factor
+        new_notional = size * new_mark_price
+        signed_notional = new_notional * direction
+        pnl = (new_mark_price - entry_price) * size * direction
+
+        total_pnl += pnl
+        gross_exposure += abs(signed_notional)
+        net_exposure += signed_notional
+
+        entry = symbol_impacts.setdefault(
+            symbol,
+            {"gross": 0.0, "net": 0.0, "pnl": 0.0},
+        )
+        entry["gross"] += abs(signed_notional)
+        entry["net"] += signed_notional
+        entry["pnl"] += pnl
+
+    balance_after = balance_before + total_pnl
+    symbol_entries: List[ScenarioSymbolExposure] = []
+    for symbol, values in symbol_impacts.items():
+        gross = float(values.get("gross", 0.0))
+        net = float(values.get("net", 0.0))
+        pnl = float(values.get("pnl", 0.0))
+        symbol_entries.append(
+            ScenarioSymbolExposure(
+                symbol=symbol,
+                gross_notional=gross,
+                net_notional=net,
+                gross_pct=_safe_ratio(gross, balance_after),
+                net_pct=_safe_ratio(net, balance_after),
+                pnl=pnl,
+            )
+        )
+    symbol_entries.sort(key=lambda entry: entry.gross_notional, reverse=True)
+
+    return ScenarioAccountImpact(
+        name=str(account.get("name", "")),
+        balance_before=balance_before,
+        balance_after=balance_after,
+        pnl=total_pnl,
+        gross_exposure=gross_exposure,
+        gross_exposure_pct=_safe_ratio(gross_exposure, balance_after),
+        net_exposure=net_exposure,
+        net_exposure_pct=_safe_ratio(net_exposure, balance_after),
+        symbols=tuple(symbol_entries),
+    )
+
+
+def _resolve_position_size(position: Mapping[str, Any], mark_price: float) -> float:
+    size_value = _to_optional_float(position.get("size"))
+    if size_value is not None:
+        return abs(size_value)
+
+    if mark_price:
+        signed_notional = _to_optional_float(position.get("signed_notional"))
+        if signed_notional is not None:
+            return abs(signed_notional) / abs(mark_price)
+        notional = _to_optional_float(position.get("notional"))
+        if notional is not None:
+            return abs(notional) / abs(mark_price)
+
+    return 0.0
+
+
+def _resolve_direction(position: Mapping[str, Any]) -> float:
+    signed_notional = _to_optional_float(position.get("signed_notional"))
+    if signed_notional is not None and signed_notional != 0.0:
+        return 1.0 if signed_notional > 0.0 else -1.0
+
+    side = str(position.get("side", "")).lower()
+    if side in {"short", "sell"}:
+        return -1.0
+    return 1.0
+
+
+def _normalise_symbol(symbol: Any) -> str:
+    if symbol is None:
+        return ""
+    return str(symbol).upper()
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator == 0.0:
+        return 0.0
+    return numerator / denominator
+
+
+def _to_float(value: Any, default: float) -> float:
+    parsed = _to_optional_float(value)
+    return parsed if parsed is not None else default
+
+
+def _to_optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = ["simulate_scenarios", "scenario_results_to_dict"]
+

--- a/risk_management/templates/dashboard/index.html
+++ b/risk_management/templates/dashboard/index.html
@@ -219,6 +219,89 @@
           <p style="color: var(--muted); margin-top: 1rem;">No active exposures.</p>
         {% endif %}
       </section>
+      {% if snapshot.scenarios %}
+        <section class="card" data-scenarios>
+          <h2 style="margin-bottom: 0.5rem;">Scenario analysis</h2>
+          <p style="color: var(--muted); margin: 0;">
+            Simulated portfolio impact under configured market shocks.
+          </p>
+          <div class="table-wrapper" style="margin-top: 1.5rem;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Scenario</th>
+                  <th>Portfolio PnL</th>
+                  <th>Balance</th>
+                  <th>Gross Exposure</th>
+                  <th>Net Exposure</th>
+                  <th>Top exposures</th>
+                  <th>Shocks</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for scenario in snapshot.scenarios %}
+                  {% set scenario_meta = scenario.scenario %}
+                  {% set portfolio = scenario.portfolio %}
+                  {% set pnl_class = 'gain' if portfolio.pnl >= 0 else 'loss' %}
+                  {% set net_class = 'gain' if portfolio.net_exposure >= 0 else 'loss' %}
+                  <tr>
+                    <td>
+                      <div style="font-weight: 600;">{{ scenario_meta.name }}</div>
+                      {% if scenario_meta.id and scenario_meta.id|lower != scenario_meta.name|lower %}
+                        <div style="color: var(--muted); font-size: 0.85rem;">{{ scenario_meta.id }}</div>
+                      {% endif %}
+                      {% if scenario_meta.description %}
+                        <div style="color: var(--muted); font-size: 0.9rem;">{{ scenario_meta.description }}</div>
+                      {% endif %}
+                    </td>
+                    <td class="{{ pnl_class }}">{{ portfolio.pnl|currency }}</td>
+                    <td>
+                      <div>{{ portfolio.balance_after|currency }}</div>
+                      <div class="subvalue">from {{ portfolio.balance_before|currency }}</div>
+                    </td>
+                    <td>
+                      <div>{{ portfolio.gross_exposure|currency }}</div>
+                      <div class="subvalue">{{ portfolio.gross_exposure_pct|pct }}</div>
+                    </td>
+                    <td class="{{ net_class }}">
+                      <div>{{ portfolio.net_exposure|currency }}</div>
+                      <div class="subvalue">{{ portfolio.net_exposure_pct|pct }}</div>
+                    </td>
+                    <td>
+                      {% set top_symbols = portfolio.symbols[:3] %}
+                      {% if top_symbols %}
+                        {% for entry in top_symbols %}
+                          <div>
+                            {{ entry.symbol }}: {{ entry.gross_notional|currency }} ({{ entry.gross_pct|pct }})
+                          </div>
+                        {% endfor %}
+                      {% else %}
+                        -
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% if scenario_meta.shocks %}
+                        {% for shock in scenario_meta.shocks %}
+                          <div>{{ shock.symbol }}: {{ shock.price_pct|pct }}</div>
+                        {% endfor %}
+                      {% else %}
+                        -
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+            <div class="table-pagination" aria-label="Scenario analysis">
+              <button type="button" disabled>Prev</button>
+              <span>
+                {{ snapshot.scenarios|length }} scenario{{ 's' if snapshot.scenarios|length != 1 else '' }}
+              </span>
+              <button type="button" disabled>Next</button>
+            </div>
+          </div>
+        </section>
+      {% endif %}
     </div>
 
     <div class="page-section" data-page-section="accounts" hidden>

--- a/tests/risk_management/test_dashboard_scenarios.py
+++ b/tests/risk_management/test_dashboard_scenarios.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from risk_management.dashboard import render_dashboard
+from risk_management.domain.models import (
+    Account,
+    Position,
+    Scenario,
+    ScenarioAccountImpact,
+    ScenarioResult,
+    ScenarioShock,
+    ScenarioSymbolExposure,
+)
+
+
+def _sample_account() -> Account:
+    position = Position(
+        symbol="BTCUSDT",
+        side="long",
+        notional=100.0,
+        entry_price=100.0,
+        mark_price=100.0,
+        liquidation_price=None,
+        wallet_exposure_pct=None,
+        unrealized_pnl=0.0,
+        max_drawdown_pct=None,
+    )
+    return Account(name="Test", balance=1000.0, positions=[position])
+
+
+def test_render_dashboard_includes_scenario_results() -> None:
+    account = _sample_account()
+    scenario = Scenario(
+        id="stress_1",
+        name="Stress Test",
+        description="BTC tumbles",
+        shocks=(ScenarioShock(symbol="BTCUSDT", price_pct=-0.1),),
+    )
+    symbol_exposure = ScenarioSymbolExposure(
+        symbol="BTCUSDT",
+        gross_notional=450.0,
+        net_notional=450.0,
+        gross_pct=0.45,
+        net_pct=0.45,
+        pnl=-50.0,
+    )
+    account_impact = ScenarioAccountImpact(
+        name="Portfolio",
+        balance_before=1000.0,
+        balance_after=950.0,
+        pnl=-50.0,
+        gross_exposure=450.0,
+        gross_exposure_pct=0.45,
+        net_exposure=450.0,
+        net_exposure_pct=0.45,
+        symbols=[symbol_exposure],
+    )
+    scenario_result = ScenarioResult(
+        scenario=scenario,
+        portfolio=account_impact,
+        accounts=[account_impact],
+    )
+
+    output = render_dashboard(
+        datetime.now(timezone.utc),
+        [account],
+        alerts=[],
+        notifications=[],
+        scenario_results=[scenario_result],
+    )
+
+    assert "Scenario analysis" in output
+    assert "Stress Test" in output
+    assert "BTCUSDT: -10.00%" in output
+    assert "Portfolio PnL: $-50.00" in output

--- a/tests/risk_management/test_stress.py
+++ b/tests/risk_management/test_stress.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from risk_management.domain.models import Scenario, ScenarioShock
+from risk_management.stress import simulate_scenarios
+
+
+def _snapshot_with_position(mark_price: float = 100.0) -> dict[str, object]:
+    return {
+        "generated_at": "2024-01-01T00:00:00Z",
+        "accounts": [
+            {
+                "name": "Test account",
+                "balance": 1000.0,
+                "positions": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "side": "long",
+                        "notional": 500.0,
+                        "entry_price": 100.0,
+                        "mark_price": mark_price,
+                        "unrealized_pnl": 0.0,
+                        "size": 5.0,
+                    }
+                ],
+            }
+        ],
+        "alert_thresholds": {},
+    }
+
+
+def test_simulate_scenarios_long_position_loss() -> None:
+    snapshot = _snapshot_with_position()
+    scenario = Scenario(
+        id="btc_down",
+        name="BTC -10%",
+        description="Bitcoin drops by ten percent",
+        shocks=(ScenarioShock(symbol="BTCUSDT", price_pct=-0.1),),
+    )
+
+    results = simulate_scenarios(snapshot, [scenario])
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.scenario.name == "BTC -10%"
+    portfolio = result.portfolio
+    assert portfolio.balance_before == pytest.approx(1000.0)
+    assert portfolio.balance_after == pytest.approx(950.0)
+    assert portfolio.pnl == pytest.approx(-50.0)
+    assert portfolio.gross_exposure == pytest.approx(450.0)
+    assert portfolio.net_exposure == pytest.approx(450.0)
+    assert portfolio.gross_exposure_pct == pytest.approx(450.0 / 950.0)
+    assert portfolio.symbols
+    symbol = portfolio.symbols[0]
+    assert symbol.symbol == "BTCUSDT"
+    assert symbol.gross_notional == pytest.approx(450.0)
+    assert symbol.pnl == pytest.approx(-50.0)
+
+
+def test_simulate_scenarios_no_scenarios_returns_empty() -> None:
+    snapshot = _snapshot_with_position()
+    assert simulate_scenarios(snapshot, []) == []


### PR DESCRIPTION
## Summary
- introduce reusable scenario dataclasses and a stress-testing engine to project risk impacts across portfolio and accounts
- extend realtime configuration, CLI, and dashboard rendering to load configured scenarios or ad-hoc shocks and display simulated metrics
- expose scenario analysis in the web UI and cover calculations and rendering with focused unit tests

## Testing
- pytest tests/risk_management/test_stress.py tests/risk_management/test_dashboard_scenarios.py
- pytest *(fails: missing optional numpy/hjson/ccxt dependencies in default environment)*

------
https://chatgpt.com/codex/tasks/task_b_6901a3f8fc08832386941a36c507c0b6