### PR TITLE
Suppress repeated invalid HTTP warnings from uvicorn

### DIFF
--- a/risk_management/web_server.py
+++ b/risk_management/web_server.py
@@ -30,19 +30,60 @@ def _import_uvicorn() -> "uvicorn":
     return uvicorn
 
 
+_INVALID_HTTP_REQUEST_FILTER_NAME = "suppress_invalid_http_request"
+
+
+class _SuppressInvalidHttpRequestFilter(logging.Filter):
+    """Filter out noisy uvicorn warnings emitted for malformed probes."""
+
+    _TARGET_MESSAGE = "Invalid HTTP request received."
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial behaviour
+        return record.getMessage() != self._TARGET_MESSAGE
+
+
+def _ensure_invalid_http_warning_filter(logging_config: dict) -> None:
+    """Install a logging filter that suppresses uvicorn's invalid request warnings."""
+
+    if not logging_config:
+        return
+
+    filters = logging_config.setdefault("filters", {})
+    if _INVALID_HTTP_REQUEST_FILTER_NAME not in filters:
+        filters[_INVALID_HTTP_REQUEST_FILTER_NAME] = {
+            "()": f"{__name__}._SuppressInvalidHttpRequestFilter",
+        }
+
+    loggers = logging_config.setdefault("loggers", {})
+    uvicorn_error = loggers.setdefault(
+        "uvicorn.error", {"handlers": ["default"], "level": "INFO", "propagate": True}
+    )
+    logger_filters = uvicorn_error.setdefault("filters", [])
+    if _INVALID_HTTP_REQUEST_FILTER_NAME not in logger_filters:
+        logger_filters.append(_INVALID_HTTP_REQUEST_FILTER_NAME)
+
+
 def _determine_uvicorn_logging(config) -> tuple[Optional[dict], str]:
     """Return logging configuration overrides for uvicorn."""
 
     debug_requested = config.debug_api_payloads or any(
         account.debug_api_payloads for account in getattr(config, "accounts", [])
     )
-    if not debug_requested:
-        return None, "info"
+
     try:
         uvicorn_config = importlib.import_module("uvicorn.config")
     except ModuleNotFoundError:  # pragma: no cover - uvicorn not importable in tests
-        return None, "debug"
+        if debug_requested:
+            return None, "debug"
+        return None, "info"
+
     LOGGING_CONFIG = getattr(uvicorn_config, "LOGGING_CONFIG", None)
+    if LOGGING_CONFIG is not None:
+        _ensure_invalid_http_warning_filter(LOGGING_CONFIG)
+
+    if not debug_requested:
+        return None, "info"
+
     if LOGGING_CONFIG is None:  # pragma: no cover - unexpected configuration shape
         return None, "debug"
 

--- a/tests/risk_management/test_web_server.py
+++ b/tests/risk_management/test_web_server.py
@@ -22,7 +22,10 @@ if "uvicorn" not in sys.modules:
     sys.modules["uvicorn"] = uvicorn_stub
 
 from risk_management.configuration import AccountConfig, RealtimeConfig  # noqa: E402
-from risk_management.web_server import _determine_uvicorn_logging  # noqa: E402
+from risk_management.web_server import (  # noqa: E402
+    _INVALID_HTTP_REQUEST_FILTER_NAME,
+    _determine_uvicorn_logging,
+)
 
 
 def _make_config(global_debug: bool = False, account_debug: bool = False) -> RealtimeConfig:
@@ -49,7 +52,7 @@ def test_determine_uvicorn_logging_uses_uvicorn_config(monkeypatch) -> None:
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {},
-        "handlers": {},
+        "handlers": {"default": {"class": "logging.StreamHandler"}},
         "loggers": {"": {"handlers": ["default"], "level": "INFO"}},
     }
     uvicorn_module = types.ModuleType("uvicorn")
@@ -66,6 +69,8 @@ def test_determine_uvicorn_logging_uses_uvicorn_config(monkeypatch) -> None:
     assert log_level == "debug"
     assert log_config["loggers"][""]["level"] == "DEBUG"
     assert log_config["loggers"]["risk_management"]["level"] == "DEBUG"
+    assert _INVALID_HTTP_REQUEST_FILTER_NAME in log_config["filters"]
+    assert _INVALID_HTTP_REQUEST_FILTER_NAME in log_config["loggers"]["uvicorn.error"]["filters"]
 
 
 def test_determine_uvicorn_logging_handles_missing_uvicorn(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a logging filter that hides uvicorn's noisy "Invalid HTTP request received" warnings
- ensure the filter is installed whenever uvicorn logging is configured, including debug mode adjustments
- extend the web server logging tests to cover the new filter handling

## Testing
- pytest tests/risk_management/test_web_server.py

------
https://chatgpt.com/codex/tasks/task_b_690748d333d08323b6316140297505da