### PR TITLE
Ensure logging redacts sensitive credentials across handlers

### DIFF
--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -45,3 +45,24 @@ def test_non_sensitive_messages_remain_intact() -> None:
     output = stream.getvalue()
 
     assert message in output
+
+
+def test_redaction_applies_to_external_handlers() -> None:
+    stream = io.StringIO()
+    logging_setup.configure_logging(debug=2, stream_target=stream)
+
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    external_logger = logging.getLogger("external.http")
+    external_logger.handlers = [handler]
+    external_logger.propagate = False
+    external_logger.setLevel(logging.DEBUG)
+
+    external_logger.debug("payload %s", {"X-MBX-APIKEY": "leaky", "signature": "should-hide"})
+
+    output = stream.getvalue()
+
+    assert "leaky" not in output
+    assert "should-hide" not in output
+    assert "***REDACTED***" in output


### PR DESCRIPTION
## Summary
- wrap the global log record factory so redaction is applied before any formatter runs
- extend the logging unit tests to cover handlers that bypass Passivbot's formatter

## Testing
- pytest tests/test_logging_setup.py -q

------
https://chatgpt.com/codex/tasks/task_b_690729f271648323b530d6cbc05f38a7