### PR TITLE
Fix snapshot parsing and Binance order book depth handling

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -70,6 +70,42 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover - allow running w
 logger = logging.getLogger(__name__)
 
 
+def _normalise_order_book_depth(exchange: str, requested: int) -> int:
+    """Return a depth limit supported by the exchange."""
+
+    allowed_depths_map = {
+        "binance": (5, 10, 20, 50, 100, 500, 1000),
+        "binanceusdm": (5, 10, 20, 50, 100, 500, 1000),
+        "binancecoinm": (5, 10, 20, 50, 100, 500, 1000),
+    }
+
+    allowed_depths = allowed_depths_map.get(exchange.lower())
+    if not allowed_depths:
+        return max(requested, 1)
+
+    if requested <= 0:
+        return allowed_depths[0]
+
+    for depth in allowed_depths:
+        if requested <= depth:
+            if requested != depth:
+                logger.debug(
+                    "Normalising unsupported order book depth %s to %s for %s",
+                    requested,
+                    depth,
+                    exchange,
+                )
+            return depth
+
+    logger.debug(
+        "Normalising unsupported order book depth %s to %s for %s",
+        requested,
+        allowed_depths[-1],
+        exchange,
+    )
+    return allowed_depths[-1]
+
+
 class AccountClientProtocol(abc.ABC):
     """Abstract interface for realtime account clients."""
 
@@ -527,7 +563,9 @@ class CCXTAccountClient(AccountClientProtocol):
         settings = self._liquidity_settings
         if not getattr(settings, "fetch_order_book", True):
             return metrics
-        depth = getattr(settings, "depth", 25) or 25
+        raw_depth = getattr(settings, "depth", 25)
+        depth = _coerce_int(raw_depth) or 25
+        depth = _normalise_order_book_depth(self._normalized_exchange, depth)
         for symbol in dict.fromkeys(symbols):
             if not symbol:
                 continue

--- a/risk_management/dashboard.py
+++ b/risk_management/dashboard.py
@@ -21,7 +21,7 @@ import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from .configuration import CustomEndpointSettings, load_realtime_config
 from .domain.models import (
@@ -352,45 +352,62 @@ def parse_snapshot(data: Dict[str, Any]) -> tuple[datetime, Sequence[Account], A
     accounts: List[Account] = []
     accounts_raw = data.get("accounts", [])
 
+    indexed_accounts: List[Tuple[int, Any]] = []
+    key_lookup: Dict[int, Any] = {}
 
     if isinstance(accounts_raw, Mapping):
-        accounts_iterable: Iterable[Any] = accounts_raw.values()
+        for idx, (key, value) in enumerate(accounts_raw.items()):
+            key_lookup[idx] = key
+            indexed_accounts.append((idx, value))
     elif isinstance(accounts_raw, Iterable) and not isinstance(
         accounts_raw, (str, bytes, bytearray)
     ):
-        accounts_iterable = accounts_raw
+        indexed_accounts = list(enumerate(accounts_raw))
     else:
         if accounts_raw not in (None, []):
             logger.warning(
-                "Skipping accounts payload because it is not an iterable of mappings: %r",
+                "Skipping accounts payload because it is not an iterable of mappings; "
+                "entries must be mappings but received %r (not a mapping).",
                 accounts_raw,
             )
-        accounts_iterable = []
+        indexed_accounts = []
 
-    for index, raw_account in enumerate(accounts_iterable):
-
-    if not isinstance(accounts_raw, Iterable):
-        accounts_raw = []
-
-    for index, raw_account in enumerate(accounts_raw):
-
+    for index, raw_account in indexed_accounts:
+        key_hint = key_lookup.get(index)
         if not isinstance(raw_account, Mapping):
-            logger.warning(
-                "Skipping account at index %s because entry is not a mapping: %r",
-                index,
-                raw_account,
-            )
+            if key_hint is not None:
+                logger.warning(
+                    "Skipping account at index %s (key %r) because entry is not a mapping: %r",
+                    index,
+                    key_hint,
+                    raw_account,
+                )
+            else:
+                logger.warning(
+                    "Skipping account at index %s because entry is not a mapping: %r",
+                    index,
+                    raw_account,
+                )
             continue
         try:
             account = _parse_account(raw_account)
         except (TypeError, ValueError) as exc:
             name = raw_account.get("name", "<unknown>")
-            logger.warning(
-                "Skipping account %s at index %s due to parse error: %s",
-                name,
-                index,
-                exc,
-            )
+            if key_hint is not None:
+                logger.warning(
+                    "Skipping account %s at index %s (key %r) due to parse error: %s",
+                    name,
+                    index,
+                    key_hint,
+                    exc,
+                )
+            else:
+                logger.warning(
+                    "Skipping account %s at index %s due to parse error: %s",
+                    name,
+                    index,
+                    exc,
+                )
             continue
         accounts.append(account)
     thresholds = _parse_thresholds(data.get("alert_thresholds", {}))


### PR DESCRIPTION
## Summary
- normalise Binance order book depth requests to supported increments
- harden dashboard snapshot parsing to ignore invalid account payloads gracefully

## Testing
- pytest tests/risk_management/test_dashboard_snapshot_parsing.py

------
https://chatgpt.com/codex/tasks/task_b_69063a5d15c883239f91d5ed06b552bd