### PR TITLE
Improve validation of accounts collections in snapshot parsing

### DIFF
--- a/tests/risk_management/test_dashboard_snapshot_parsing.py
+++ b/tests/risk_management/test_dashboard_snapshot_parsing.py
@@ -1,0 +1,68 @@
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from risk_management.dashboard import parse_snapshot
+from risk_management.domain.models import AlertThresholds
+
+
+def test_parse_snapshot_skips_accounts_missing_required_fields(caplog):
+    generated_at = "2024-07-01T12:00:00Z"
+    snapshot = {
+        "generated_at": generated_at,
+        "accounts": [
+            {},
+            {"name": "incomplete"},
+            {
+                "name": "valid",
+                "balance": 1000,
+                "positions": [],
+                "open_orders": [],
+            },
+        ],
+        "alert_thresholds": {},
+        "notification_channels": ["email"],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        parsed_generated_at, accounts, thresholds, notifications = parse_snapshot(snapshot)
+
+    assert parsed_generated_at == datetime(2024, 7, 1, 12, 0, tzinfo=timezone.utc)
+    assert len(accounts) == 1
+    assert accounts[0].name == "valid"
+    defaults = AlertThresholds()
+    assert thresholds.wallet_exposure_pct == defaults.wallet_exposure_pct
+    assert notifications == ["email"]
+
+    assert any("Skipping account" in message for message in caplog.messages)
+
+
+def test_parse_snapshot_ignores_non_mapping_accounts(caplog):
+    snapshot = {
+        "generated_at": "2024-07-01T12:00:00Z",
+        "accounts": ["not-a-dict", []],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _, accounts, _, _ = parse_snapshot(snapshot)
+
+    assert accounts == []
+    assert any("not a mapping" in message for message in caplog.messages)
+
+
+def test_parse_snapshot_logs_when_accounts_payload_not_iterable(caplog):
+    snapshot = {
+        "generated_at": "2024-07-01T12:00:00Z",
+        "accounts": "invalid",
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _, accounts, _, _ = parse_snapshot(snapshot)
+
+    assert accounts == []
+    assert any("not an iterable of mappings" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- treat non-iterable account payloads as invalid and log a warning instead of iterating character by character
- extend snapshot parsing tests to cover malformed account collections and tighten log assertions

## Testing
- pytest tests/risk_management/test_dashboard_snapshot_parsing.py
- python -m risk_management.web_server --config risk_management/realtime_config.json --host 0.0.0.0 --port 8000 *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_69062b1f66e08323839b4ee1424ef103