### PR TITLE
Gracefully skip invalid accounts when parsing risk snapshots

### DIFF
--- a/risk_management/dashboard.py
+++ b/risk_management/dashboard.py
@@ -254,7 +254,7 @@ def _parse_position(raw: Dict[str, Any]) -> Position:
     )
 
 
-def _parse_account(raw: Dict[str, Any]) -> Account:
+def _parse_account(raw: Mapping[str, Any]) -> Account:
     if "name" not in raw or "balance" not in raw:
         raise ValueError("Account entries must include 'name' and 'balance'.")
 
@@ -349,7 +349,31 @@ def parse_snapshot(data: Dict[str, Any]) -> tuple[datetime, Sequence[Account], A
     else:
         generated_at = datetime.now(timezone.utc)
 
-    accounts = [_parse_account(acc) for acc in data.get("accounts", [])]
+    accounts: List[Account] = []
+    accounts_raw = data.get("accounts", [])
+    if not isinstance(accounts_raw, Iterable):
+        accounts_raw = []
+
+    for index, raw_account in enumerate(accounts_raw):
+        if not isinstance(raw_account, Mapping):
+            logger.warning(
+                "Skipping account at index %s because entry is not a mapping: %r",
+                index,
+                raw_account,
+            )
+            continue
+        try:
+            account = _parse_account(raw_account)
+        except (TypeError, ValueError) as exc:
+            name = raw_account.get("name", "<unknown>")
+            logger.warning(
+                "Skipping account %s at index %s due to parse error: %s",
+                name,
+                index,
+                exc,
+            )
+            continue
+        accounts.append(account)
     thresholds = _parse_thresholds(data.get("alert_thresholds", {}))
     notifications = [str(channel) for channel in data.get("notification_channels", [])]
     return generated_at, accounts, thresholds, notifications

--- a/tests/risk_management/test_dashboard_snapshot_parsing.py
+++ b/tests/risk_management/test_dashboard_snapshot_parsing.py
@@ -1,0 +1,57 @@
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from risk_management.dashboard import parse_snapshot
+from risk_management.domain.models import AlertThresholds
+
+
+def test_parse_snapshot_skips_accounts_missing_required_fields(caplog):
+    generated_at = "2024-07-01T12:00:00Z"
+    snapshot = {
+        "generated_at": generated_at,
+        "accounts": [
+            {},
+            {"name": "incomplete"},
+            {
+                "name": "valid",
+                "balance": 1000,
+                "positions": [],
+                "open_orders": [],
+            },
+        ],
+        "alert_thresholds": {},
+        "notification_channels": ["email"],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        parsed_generated_at, accounts, thresholds, notifications = parse_snapshot(snapshot)
+
+    assert parsed_generated_at == datetime(2024, 7, 1, 12, 0, tzinfo=timezone.utc)
+    assert len(accounts) == 1
+    assert accounts[0].name == "valid"
+    defaults = AlertThresholds()
+    assert thresholds.wallet_exposure_pct == defaults.wallet_exposure_pct
+    assert notifications == ["email"]
+
+    messages = "".join(record.message for record in caplog.records)
+    assert "Skipping account" in messages
+
+
+def test_parse_snapshot_ignores_non_mapping_accounts(caplog):
+    snapshot = {
+        "generated_at": "2024-07-01T12:00:00Z",
+        "accounts": ["not-a-dict", []],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _, accounts, _, _ = parse_snapshot(snapshot)
+
+    assert accounts == []
+    messages = "".join(record.message for record in caplog.records)
+    assert "not a mapping" in messages


### PR DESCRIPTION
## Summary
- skip malformed account entries when parsing risk snapshots instead of raising
- log skipped entries and cover the behaviour with snapshot parsing tests

## Testing
- pytest tests/risk_management/test_dashboard_snapshot_parsing.py

------
https://chatgpt.com/codex/tasks/task_b_69062b1f66e08323839b4ee1424ef103