### PR TITLE
Handle Binance depth limits and legacy account fields

### DIFF
--- a/tests/risk_management/test_account_clients.py
+++ b/tests/risk_management/test_account_clients.py
@@ -113,6 +113,12 @@ def test_instantiate_ccxt_client_applies_custom_endpoints(monkeypatch) -> None:
     assert client.urls["host"] == "https://proxy.example"
 
 
+def test_normalise_order_book_depth_clamps_binance_variants() -> None:
+    assert module._normalise_order_book_depth("binanceusdm", 25) == 50
+    assert module._normalise_order_book_depth("Binance-USDM", 7) == 10
+    assert module._normalise_order_book_depth("binance coinm", 2500) == 1000
+
+
 def test_instantiate_ccxt_client_respects_load_helper_override(monkeypatch) -> None:
     class DummyExchange:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- normalise Binance order book depth requests even when exchange ids include separators or suffix variations
- include the account name in realtime snapshots and accept legacy `account` fields when parsing dashboard payloads
- cover the new behaviours with unit tests for depth normalisation and snapshot parsing

## Testing
- pytest tests/risk_management/test_dashboard_snapshot_parsing.py tests/risk_management/test_account_clients.py

------
https://chatgpt.com/codex/tasks/task_b_69063a5d15c883239f91d5ed06b552bd