### PR TITLE
Add audit logging infrastructure and dashboard

### DIFF
--- a/risk_management/audit.py
+++ b/risk_management/audit.py
@@ -1,0 +1,317 @@
+"""Append-only audit trail utilities for the risk management dashboard."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Dict, Iterator, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REDACT_FIELDS: tuple[str, ...] = (
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "private_key",
+)
+
+
+@dataclass(frozen=True)
+class AuditS3Settings:
+    """Configuration for offloading audit records to S3."""
+
+    bucket: str
+    prefix: str = ""
+    region_name: Optional[str] = None
+    profile_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AuditSyslogSettings:
+    """Configuration for forwarding audit records to syslog."""
+
+    address: str = "localhost"
+    port: int = 514
+    facility: str = "user"
+
+
+@dataclass(frozen=True)
+class AuditSettings:
+    """Audit logging preferences loaded from the realtime configuration."""
+
+    log_path: Path
+    enabled: bool = True
+    redact_fields: Sequence[str] = DEFAULT_REDACT_FIELDS
+    s3: Optional[AuditS3Settings] = None
+    syslog: Optional[AuditSyslogSettings] = None
+
+
+class AuditSink:
+    """Protocol-like base class for audit sinks."""
+
+    def write(self, payload: str) -> None:  # pragma: no cover - interface method
+        raise NotImplementedError
+
+
+class FileAuditSink(AuditSink):
+    """Persist audit records to a JSONL file on disk."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def bootstrap_hash(self) -> str:
+        """Return the last stored hash from the log file, if any."""
+
+        try:
+            with self._path.open("r", encoding="utf-8") as handle:
+                last_line = ""
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        last_line = line
+        except FileNotFoundError:
+            return "0" * 64
+        except OSError as exc:  # pragma: no cover - unexpected filesystem failure
+            logger.warning("Unable to read audit log %s: %s", self._path, exc)
+            return "0" * 64
+        if not last_line:
+            return "0" * 64
+        try:
+            payload = json.loads(last_line)
+        except json.JSONDecodeError:  # pragma: no cover - corrupted payload
+            logger.error("Encountered invalid JSON in audit log %s", self._path)
+            return "0" * 64
+        return str(payload.get("hash") or "0" * 64)
+
+    def write(self, payload: str) -> None:
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(payload)
+
+
+class S3AuditSink(AuditSink):
+    """Send audit records to an S3 bucket as individual objects."""
+
+    def __init__(self, settings: AuditS3Settings) -> None:
+        try:
+            import boto3  # type: ignore[import]
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "S3 audit offloading requires the 'boto3' package to be installed."
+            ) from exc
+
+        session_kwargs: Dict[str, Any] = {}
+        if settings.profile_name:
+            session_kwargs["profile_name"] = settings.profile_name
+        session = boto3.session.Session(**session_kwargs)
+        client_kwargs: Dict[str, Any] = {"service_name": "s3"}
+        if settings.region_name:
+            client_kwargs["region_name"] = settings.region_name
+        self._client = session.client(**client_kwargs)
+        self._settings = settings
+
+    def write(self, payload: str) -> None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        key_prefix = self._settings.prefix.rstrip("/")
+        if key_prefix:
+            key = f"{key_prefix}/{timestamp}.json"
+        else:
+            key = f"{timestamp}.json"
+        try:
+            self._client.put_object(
+                Bucket=self._settings.bucket,
+                Key=key,
+                Body=payload.encode("utf-8"),
+                ContentType="application/json",
+            )
+        except Exception as exc:  # pragma: no cover - network errors hard to reproduce
+            logger.warning("Failed to offload audit record to S3: %s", exc)
+
+
+class SyslogAuditSink(AuditSink):
+    """Dispatch audit records to a syslog endpoint."""
+
+    def __init__(self, settings: AuditSyslogSettings) -> None:
+        from logging.handlers import SysLogHandler
+
+        self._handler = SysLogHandler(
+            address=(settings.address, int(settings.port)),
+            facility=settings.facility,
+        )
+
+    def write(self, payload: str) -> None:
+        record = logging.LogRecord(
+            name="risk_management.audit",
+            level=logging.INFO,
+            pathname="audit",
+            lineno=0,
+            msg=payload,
+            args=(),
+            exc_info=None,
+        )
+        self._handler.handle(record)
+
+
+class AuditLogWriter:
+    """Append-only audit writer that maintains a hash chain."""
+
+    def __init__(
+        self,
+        *,
+        file_sink: FileAuditSink,
+        redact_fields: Sequence[str],
+        extra_sinks: Sequence[AuditSink] = (),
+    ) -> None:
+        self._file_sink = file_sink
+        self._sinks = [file_sink, *extra_sinks]
+        self._lock = threading.Lock()
+        self._redact_keys = {self._normalise_key(field) for field in redact_fields}
+        self._last_hash = file_sink.bootstrap_hash()
+
+    @staticmethod
+    def _normalise_key(key: str) -> str:
+        return key.replace(" ", "").replace("-", "_").lower()
+
+    def _redact(self, value: Any) -> Any:
+        if isinstance(value, Mapping):
+            redacted: Dict[str, Any] = {}
+            for key, item in value.items():
+                norm_key = self._normalise_key(str(key))
+                if any(field in norm_key for field in self._redact_keys):
+                    redacted[key] = "<redacted>"
+                else:
+                    redacted[key] = self._redact(item)
+            return redacted
+        if isinstance(value, list):
+            return [self._redact(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact(item) for item in value)
+        if isinstance(value, set):
+            return [self._redact(item) for item in value]
+        return value
+
+    def _canonical_payload(self, record: Mapping[str, Any]) -> str:
+        return json.dumps(record, sort_keys=True, separators=(",", ":"))
+
+    def log(self, action: str, actor: str, details: Mapping[str, Any] | None = None) -> str:
+        """Append an audit record and return its hash."""
+
+        if details is None:
+            details = {}
+        timestamp = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            base_record: Dict[str, Any] = {
+                "timestamp": timestamp,
+                "action": str(action),
+                "actor": str(actor),
+                "details": self._redact(dict(details)),
+                "prev_hash": self._last_hash,
+            }
+            canonical = self._canonical_payload(base_record)
+            record_hash = sha256(canonical.encode("utf-8")).hexdigest()
+            base_record["hash"] = record_hash
+            payload = json.dumps(base_record, sort_keys=True) + "\n"
+            for sink in self._sinks:
+                try:
+                    sink.write(payload)
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    logger.warning("Failed to write audit record via %s: %s", type(sink).__name__, exc)
+            self._last_hash = record_hash
+        return record_hash
+
+    @property
+    def log_path(self) -> Path:
+        return self._file_sink.path
+
+
+def iter_audit_entries(path: Path) -> Iterator[Dict[str, Any]]:
+    """Yield parsed audit records from ``path``."""
+
+    try:
+        with Path(path).open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:  # pragma: no cover - corrupted entry
+                    logger.warning("Skipping invalid audit record: %s", line)
+    except FileNotFoundError:
+        return
+
+
+def read_audit_entries(
+    path: Path,
+    *,
+    limit: Optional[int] = None,
+    action: Optional[str] = None,
+    actor: Optional[str] = None,
+) -> list[Dict[str, Any]]:
+    """Return filtered audit entries from ``path`` respecting ``limit``."""
+
+    action_norm = action.lower() if action else None
+    actor_norm = actor.lower() if actor else None
+    results: list[Dict[str, Any]] = []
+    for entry in iter_audit_entries(path):
+        if action_norm and str(entry.get("action", "")).lower() != action_norm:
+            continue
+        if actor_norm and str(entry.get("actor", "")).lower() != actor_norm:
+            continue
+        results.append(entry)
+    if limit is not None:
+        return results[-limit:]
+    return results
+
+
+_audit_registry: Dict[Path, AuditLogWriter] = {}
+_registry_lock = threading.Lock()
+
+
+def reset_audit_registry() -> None:
+    """Reset the cached audit writers. Intended for tests only."""
+
+    with _registry_lock:
+        _audit_registry.clear()
+
+
+def get_audit_logger(settings: Optional[AuditSettings]) -> Optional[AuditLogWriter]:
+    """Return a cached :class:`AuditLogWriter` for ``settings``."""
+
+    if settings is None or not settings.enabled:
+        return None
+    log_path = settings.log_path
+    with _registry_lock:
+        writer = _audit_registry.get(log_path)
+        if writer is not None:
+            return writer
+        extra_sinks: list[AuditSink] = []
+        if settings.s3:
+            try:
+                extra_sinks.append(S3AuditSink(settings.s3))
+            except Exception as exc:
+                logger.warning("Unable to initialise S3 audit sink: %s", exc)
+        if settings.syslog:
+            try:
+                extra_sinks.append(SyslogAuditSink(settings.syslog))
+            except Exception as exc:
+                logger.warning("Unable to initialise syslog audit sink: %s", exc)
+        file_sink = FileAuditSink(log_path)
+        writer = AuditLogWriter(
+            file_sink=file_sink,
+            redact_fields=settings.redact_fields,
+            extra_sinks=tuple(extra_sinks),
+        )
+        _audit_registry[log_path] = writer
+        return writer

--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -32,6 +32,7 @@ from ._parsing import (
     parse_position as _parse_position,
 )
 from .account_clients import AccountClientProtocol, CCXTAccountClient
+from .audit import get_audit_logger
 from .configuration import CustomEndpointSettings, RealtimeConfig
 from .performance import PerformanceTracker
 
@@ -133,7 +134,10 @@ class RealtimeDataFetcher:
                 logger.info(
                     "Debug API payload logging enabled for account %s", account.name
                 )
-        self._notifications = NotificationCoordinator(config)
+        self._notifications = NotificationCoordinator(
+            config,
+            audit_logger=get_audit_logger(config.audit),
+        )
         self._portfolio_stop_loss: Optional[Dict[str, Any]] = None
         self._last_portfolio_balance: Optional[float] = None
         self._account_stop_losses: Dict[str, Dict[str, Any]] = {}

--- a/risk_management/templates/audit/index.html
+++ b/risk_management/templates/audit/index.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block title %}Audit Trail · Risk Management Dashboard{% endblock %}
+
+{% block header_controls %}
+  <a class="button" id="audit-download" data-base-url="{{ request.url_for('audit_download') }}" href="{{ download_url }}">Download log</a>
+{% endblock %}
+
+{% block content %}
+  <section class="panel">
+    <header class="panel__header">
+      <h2>Audit trail</h2>
+    </header>
+    <form method="get" class="form form--inline">
+      <label>
+        <span>Action</span>
+        <input type="text" name="action" value="{{ filters.action }}" placeholder="e.g. kill_switch.global" />
+      </label>
+      <label>
+        <span>User</span>
+        <input type="text" name="actor" value="{{ filters.actor }}" placeholder="dashboard user" />
+      </label>
+      <label>
+        <span>Limit</span>
+        <input type="number" name="limit" min="1" max="5000" value="{{ filters.limit or '' }}" />
+      </label>
+      <button type="submit" class="button">Apply</button>
+    </form>
+    <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Timestamp</th>
+            <th scope="col">User</th>
+            <th scope="col">Action</th>
+            <th scope="col">Details</th>
+            <th scope="col">Hash</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if entries %}
+            {% for entry in entries %}
+              <tr>
+                <td data-label="Timestamp">{{ entry.timestamp }}</td>
+                <td data-label="User">{{ entry.actor }}</td>
+                <td data-label="Action">{{ entry.action }}</td>
+                <td data-label="Details"><pre class="audit-details">{{ entry.details | tojson(indent=2) }}</pre></td>
+                <td data-label="Hash"><code>{{ entry.hash }}</code></td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="5" class="empty">No audit entries available.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    (function () {
+      const downloadLink = document.getElementById('audit-download');
+      if (!downloadLink) {
+        return;
+      }
+      const form = document.querySelector('form');
+      const updateLink = () => {
+        const params = new URLSearchParams(new FormData(form));
+        const baseUrl = downloadLink.dataset.baseUrl || downloadLink.href;
+        const query = params.toString();
+        downloadLink.href = query ? `${baseUrl}?${query}` : baseUrl;
+      };
+      form.addEventListener('change', updateLink);
+      form.addEventListener('submit', updateLink);
+      updateLink();
+    })();
+  </script>
+{% endblock %}

--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -5,18 +5,27 @@ The application exposes REST endpoints and templated views backed by the
 """
 
 from __future__ import annotations
+import json
+import logging
 from collections.abc import Iterable as IterableABC
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from passlib.context import CryptContext
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from starlette.middleware.sessions import SessionMiddleware
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urlencode, urljoin
 
+from .audit import AuditLogWriter, AuditSettings, get_audit_logger, read_audit_entries
 from .configuration import RealtimeConfig
 from .services.risk_service import RiskService, RiskServiceProtocol
 from .reporting import ReportManager
@@ -292,6 +301,55 @@ def create_app(
     if performance_repository is None:
         performance_repository = PerformanceRepository(Path(reports_dir))
     app.state.performance_repository = performance_repository
+    audit_logger = get_audit_logger(config.audit)
+    app.state.audit_logger = audit_logger
+    app.state.audit_settings = config.audit
+    audit_log = logging.getLogger("risk_management.web.audit")
+
+    def emit_audit(
+        request: Request,
+        action: str,
+        details: Mapping[str, Any],
+        *,
+        actor: Optional[str] = None,
+    ) -> None:
+        logger_instance: Optional[AuditLogWriter] = getattr(
+            request.app.state, "audit_logger", None
+        )
+        if not logger_instance:
+            return
+        resolved_actor = actor or request.session.get("user") or "unknown"
+        try:
+            logger_instance.log(action=action, actor=str(resolved_actor), details=dict(details))
+        except Exception as exc:  # pragma: no cover - defensive guard
+            audit_log.warning("Failed to write audit entry '%s': %s", action, exc)
+
+    def resolve_audit_settings(request: Request) -> AuditSettings:
+        settings = getattr(request.app.state, "audit_settings", None)
+        if settings is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Audit logging is not enabled.",
+            )
+        return settings
+
+    def resolve_audit_filters(
+        request: Request,
+        *,
+        default_limit: Optional[int] = None,
+    ) -> tuple[Optional[str], Optional[str], Optional[int]]:
+        params = request.query_params
+        action_filter = params.get("action") or None
+        actor_filter = params.get("actor") or None
+        limit_value: Optional[int] = None
+        limit_raw = params.get("limit")
+        if limit_raw is not None:
+            parsed_limit = _parse_positive_int(limit_raw, "limit", maximum=5000)
+            if parsed_limit is not None:
+                limit_value = parsed_limit
+        elif default_limit is not None:
+            limit_value = default_limit
+        return action_filter, actor_filter, limit_value
 
     def resolve_grafana_context() -> dict[str, Any]:
         grafana_cfg = config.grafana
@@ -764,11 +822,21 @@ def create_app(
 
     @app.post("/api/kill-switch", response_class=JSONResponse)
     async def api_global_kill_switch(
+        request: Request,
         service: RiskDashboardService = Depends(get_service),
-        _: str = Depends(require_user),
+        user: str = Depends(require_user),
     ) -> JSONResponse:
         results = await service.trigger_kill_switch()
         payload = _build_kill_switch_response(results)
+        emit_audit(
+            request,
+            "kill_switch.global",
+            {
+                "success": payload.get("success"),
+                "error_count": len(payload.get("errors", [])),
+            },
+            actor=user,
+        )
         return JSONResponse(payload)
 
     @app.post("/api/accounts/{account_name}/kill-switch", response_class=JSONResponse)
@@ -776,7 +844,7 @@ def create_app(
         request: Request,
         account_name: str,
         service: RiskDashboardService = Depends(get_service),
-        _: str = Depends(require_user),
+        user: str = Depends(require_user),
     ) -> JSONResponse:
         target = account_name.strip()
         symbol = request.query_params.get("symbol")
@@ -792,6 +860,17 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         payload = _build_kill_switch_response(results)
+        emit_audit(
+            request,
+            "kill_switch.account",
+            {
+                "account": target or "all",
+                "symbol": symbol or "all",
+                "success": payload.get("success"),
+                "error_count": len(payload.get("errors", [])),
+            },
+            actor=user,
+        )
         return JSONResponse(payload)
 
     @app.post(
@@ -802,7 +881,7 @@ def create_app(
         account_name: str,
         symbol: str,
         service: RiskDashboardService = Depends(get_service),
-        _: str = Depends(require_user),
+        user: str = Depends(require_user),
     ) -> JSONResponse:
         target_symbol = symbol.strip()
         if not target_symbol:
@@ -815,7 +894,104 @@ def create_app(
         except ValueError as exc:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
         payload = _build_kill_switch_response(results)
+        emit_audit(
+            request,
+            "kill_switch.position",
+            {
+                "account": target_account or "all",
+                "symbol": target_symbol,
+                "success": payload.get("success"),
+                "error_count": len(payload.get("errors", [])),
+            },
+            actor=user,
+        )
         return JSONResponse(payload)
+
+    @app.get("/audit", response_class=HTMLResponse)
+    async def audit_dashboard_view(
+        request: Request,
+        _: str = Depends(require_user),
+    ) -> HTMLResponse:
+        settings = resolve_audit_settings(request)
+        action_filter, actor_filter, limit_value = resolve_audit_filters(
+            request, default_limit=200
+        )
+        entries = read_audit_entries(
+            settings.log_path,
+            action=action_filter,
+            actor=actor_filter,
+            limit=limit_value,
+        )
+        ordered = list(reversed(entries))
+        download_params: dict[str, Any] = {}
+        if action_filter:
+            download_params["action"] = action_filter
+        if actor_filter:
+            download_params["actor"] = actor_filter
+        if limit_value:
+            download_params["limit"] = limit_value
+        download_url = request.url_for("audit_download")
+        if download_params:
+            download_url = f"{download_url}?{urlencode(download_params)}"
+        return templates.TemplateResponse(
+            "audit/index.html",
+            {
+                "request": request,
+                "entries": ordered,
+                "filters": {
+                    "action": action_filter or "",
+                    "actor": actor_filter or "",
+                    "limit": limit_value,
+                },
+                "download_url": download_url,
+            },
+        )
+
+    @app.get("/api/audit", response_class=JSONResponse)
+    async def api_audit_entries(
+        request: Request,
+        _: str = Depends(require_user),
+    ) -> JSONResponse:
+        settings = resolve_audit_settings(request)
+        action_filter, actor_filter, limit_value = resolve_audit_filters(
+            request, default_limit=200
+        )
+        entries = read_audit_entries(
+            settings.log_path,
+            action=action_filter,
+            actor=actor_filter,
+            limit=limit_value,
+        )
+        payload = {
+            "entries": list(reversed(entries)),
+            "filters": {
+                "action": action_filter,
+                "actor": actor_filter,
+                "limit": limit_value,
+            },
+        }
+        return JSONResponse(payload)
+
+    @app.get("/audit/download", response_class=PlainTextResponse)
+    async def audit_download(
+        request: Request,
+        _: str = Depends(require_user),
+    ) -> PlainTextResponse:
+        settings = resolve_audit_settings(request)
+        action_filter, actor_filter, limit_value = resolve_audit_filters(request)
+        entries = read_audit_entries(
+            settings.log_path,
+            action=action_filter,
+            actor=actor_filter,
+            limit=limit_value,
+        )
+        lines = [json.dumps(entry, sort_keys=True) for entry in entries]
+        content = "\n".join(lines)
+        if content:
+            content += "\n"
+        response = PlainTextResponse(content, media_type="application/jsonl")
+        response.headers["Content-Disposition"] = "attachment; filename=audit-log.jsonl"
+        return response
 
     @app.get("/api/accounts/{account_name}/reports", response_class=JSONResponse)
     async def api_list_reports(

--- a/tests/risk_management/test_audit.py
+++ b/tests/risk_management/test_audit.py
@@ -1,0 +1,71 @@
+import json
+import hashlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from risk_management.audit import (
+    AuditSettings,
+    get_audit_logger,
+    reset_audit_registry,
+)
+
+
+def test_audit_log_hash_chain(tmp_path):
+    reset_audit_registry()
+    log_path = tmp_path / "audit.log"
+    settings = AuditSettings(log_path=log_path)
+
+    writer = get_audit_logger(settings)
+    assert writer is not None
+
+    first_hash = writer.log("event.one", "alice", {"foo": "bar"})
+    second_hash = writer.log("event.two", "bob", {"foo": "baz"})
+
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    assert payloads[0]["hash"] == first_hash
+    assert payloads[1]["hash"] == second_hash
+    assert payloads[1]["prev_hash"] == payloads[0]["hash"]
+
+    canonical = json.dumps(
+        {
+            "timestamp": payloads[0]["timestamp"],
+            "action": payloads[0]["action"],
+            "actor": payloads[0]["actor"],
+            "details": payloads[0]["details"],
+            "prev_hash": payloads[0]["prev_hash"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    assert payloads[0]["hash"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def test_audit_log_redacts_sensitive_fields(tmp_path):
+    reset_audit_registry()
+    log_path = tmp_path / "audit.log"
+    settings = AuditSettings(log_path=log_path, redact_fields=("token", "password"))
+
+    writer = get_audit_logger(settings)
+    assert writer is not None
+
+    writer.log(
+        "event.redact",
+        "system",
+        {
+            "token": "should-hide",
+            "nested": {"password": "super-secret", "other": "visible"},
+            "list": [{"apiToken": "secret"}],
+        },
+    )
+
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+    assert payloads
+    details = payloads[0]["details"]
+    assert details["token"] == "<redacted>"
+    assert details["nested"]["password"] == "<redacted>"
+    assert details["nested"]["other"] == "visible"
+    assert details["list"][0]["apiToken"] == "<redacted>"


### PR DESCRIPTION
## Summary
- add an append-only audit log writer with optional S3/syslog sinks and registry helpers
- integrate audit logging into realtime configuration loading, notifications, kill switch endpoints, and web server startup
- expose audit dashboard views, API/download endpoints, and tests covering log integrity, redaction, and UI flows

## Testing
- pytest tests/risk_management/test_audit.py
- pytest tests/risk_management/test_configuration.py::test_load_realtime_config_parses_audit_settings
- pytest tests/test_risk_management_web.py


------
https://chatgpt.com/codex/tasks/task_b_6901a42fb0348323af6cb2f097adcd43