### PR TITLE
Clean up risk management realtime setup

### DIFF
--- a/risk_management/liquidity.py
+++ b/risk_management/liquidity.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-"""Utilities for analysing order-book liquidity and slippage."""
-
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 __all__ = ["normalise_order_book", "calculate_position_liquidity"]

--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -36,7 +36,6 @@ from .account_clients import AccountClientProtocol, CCXTAccountClient
 from .configuration import AccountConfig, CustomEndpointSettings, RealtimeConfig
 
 from .audit import get_audit_logger
-from .configuration import CustomEndpointSettings, RealtimeConfig
 from .performance import PerformanceTracker
 from .policies import PolicyEvaluator
 
@@ -139,17 +138,16 @@ class RealtimeDataFetcher:
                     "Debug API payload logging enabled for account %s", account.name
                 )
 
-        self._notifications = NotificationCoordinator(config)
+        audit_logger = get_audit_logger(config.audit)
+        self._notifications = NotificationCoordinator(
+            config,
+            audit_logger=audit_logger,
+        )
         self._policy_evaluator: Optional[PolicyEvaluator]
         if config.policies:
             self._policy_evaluator = PolicyEvaluator(config.policies)
         else:
             self._policy_evaluator = None
-
-        self._notifications = NotificationCoordinator(
-            config,
-            audit_logger=get_audit_logger(config.audit),
-        )
 
         self._portfolio_stop_loss: Optional[Dict[str, Any]] = None
         self._last_portfolio_balance: Optional[float] = None


### PR DESCRIPTION
## Summary
- remove the redundant NotificationCoordinator construction in the realtime fetcher
- drop the duplicated configuration import in the realtime module
- eliminate the duplicate module docstring in the liquidity utilities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_69076ab32ea88323bfd583f72d412907