### PR TITLE
Fix realtime risk config JSON structure

### DIFF
--- a/risk_management/realtime_config.json
+++ b/risk_management/realtime_config.json
@@ -1,8 +1,8 @@
 {
-  "api_keys_file": "/root/passivbot/api-keys.json",
+  "api_keys_file": "../api-keys.json",
   "debug_api_payloads": false,
   "custom_endpoints": {
-    "path": "/root/passivbot/configs/custom_endpoints.json",
+    "path": "../configs/custom_endpoints.json",
     "autodiscover": false
   },
   "reports_dir": "../risk_reports",
@@ -120,6 +120,8 @@
         "instructions": "Escalate to exchange coverage before overriding the balance floor.",
         "expires_after_seconds": 7200
       }
+    }
+  ],
 
   "scenarios": [
     {


### PR DESCRIPTION
## Summary
- repair the realtime risk configuration JSON so policy blocks are properly closed
- use repository-relative paths for API keys and custom endpoint configuration to support different deployment locations

## Testing
- pytest tests/test_risk_management_web.py
- pytest tests/risk_management/test_risk_dashboard_service.py

------
https://chatgpt.com/codex/tasks/task_b_6901acca94f88323846763105135aba3