### PR TITLE
Add liquidity analytics and order book insights to risk dashboard

### DIFF
--- a/risk_management/dashboard.py
+++ b/risk_management/dashboard.py
@@ -59,6 +59,48 @@ def _parse_position(raw: Dict[str, Any]) -> Position:
 
     size_raw = raw.get("size")
     signed_notional_raw = raw.get("signed_notional")
+    volatility = (
+        {str(key): float(value) for key, value in raw.get("volatility", {}).items()}
+        if isinstance(raw.get("volatility"), Mapping)
+        else None
+    )
+    funding_rates = (
+        {str(key): float(value) for key, value in raw.get("funding_rates", {}).items()}
+        if isinstance(raw.get("funding_rates"), Mapping)
+        else None
+    )
+    liquidity_raw = raw.get("liquidity") if isinstance(raw.get("liquidity"), Mapping) else None
+    liquidity: Optional[Dict[str, Any]] = None
+    liquidity_warnings: List[str] = []
+    if isinstance(liquidity_raw, Mapping):
+        liquidity = {}
+        for key, value in liquidity_raw.items():
+            if key == "warnings" and isinstance(value, Iterable):
+                liquidity_warnings = [str(item) for item in value if isinstance(item, str)]
+                liquidity["warnings"] = list(liquidity_warnings)
+                continue
+            if key in {
+                "filled_size",
+                "filled_notional",
+                "average_price",
+                "slippage_pct",
+                "unfilled_size",
+                "coverage_pct",
+                "reference_price",
+                "warning_threshold_pct",
+                "timestamp",
+            }:
+                try:
+                    liquidity[key] = float(value) if value is not None else None
+                except (TypeError, ValueError):
+                    liquidity[key] = None
+            else:
+                liquidity[key] = value
+    extra_warnings = raw.get("liquidity_warnings")
+    if isinstance(extra_warnings, Iterable):
+        for warning in extra_warnings:
+            if isinstance(warning, str) and warning not in liquidity_warnings:
+                liquidity_warnings.append(warning)
     return Position(
         symbol=str(raw["symbol"]),
         side=str(raw.get("side", "")),
@@ -97,17 +139,11 @@ def _parse_position(raw: Dict[str, Any]) -> Position:
             if signed_notional_raw not in (None, "")
             else None
         ),
-        volatility=(
-            {str(key): float(value) for key, value in raw.get("volatility", {}).items()}
-            if isinstance(raw.get("volatility"), Mapping)
-            else None
-        ),
-        funding_rates=(
-            {str(key): float(value) for key, value in raw.get("funding_rates", {}).items()}
-            if isinstance(raw.get("funding_rates"), Mapping)
-            else None
-        ),
+        volatility=volatility,
+        funding_rates=funding_rates,
         daily_realized_pnl=float(raw.get("daily_realized_pnl", 0.0)),
+        liquidity=liquidity,
+        liquidity_warnings=tuple(liquidity_warnings),
     )
 
 
@@ -227,6 +263,63 @@ def evaluate_alerts(accounts: Sequence[Account], thresholds: AlertThresholds) ->
                 alerts.append(
                     f"{account.name} {position.symbol}: drawdown {position.max_drawdown_pct:.2%} exceeds {thresholds.max_drawdown_pct:.2%}"
                 )
+            liquidity = position.liquidity or {}
+            raw_warnings = list(position.liquidity_warnings)
+            if isinstance(liquidity, Mapping):
+                warning_entries = liquidity.get("warnings")
+                if isinstance(warning_entries, Iterable):
+                    raw_warnings.extend([str(item) for item in warning_entries if isinstance(item, str)])
+            seen: set[str] = set()
+            for warning in raw_warnings:
+                if warning in seen:
+                    continue
+                seen.add(warning)
+                if warning == "depth_unavailable":
+                    alerts.append(
+                        f"{account.name} {position.symbol}: order book depth unavailable; liquidity estimates rely on fallbacks"
+                    )
+                elif warning == "insufficient_depth":
+                    coverage = None
+                    if isinstance(liquidity, Mapping):
+                        coverage = liquidity.get("coverage_pct")
+                        if isinstance(coverage, (int, float)):
+                            coverage = float(coverage)
+                    if isinstance(coverage, float):
+                        alerts.append(
+                            f"{account.name} {position.symbol}: order book covers only {coverage:.0%} of position size"
+                        )
+                    else:
+                        alerts.append(
+                            f"{account.name} {position.symbol}: insufficient order book depth to exit position"
+                        )
+                elif warning == "slippage_threshold_exceeded":
+                    slippage = None
+                    threshold_value = None
+                    if isinstance(liquidity, Mapping):
+                        slippage = liquidity.get("slippage_pct")
+                        threshold_value = liquidity.get("warning_threshold_pct")
+                    slippage_str = None
+                    if isinstance(slippage, (int, float)):
+                        slippage_str = f"{float(slippage):.2%}"
+                    threshold_str = None
+                    if isinstance(threshold_value, (int, float)):
+                        threshold_str = f"{float(threshold_value):.2%}"
+                    if slippage_str and threshold_str:
+                        alerts.append(
+                            f"{account.name} {position.symbol}: estimated slippage {slippage_str} exceeds threshold {threshold_str}"
+                        )
+                    elif slippage_str:
+                        alerts.append(
+                            f"{account.name} {position.symbol}: estimated slippage {slippage_str} exceeds configured threshold"
+                        )
+                    else:
+                        alerts.append(
+                            f"{account.name} {position.symbol}: estimated slippage exceeds configured threshold"
+                        )
+                elif warning == "position_size_undefined":
+                    alerts.append(
+                        f"{account.name} {position.symbol}: unable to determine position size for liquidity analysis"
+                    )
     return alerts
 
 
@@ -277,6 +370,30 @@ def render_dashboard(
                     + f"{_format_pct(position.max_drawdown_pct or 0.0):>10}"
                     + f"{_format_price(position.take_profit_price):>12}{_format_price(position.stop_loss_price):>12}"
                 )
+                liquidity = position.liquidity if isinstance(position.liquidity, Mapping) else None
+                if liquidity:
+                    details: List[str] = []
+                    coverage = liquidity.get("coverage_pct")
+                    if isinstance(coverage, (int, float)):
+                        details.append(f"coverage {float(coverage):.0%}")
+                    slippage = liquidity.get("slippage_pct")
+                    if isinstance(slippage, (int, float)):
+                        details.append(f"slippage {float(slippage):.2%}")
+                    average_price = liquidity.get("average_price")
+                    if isinstance(average_price, (int, float)):
+                        details.append(f"avg {float(average_price):,.2f}")
+                    source = liquidity.get("source")
+                    if isinstance(source, str) and source:
+                        details.append(f"source {source}")
+                    if details:
+                        lines.append("      Liquidity: " + ", ".join(details))
+                    warnings = list(position.liquidity_warnings)
+                    warning_entries = liquidity.get("warnings")
+                    if isinstance(warning_entries, Iterable):
+                        warnings.extend([str(item) for item in warning_entries if isinstance(item, str)])
+                    if warnings:
+                        unique = list(dict.fromkeys(warnings))
+                        lines.append("      Liquidity warnings: " + ", ".join(unique))
         else:
             lines.append("    No open positions.")
         lines.append("")

--- a/risk_management/domain/models.py
+++ b/risk_management/domain/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 
 @dataclass
@@ -26,6 +26,8 @@ class Position:
     volatility: Optional[Mapping[str, float]] = None
     funding_rates: Optional[Mapping[str, float]] = None
     daily_realized_pnl: float = 0.0
+    liquidity: Optional[Mapping[str, Any]] = None
+    liquidity_warnings: Sequence[str] = ()
 
     def exposure_relative_to(self, balance: float) -> float:
         if balance == 0:

--- a/risk_management/liquidity.py
+++ b/risk_management/liquidity.py
@@ -1,0 +1,212 @@
+"""Utilities for analysing order-book liquidity and slippage."""
+
+from __future__ import annotations
+
+"""Utilities for analysing order-book liquidity and slippage."""
+
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+__all__ = ["normalise_order_book", "calculate_position_liquidity"]
+
+
+def _to_float(value: Any) -> Optional[float]:
+    """Attempt to coerce ``value`` to ``float`` returning ``None`` on failure."""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        try:
+            return float(candidate)
+        except (TypeError, ValueError):
+            return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_side(levels: Any, depth: Optional[int]) -> List[Tuple[float, float]]:
+    """Return a normalised ``[(price, size), ...]`` list for an order-book side."""
+
+    if not isinstance(levels, Iterable):
+        return []
+    normalised: List[Tuple[float, float]] = []
+    for level in levels:
+        price: Optional[float] = None
+        amount: Optional[float] = None
+        if isinstance(level, Mapping):
+            price = _to_float(level.get("price"))
+            amount = _to_float(level.get("amount")) or _to_float(level.get("size"))
+        elif isinstance(level, Sequence):
+            sequence: Sequence[Any] = level
+            if len(sequence) >= 2:
+                price = _to_float(sequence[0])
+                amount = _to_float(sequence[1])
+        if price is None or amount is None:
+            continue
+        if amount <= 0:
+            continue
+        normalised.append((price, amount))
+        if depth is not None and depth > 0 and len(normalised) >= depth:
+            break
+    return normalised
+
+
+def normalise_order_book(
+    order_book: Mapping[str, Any], *, depth: Optional[int] = None
+) -> Optional[MutableMapping[str, Any]]:
+    """Normalise a ccxt style order-book payload."""
+
+    if not isinstance(order_book, Mapping):
+        return None
+
+    bids = _normalise_side(order_book.get("bids"), depth)
+    asks = _normalise_side(order_book.get("asks"), depth)
+    if not bids and not asks:
+        return None
+
+    timestamp = _to_float(order_book.get("timestamp"))
+    datetime_raw = order_book.get("datetime")
+    datetime_value = str(datetime_raw) if isinstance(datetime_raw, str) and datetime_raw else None
+
+    payload: MutableMapping[str, Any] = {
+        "bids": [[price, size] for price, size in bids],
+        "asks": [[price, size] for price, size in asks],
+        "timestamp": timestamp,
+    }
+    if datetime_value:
+        payload["datetime"] = datetime_value
+    if bids:
+        payload["best_bid"] = bids[0][0]
+    if asks:
+        payload["best_ask"] = asks[0][0]
+    payload["depth"] = {"bids": len(bids), "asks": len(asks)}
+    return payload
+
+
+def _resolve_reference_price(position: Mapping[str, Any], fallback: Optional[float]) -> Optional[float]:
+    for key in ("mark_price", "markPrice", "mark", "last", "last_price"):
+        value = position.get(key)
+        price = _to_float(value)
+        if price:
+            return price
+    for key in ("entry_price", "entryPrice", "entry"):
+        value = position.get(key)
+        price = _to_float(value)
+        if price:
+            return price
+    return fallback
+
+
+def calculate_position_liquidity(
+    position: Mapping[str, Any],
+    order_book: Optional[Mapping[str, Any]],
+    *,
+    fallback_price: Optional[float] = None,
+    warning_threshold: float = 0.02,
+) -> MutableMapping[str, Any]:
+    """Estimate liquidity metrics for ``position`` using ``order_book``."""
+
+    size = _to_float(position.get("size"))
+    notional = _to_float(position.get("notional"))
+    reference_price = _resolve_reference_price(position, fallback_price)
+
+    if size is None or size == 0:
+        if reference_price and reference_price > 0 and notional:
+            size = abs(notional / reference_price)
+        elif notional and reference_price is None:
+            reference_price = _to_float(position.get("mark_price")) or _to_float(
+                position.get("entry_price")
+            )
+            if reference_price:
+                size = abs(notional / reference_price) if reference_price else None
+    if size is None or size <= 0:
+        return {
+            "filled_size": 0.0,
+            "filled_notional": 0.0,
+            "average_price": None,
+            "slippage_pct": None,
+            "unfilled_size": 0.0,
+            "coverage_pct": 0.0,
+            "reference_price": reference_price,
+            "warnings": ["position_size_undefined"],
+            "source": "unavailable",
+            "warning_threshold_pct": warning_threshold,
+        }
+
+    position_size = abs(size)
+    side = str(position.get("side", "")).lower()
+    exit_side = "sell" if side == "long" else "buy"
+
+    coverage_pct = 0.0
+    filled_size = 0.0
+    filled_notional = 0.0
+    slippage_pct: Optional[float] = None
+    average_price: Optional[float] = None
+    warnings: List[str] = []
+    source = "order_book"
+
+    if order_book and isinstance(order_book, Mapping):
+        levels_key = "bids" if exit_side == "sell" else "asks"
+        levels = order_book.get(levels_key)
+        normalised_levels = _normalise_side(levels, None)
+        for price, available in normalised_levels:
+            take = min(available, position_size - filled_size)
+            if take <= 0:
+                break
+            filled_size += take
+            filled_notional += take * price
+        if filled_size > 0:
+            average_price = filled_notional / filled_size
+            if reference_price is None:
+                reference_price = normalised_levels[0][0]
+            coverage_pct = min(1.0, filled_size / position_size)
+            if reference_price and reference_price > 0 and average_price is not None:
+                slippage_pct = (average_price - reference_price) / reference_price
+        else:
+            coverage_pct = 0.0
+            warnings.append("depth_unavailable")
+        if filled_size < position_size:
+            warnings.append("insufficient_depth")
+        unfilled_size = max(0.0, position_size - filled_size)
+        timestamp = order_book.get("timestamp") if isinstance(order_book, Mapping) else None
+        datetime_value = order_book.get("datetime") if isinstance(order_book, Mapping) else None
+    else:
+        unfilled_size = position_size
+        source = "fallback" if fallback_price is not None else "unavailable"
+        warnings.append("depth_unavailable")
+        timestamp = None
+        datetime_value = None
+        if fallback_price is not None:
+            average_price = fallback_price
+            reference_price = reference_price or fallback_price
+            coverage_pct = 0.0
+    if slippage_pct is not None and abs(slippage_pct) >= warning_threshold:
+        warnings.append("slippage_threshold_exceeded")
+
+    payload: MutableMapping[str, Any] = {
+        "filled_size": float(filled_size),
+        "filled_notional": float(filled_notional),
+        "average_price": average_price,
+        "slippage_pct": slippage_pct,
+        "unfilled_size": float(unfilled_size),
+        "coverage_pct": float(coverage_pct),
+        "reference_price": reference_price,
+        "warnings": warnings,
+        "side": exit_side,
+        "source": source,
+        "warning_threshold_pct": warning_threshold,
+    }
+    if timestamp is not None:
+        payload["timestamp"] = timestamp
+    if datetime_value:
+        payload["datetime"] = datetime_value
+    return payload

--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -364,6 +364,29 @@ def _build_account_view(
 def _build_position_view(position: Position, balance: float) -> Dict[str, Any]:
     exposure = position.exposure_relative_to(balance)
     pnl_pct = position.pnl_pct(balance)
+    liquidity = position.liquidity if isinstance(position.liquidity, Mapping) else None
+    liquidity_warnings = list(position.liquidity_warnings) if position.liquidity_warnings else []
+    if liquidity:
+        warnings = liquidity.get("warnings")
+        if isinstance(warnings, Iterable):
+            liquidity_warnings.extend([str(item) for item in warnings if isinstance(item, str)])
+    coverage_pct = None
+    slippage_pct = None
+    average_price = None
+    source = None
+    if liquidity:
+        coverage = liquidity.get("coverage_pct")
+        if isinstance(coverage, (int, float)):
+            coverage_pct = float(coverage)
+        slippage = liquidity.get("slippage_pct")
+        if isinstance(slippage, (int, float)):
+            slippage_pct = float(slippage)
+        avg = liquidity.get("average_price")
+        if isinstance(avg, (int, float)):
+            average_price = float(avg)
+        src = liquidity.get("source")
+        if isinstance(src, str):
+            source = src
     return {
         "symbol": position.symbol,
         "side": position.side,
@@ -383,6 +406,12 @@ def _build_position_view(position: Position, balance: float) -> Dict[str, Any]:
         "daily_realized_pnl": position.daily_realized_pnl,
         "volatility": dict(position.volatility) if position.volatility else {},
         "funding_rates": dict(position.funding_rates) if position.funding_rates else {},
+        "liquidity": dict(liquidity) if isinstance(liquidity, Mapping) else {},
+        "liquidity_warnings": liquidity_warnings,
+        "liquidity_coverage_pct": coverage_pct,
+        "liquidity_slippage_pct": slippage_pct,
+        "liquidity_average_price": average_price,
+        "liquidity_source": source,
     }
 
 

--- a/risk_management/templates/dashboard/index.html
+++ b/risk_management/templates/dashboard/index.html
@@ -497,6 +497,10 @@
                       <th>Max DD</th>
                       <th>TP</th>
                       <th>SL</th>
+                      <th>Depth coverage</th>
+                      <th>Est. slippage</th>
+                      <th>Avg exit</th>
+                      <th>Liquidity warnings</th>
                       <th>Vol 4h</th>
                       <th>Vol 24h</th>
                       <th>Vol 3d</th>
@@ -525,6 +529,10 @@
                         <td>{% if position.max_drawdown_pct is not none %}{{ position.max_drawdown_pct|pct }}{% else %}-{% endif %}</td>
                         <td>{% if position.take_profit_price is not none %}{{ position.take_profit_price|currency }}{% else %}-{% endif %}</td>
                         <td>{% if position.stop_loss_price is not none %}{{ position.stop_loss_price|currency }}{% else %}-{% endif %}</td>
+                        <td>{% if position.liquidity_coverage_pct is not none %}{{ position.liquidity_coverage_pct|pct }}{% else %}-{% endif %}</td>
+                        <td>{% if position.liquidity_slippage_pct is not none %}{{ position.liquidity_slippage_pct|pct }}{% else %}-{% endif %}</td>
+                        <td>{% if position.liquidity_average_price is not none %}{{ position.liquidity_average_price|currency }}{% else %}-{% endif %}</td>
+                        <td>{% if position.liquidity_warnings %}{{ position.liquidity_warnings|join(', ') }}{% else %}-{% endif %}</td>
                         <td>{% if position_vol and position_vol.get("4h") is not none %}{{ position_vol.get("4h")|pct }}{% else %}-{% endif %}</td>
                         <td>{% if position_vol and position_vol.get("24h") is not none %}{{ position_vol.get("24h")|pct }}{% else %}-{% endif %}</td>
                         <td>{% if position_vol and position_vol.get("3d") is not none %}{{ position_vol.get("3d")|pct }}{% else %}-{% endif %}</td>
@@ -802,6 +810,10 @@
                 <th>Max DD</th>
                 <th>TP</th>
                 <th>SL</th>
+                <th>Depth coverage</th>
+                <th>Est. slippage</th>
+                <th>Avg exit</th>
+                <th>Liquidity warnings</th>
                 <th>Actions</th>
               </tr>
             </thead>
@@ -1347,6 +1359,10 @@
                 <td>${maxDrawdown}</td>
                 <td>${takeProfit}</td>
                 <td>${stopLossPrice}</td>
+                <td>${position.liquidity_coverage_pct !== null && position.liquidity_coverage_pct !== undefined ? formatPct(position.liquidity_coverage_pct) : "-"}</td>
+                <td>${position.liquidity_slippage_pct !== null && position.liquidity_slippage_pct !== undefined ? formatPct(position.liquidity_slippage_pct) : "-"}</td>
+                <td>${position.liquidity_average_price !== null && position.liquidity_average_price !== undefined ? formatCurrency(position.liquidity_average_price) : "-"}</td>
+                <td>${Array.isArray(position.liquidity_warnings) && position.liquidity_warnings.length > 0 ? position.liquidity_warnings.join(", ") : "-"}</td>
                 <td>
                   <div class="actions-column">
                     <button type="button" class="button danger small" data-close-position data-symbol="${position.symbol}">Close</button>
@@ -2085,6 +2101,10 @@
                   <td>${maxDd}</td>
                   <td>${formatPrice(position.take_profit_price)}</td>
                   <td>${formatPrice(position.stop_loss_price)}</td>
+                  <td>${position.liquidity_coverage_pct !== null && position.liquidity_coverage_pct !== undefined ? formatPct(position.liquidity_coverage_pct) : "-"}</td>
+                  <td>${position.liquidity_slippage_pct !== null && position.liquidity_slippage_pct !== undefined ? formatPct(position.liquidity_slippage_pct) : "-"}</td>
+                  <td>${position.liquidity_average_price !== null && position.liquidity_average_price !== undefined ? formatCurrency(position.liquidity_average_price) : "-"}</td>
+                  <td>${Array.isArray(position.liquidity_warnings) && position.liquidity_warnings.length > 0 ? position.liquidity_warnings.join(", ") : "-"}</td>
                   ${METRIC_WINDOWS.map((window) => `<td>${formatMetricValue(volatility?.[window])}</td>`).join("")}
                   ${METRIC_WINDOWS.map((window) => `<td>${formatMetricValue(funding?.[window])}</td>`).join("")}
                   <td>
@@ -2169,6 +2189,10 @@
                         <th>Max DD</th>
                         <th>TP</th>
                         <th>SL</th>
+                        <th>Depth coverage</th>
+                        <th>Est. slippage</th>
+                        <th>Avg exit</th>
+                        <th>Liquidity warnings</th>
                         ${METRIC_WINDOWS.map((window) => `<th>Vol ${window}</th>`).join("")}
                         ${METRIC_WINDOWS.map((window) => `<th>Fund ${window}</th>`).join("")}
                         <th>Actions</th>

--- a/tests/test_risk_management_liquidity.py
+++ b/tests/test_risk_management_liquidity.py
@@ -1,0 +1,46 @@
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from risk_management.liquidity import calculate_position_liquidity, normalise_order_book
+
+
+def test_normalise_order_book_trims_levels():
+    raw = {
+        "bids": [["1000", "1"], ["bad", "data"], [995, 2]],
+        "asks": [[1010, 3]],
+        "timestamp": 111,
+    }
+    snapshot = normalise_order_book(raw, depth=2)
+    assert snapshot is not None
+    assert snapshot["bids"] == [[1000.0, 1.0], [995.0, 2.0]]
+    assert snapshot["best_bid"] == 1000.0
+    assert snapshot["best_ask"] == 1010.0
+    assert snapshot["depth"] == {"bids": 2, "asks": 1}
+
+
+def test_calculate_liquidity_warns_for_thin_books():
+    position = {
+        "symbol": "BTC/USDT",
+        "side": "LONG",
+        "size": 5,
+        "notional": 5000,
+        "mark_price": 1000,
+    }
+    order_book = {
+        "bids": [[920, 2], [900, 1]],
+        "asks": [[1080, 5]],
+    }
+    metrics = calculate_position_liquidity(position, order_book, warning_threshold=0.01)
+    assert math.isclose(metrics["filled_size"], 3.0)
+    assert math.isclose(metrics["coverage_pct"], 0.6)
+    assert "insufficient_depth" in metrics["warnings"]
+    assert "slippage_threshold_exceeded" in metrics["warnings"]
+    assert metrics["slippage_pct"] < 0
+    assert metrics["average_price"] == pytest.approx((920 * 2 + 900) / 3)


### PR DESCRIPTION
## Summary
- add reusable liquidity utilities to normalise order books and estimate executable size, slippage, and warnings
- fetch order-book depth in account clients with configurable liquidity settings and embed metrics into realtime snapshots
- surface liquidity coverage/slippage in the CLI and web dashboards and extend tests to cover thin book scenarios

## Testing
- pytest tests/test_risk_management_liquidity.py tests/test_risk_management_account_clients.py

------
https://chatgpt.com/codex/tasks/task_b_6901a419ba408323bd065ae60b052567