### PR TITLE
Fix Binance order book depth normalization for risk management clients

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -73,18 +73,15 @@ logger = logging.getLogger(__name__)
 def _normalise_order_book_depth(exchange: str, requested: int) -> int:
     """Return a depth limit supported by the exchange."""
 
-
     exchange_key = (exchange or "").strip().lower()
     if exchange_key:
         exchange_key = exchange_key.replace("-", "").replace("_", "")
-
 
     allowed_depths_map = {
         "binance": (5, 10, 20, 50, 100, 500, 1000),
         "binanceusdm": (5, 10, 20, 50, 100, 500, 1000),
         "binancecoinm": (5, 10, 20, 50, 100, 500, 1000),
     }
-
 
     allowed_depths = allowed_depths_map.get(exchange_key)
     if allowed_depths is None:
@@ -93,10 +90,8 @@ def _normalise_order_book_depth(exchange: str, requested: int) -> int:
         elif exchange_key.startswith("binance"):
             allowed_depths = allowed_depths_map["binanceusdm"]
 
-    allowed_depths = allowed_depths_map.get(exchange.lower())
-
     if not allowed_depths:
-        return max(requested, 1)
+        return max(int(requested), 1)
 
     if requested <= 0:
         return allowed_depths[0]

--- a/tests/test_risk_management_utils.py
+++ b/tests/test_risk_management_utils.py
@@ -1,0 +1,84 @@
+"""Tests for the :mod:`risk_management._utils` helpers."""
+
+from __future__ import annotations
+
+import json
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+utils = importlib.import_module("risk_management._utils")
+account_clients = importlib.import_module("risk_management.account_clients")
+
+
+def test_stringify_payload_serialises_sets_and_bytes() -> None:
+    payload = {"assets": {"BTC", "ETH"}, "note": b"risk"}
+
+    result = utils.stringify_payload(payload)
+
+    parsed = json.loads(result)
+    assert sorted(parsed["assets"]) == ["BTC", "ETH"]
+    assert parsed["note"] == "risk"
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ((None, ""), None),
+        (
+            (("1.5",),),
+            1.5,
+        ),
+        ((None, " 42 "), 42.0),
+        (
+            (("abc", 1.0), "2"),
+            2.0,
+        ),
+    ],
+)
+def test_first_float(values: tuple[object, ...], expected: float | None) -> None:
+    assert utils.first_float(*values) == expected
+
+
+def test_extract_position_details_prefers_explicit_fields() -> None:
+    position = {
+        "positionSide": "long",
+        "info": {"positionIdx": "2", "positionSide": "short"},
+    }
+
+    side, idx, explicit = utils.extract_position_details(position)
+
+    assert side == "LONG"
+    assert idx == 2
+    assert explicit is True
+
+
+def test_extract_position_details_infers_side_from_index() -> None:
+    position = {"info": {"positionIdx": 1}}
+
+    side, idx, explicit = utils.extract_position_details(position)
+
+    assert side == "LONG"
+    assert idx == 1
+    assert explicit is False
+
+
+def test_normalise_order_book_depth_handles_aliases() -> None:
+    normalise = account_clients._normalise_order_book_depth
+
+    assert normalise("binanceusdm", 7) == 10
+    assert normalise("Binance-USDm", 600) == 1000
+    assert normalise("binance_coinm", 1002) == 1000
+
+
+def test_normalise_order_book_depth_defaults_for_unknown_exchange() -> None:
+    normalise = account_clients._normalise_order_book_depth
+
+    assert normalise("unknown", 12) == 12
+    assert normalise("", -5) == 1


### PR DESCRIPTION
## Summary
- ensure `_normalise_order_book_depth` respects sanitised exchange identifiers and defaults gracefully when no mapping is available
- add regression tests covering `_utils` helpers and the order book depth normalisation logic

## Testing
- pytest tests/test_risk_management_utils.py

------
https://chatgpt.com/codex/tasks/task_b_69071920fe5c8323b9458a00eb4b80e3