### PR TITLE
Redact sensitive exchange credentials from logs

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,47 @@
+import io
+import logging
+
+import logging_setup
+
+
+def _configure_logging_to_stream() -> tuple[logging.Logger, io.StringIO]:
+    stream = io.StringIO()
+    logging_setup.configure_logging(debug=2, stream_target=stream)
+    logger = logging.getLogger("test_logging")
+    logger.setLevel(logging.DEBUG)
+    return logger, stream
+
+
+def test_sensitive_data_is_redacted_from_logs() -> None:
+    logger, stream = _configure_logging_to_stream()
+
+    logger.debug(
+        "Request headers: %s",
+        {
+            "X-MBX-APIKEY": "2jlFsTPzvm8Y4X66LFvR28IPypdakaZJYjynu2dL5ZZ8ZxyZW3Jq7lFAExLVQBua",
+            "signature": "deadbeefcafebabe",
+            "apiKey": "should_not_leak",
+        },
+    )
+    logger.debug(
+        "Signed URL: https://fapi.binance.com/fapi/v1/openOrders?signature=%s",
+        "abcdef1234567890",
+    )
+
+    output = stream.getvalue()
+
+    assert "should_not_leak" not in output
+    assert "abcdef1234567890" not in output
+    assert "2jlFsTPzvm8Y4X66LFvR28IPypdakaZJYjynu2dL5ZZ8ZxyZW3Jq7lFAExLVQBua" not in output
+    assert output.count("***REDACTED***") >= 3
+
+
+def test_non_sensitive_messages_remain_intact() -> None:
+    logger, stream = _configure_logging_to_stream()
+
+    message = "Order book depth fetch succeeded"
+    logger.info(message)
+
+    output = stream.getvalue()
+
+    assert message in output


### PR DESCRIPTION
## Summary
- add a sensitive-data-aware formatter to `configure_logging` so API keys and signatures are redacted before they reach the logs
- add unit tests that cover the new formatter and ensure regular log messages remain unchanged

## Testing
- pytest tests/test_logging_setup.py

------
https://chatgpt.com/codex/tasks/task_b_6907268fae1c8323a44ef565a0f284a0