### PR TITLE
Add risk dashboard admin tools and conditional stop controls

### DIFF
--- a/risk_management/api_keys.py
+++ b/risk_management/api_keys.py
@@ -1,0 +1,43 @@
+"""Utilities for loading and persisting API key configuration files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+
+def _ensure_mapping(payload: Any) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise TypeError("API key configuration must be a JSON object")
+    return payload
+
+
+def load_api_keys(path: Path) -> Dict[str, Any]:
+    """Load and validate an api-keys.json payload."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    mapping = _ensure_mapping(data)
+    return {str(key): value for key, value in mapping.items()}
+
+
+def save_api_keys(path: Path, payload: Mapping[str, Any]) -> None:
+    """Persist API keys to ``path`` with a stable formatting."""
+
+    _ensure_mapping(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def validate_api_key_entry(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a normalised API key entry ensuring required fields exist."""
+
+    if not isinstance(entry, Mapping):
+        raise TypeError("API key entry must be an object")
+    exchange = entry.get("exchange")
+    if not exchange:
+        raise ValueError("API key entries require an 'exchange' field")
+
+    normalized = {str(key): value for key, value in entry.items()}
+    normalized["exchange"] = str(exchange).strip()
+    return normalized

--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -179,6 +179,7 @@ class GrafanaConfig:
     default_height: int = 600
     theme: str = "dark"
     base_url: Optional[str] = None
+    account_equity_template: Optional[str] = None
 
 
 @dataclass()
@@ -196,6 +197,8 @@ class RealtimeConfig:
     debug_api_payloads: bool = False
     reports_dir: Optional[Path] = None
     grafana: Optional[GrafanaConfig] = None
+    api_keys_path: Optional[Path] = None
+    config_path: Optional[Path] = None
 
 
 def _load_json(path: Path) -> Dict[str, Any]:
@@ -460,12 +463,19 @@ def _parse_grafana_config(settings: Any) -> Optional[GrafanaConfig]:
 
     base_url_raw = settings.get("base_url")
     base_url = str(base_url_raw).strip() if base_url_raw not in (None, "") else None
+    account_equity_template_raw = settings.get("account_equity_template")
+    account_equity_template = (
+        str(account_equity_template_raw).strip()
+        if account_equity_template_raw not in (None, "")
+        else None
+    )
 
     return GrafanaConfig(
         dashboards=dashboards,
         default_height=default_height,
         theme=theme,
         base_url=base_url,
+        account_equity_template=account_equity_template,
     )
 
 
@@ -596,7 +606,7 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
 
     _configure_default_logging(debug_level=1)
 
-    path = Path(path)
+    path = Path(path).resolve()
 
     config_payload = _load_json(path)
     config = _ensure_mapping(config_payload, description="Realtime configuration")
@@ -686,4 +696,6 @@ def load_realtime_config(path: Path | str) -> RealtimeConfig:
         reports_dir=reports_dir,
         grafana=grafana_settings,
         account_messages=account_messages,
+        api_keys_path=api_keys_path,
+        config_path=path,
     )

--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -37,6 +37,9 @@ def build_presentable_snapshot(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
     stop_loss = snapshot.get("portfolio_stop_loss") if isinstance(snapshot, Mapping) else None
     if isinstance(stop_loss, Mapping):
         payload["portfolio_stop_loss"] = dict(stop_loss)
+    conditional = snapshot.get("conditional_stop_losses") if isinstance(snapshot, Mapping) else None
+    if isinstance(conditional, Sequence):
+        payload["conditional_stop_losses"] = list(conditional)
 
     return payload
 

--- a/risk_management/templates/api_keys.html
+++ b/risk_management/templates/api_keys.html
@@ -1,0 +1,298 @@
+{% extends "base.html" %}
+
+{% block head %}
+  <style>
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      gap: 1rem;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    textarea {
+      min-height: 160px;
+      resize: vertical;
+      padding: 0.6rem 0.75rem;
+      border-radius: 0.6rem;
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      background: rgba(15, 23, 42, 0.6);
+      color: var(--text);
+    }
+
+    .status-message {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .status-message.success {
+      color: var(--success);
+    }
+
+    .status-message.error {
+      color: var(--danger);
+    }
+  </style>
+{% endblock %}
+
+{% block header_controls %}
+  <div style="display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;">
+    <span class="badge">Logged in as {{ user }}</span>
+    <a href="/" class="button secondary">Dashboard</a>
+    <a href="/trading-panel" class="button secondary">Trading panel</a>
+    <form method="post" action="/logout">
+      <button type="submit">Logout</button>
+    </form>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <section class="card" style="margin-bottom: 1rem;">
+    <h2 style="margin-top: 0;">API keys and account parameters</h2>
+    <p style="color: var(--muted); margin-bottom: 0;">
+      Keys are stored at <code>{{ api_keys_path }}</code>. Account definitions are updated in <code>{{ config_path }}</code>.
+    </p>
+  </section>
+
+  <div class="grid">
+    <section class="card">
+      <h3 style="margin-top: 0;">API keys</h3>
+      <p class="status-message" id="keys-status" hidden></p>
+      <div class="table-wrapper" style="margin-bottom: 1rem; max-height: 220px;">
+        <table class="compact" id="keys-table">
+          <thead>
+            <tr>
+              <th>Id</th>
+              <th>Exchange</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <form id="key-form" style="display: flex; flex-direction: column; gap: 0.75rem;">
+        <div class="form-group">
+          <label for="key-id">Key id</label>
+          <input id="key-id" name="key_id" placeholder="e.g. binance_01" required />
+        </div>
+        <div class="form-group">
+          <label for="key-entry">API key payload (JSON)</label>
+          <textarea id="key-entry" name="entry" placeholder='{"exchange": "binance", "key": "...", "secret": "..."}' required></textarea>
+        </div>
+        <button type="submit" class="button">Save key</button>
+      </form>
+    </section>
+
+    <section class="card">
+      <h3 style="margin-top: 0;">Accounts</h3>
+      <p class="status-message" id="accounts-status" hidden></p>
+      <div class="table-wrapper" style="margin-bottom: 1rem; max-height: 220px;">
+        <table class="compact" id="accounts-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Exchange</th>
+              <th>Key id</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <form id="account-form" style="display: flex; flex-direction: column; gap: 0.75rem;">
+        <div class="form-group">
+          <label for="account-name">Name</label>
+          <input id="account-name" name="name" placeholder="e.g. Binance Futures" required />
+        </div>
+        <div class="form-group">
+          <label for="account-exchange">Exchange</label>
+          <input id="account-exchange" name="exchange" placeholder="binanceusdm" required />
+        </div>
+        <div class="form-group">
+          <label for="account-key-id">API key id</label>
+          <input id="account-key-id" name="api_key_id" placeholder="binance_01" />
+        </div>
+        <div class="form-group">
+          <label for="account-settle">Settle currency</label>
+          <input id="account-settle" name="settle_currency" placeholder="USDT" value="USDT" />
+        </div>
+        <div class="form-group">
+          <label for="account-symbols">Symbols (comma separated)</label>
+          <input id="account-symbols" name="symbols" placeholder="BTC/USDT,ETH/USDT" />
+        </div>
+        <div class="form-group">
+          <label for="account-params">Params (JSON)</label>
+          <textarea id="account-params" name="params" placeholder='{"balance": {"type": "swap"}}'></textarea>
+        </div>
+        <div class="form-group" style="flex-direction: row; gap: 0.5rem; align-items: center;">
+          <input type="checkbox" id="account-enabled" name="enabled" checked />
+          <label for="account-enabled">Enabled</label>
+        </div>
+        <button type="submit" class="button">Save account</button>
+      </form>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    const apiKeysPayload = {{ api_keys | tojson | safe }};
+    const accountsPayload = {{ accounts | tojson | safe }};
+
+    const keysTableBody = document.querySelector('#keys-table tbody');
+    const accountsTableBody = document.querySelector('#accounts-table tbody');
+    const keysStatus = document.getElementById('keys-status');
+    const accountsStatus = document.getElementById('accounts-status');
+
+    const renderKeys = (data) => {
+      if (!keysTableBody) return;
+      const items = Object.entries(data || {})
+        .filter(([key]) => key !== 'referrals')
+        .map(([id, entry]) => {
+          const exchange = entry?.exchange || 'unknown';
+          return `<tr><td>${id}</td><td>${exchange}</td><td><button class="button danger small" data-delete-key="${id}">Delete</button></td></tr>`;
+        })
+        .join('');
+      keysTableBody.innerHTML = items || '<tr><td colspan="3" style="color: var(--muted); text-align: center;">No API keys found.</td></tr>';
+    };
+
+    const renderAccounts = (data) => {
+      if (!accountsTableBody) return;
+      const rows = Array.isArray(data)
+        ? data.map((account) => {
+            const keyId = account.api_key_id || '-';
+            return `<tr><td>${account.name}</td><td>${account.exchange}</td><td>${keyId}</td><td><button class="button secondary small" data-fill-account='${JSON.stringify(account)}'>Edit</button></td></tr>`;
+          })
+        : [];
+      accountsTableBody.innerHTML = rows.join('') || '<tr><td colspan="4" style="color: var(--muted); text-align: center;">No accounts configured.</td></tr>';
+    };
+
+    const showStatus = (element, message, variant = 'info') => {
+      if (!element) return;
+      element.hidden = !message;
+      element.textContent = message || '';
+      element.classList.remove('success', 'error');
+      if (variant === 'success') element.classList.add('success');
+      if (variant === 'error') element.classList.add('error');
+    };
+
+    renderKeys(apiKeysPayload);
+    renderAccounts(accountsPayload);
+
+    document.getElementById('key-form').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const form = event.currentTarget;
+      const id = form.key_id.value.trim();
+      let entry;
+      try {
+        entry = JSON.parse(form.entry.value);
+      } catch (error) {
+        showStatus(keysStatus, 'Entry must be valid JSON.', 'error');
+        return;
+      }
+      showStatus(keysStatus, 'Saving key...');
+      try {
+        const response = await fetch('/api/admin/api-keys', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, entry }),
+        });
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          throw new Error(error.detail || `Failed with ${response.status}`);
+        }
+        const updated = await (await fetch('/api/admin/api-keys', { credentials: 'include' })).json();
+        renderKeys(updated.keys);
+        showStatus(keysStatus, 'Key saved.', 'success');
+      } catch (error) {
+        showStatus(keysStatus, error.message, 'error');
+      }
+    });
+
+    document.addEventListener('click', async (event) => {
+      const deleteKey = event.target.closest('[data-delete-key]');
+      if (deleteKey) {
+        const id = deleteKey.getAttribute('data-delete-key');
+        showStatus(keysStatus, `Deleting ${id}...`);
+        try {
+          const response = await fetch(`/api/admin/api-keys/${encodeURIComponent(id)}`, { method: 'DELETE', credentials: 'include' });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || `Failed with ${response.status}`);
+          }
+          const updated = await (await fetch('/api/admin/api-keys', { credentials: 'include' })).json();
+          renderKeys(updated.keys);
+          showStatus(keysStatus, 'Key removed.', 'success');
+        } catch (error) {
+          showStatus(keysStatus, error.message, 'error');
+        }
+      }
+
+      const fillButton = event.target.closest('[data-fill-account]');
+      if (fillButton) {
+        try {
+          const data = JSON.parse(fillButton.getAttribute('data-fill-account'));
+          document.getElementById('account-name').value = data.name || '';
+          document.getElementById('account-exchange').value = data.exchange || '';
+          document.getElementById('account-key-id').value = data.api_key_id || '';
+          document.getElementById('account-settle').value = data.settle_currency || 'USDT';
+          document.getElementById('account-symbols').value = Array.isArray(data.symbols) ? data.symbols.join(',') : '';
+          document.getElementById('account-params').value = data.params ? JSON.stringify(data.params, null, 2) : '';
+          document.getElementById('account-enabled').checked = data.enabled !== false;
+        } catch (error) {
+          showStatus(accountsStatus, 'Unable to load account into form.', 'error');
+        }
+      }
+    });
+
+    document.getElementById('account-form').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const form = event.currentTarget;
+      const symbolsRaw = form.symbols.value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+      let params = {};
+      if (form.params.value.trim()) {
+        try {
+          params = JSON.parse(form.params.value);
+        } catch (error) {
+          showStatus(accountsStatus, 'Params must be valid JSON.', 'error');
+          return;
+        }
+      }
+      const payload = {
+        name: form.name.value,
+        exchange: form.exchange.value,
+        api_key_id: form.api_key_id.value,
+        settle_currency: form.settle_currency.value,
+        symbols: symbolsRaw.length ? symbolsRaw : null,
+        params,
+        enabled: form.enabled.checked,
+      };
+      showStatus(accountsStatus, 'Saving account...');
+      try {
+        const response = await fetch('/api/admin/accounts', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          throw new Error(error.detail || `Failed with ${response.status}`);
+        }
+        const updated = await (await fetch('/api/admin/accounts', { credentials: 'include' })).json();
+        renderAccounts(updated.accounts);
+        showStatus(accountsStatus, 'Account saved.', 'success');
+      } catch (error) {
+        showStatus(accountsStatus, error.message, 'error');
+      }
+    });
+  </script>
+{% endblock %}

--- a/risk_management/templates/dashboard.html
+++ b/risk_management/templates/dashboard.html
@@ -90,6 +90,7 @@
   <div style="display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;">
     <span class="badge">Logged in as {{ user }}</span>
     <a href="/trading-panel" class="button secondary">Trading panel</a>
+    <a href="/api-keys" class="button secondary">API keys &amp; accounts</a>
     <button type="button" class="button danger" data-kill-portfolio>Kill portfolio</button>
     <div class="status-message" data-kill-status="__portfolio__" hidden></div>
     <form method="post" action="/logout">
@@ -117,6 +118,15 @@
       data-page-target="accounts"
     >
       Accounts
+    </button>
+    <button
+      type="button"
+      class="view-nav__button"
+      role="tab"
+      aria-selected="false"
+      data-page-target="cashflows"
+    >
+      Cash flow
     </button>
     <button
       type="button"
@@ -482,6 +492,70 @@
       </div>
     </div>
 
+    <div class="page-section" data-page-section="cashflows" hidden>
+      <section class="card" style="margin-bottom: 1rem;">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;">
+          <div>
+            <h2 style="margin: 0 0 0.25rem;">Cash flow</h2>
+            <p style="color: var(--muted); margin: 0;">Record deposits and withdrawals to keep NAV changes accurate.</p>
+          </div>
+          <div class="status-message" id="cashflow-status" hidden></div>
+        </div>
+      </section>
+
+      <section class="card" style="margin-bottom: 1rem;">
+        <h3 style="margin-top: 0;">Add cash flow</h3>
+        <form id="cashflow-form" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; align-items: flex-end;">
+          <div class="form-group">
+            <label for="cashflow-type">Type</label>
+            <select id="cashflow-type" name="type" required>
+              <option value="deposit">Deposit</option>
+              <option value="withdrawal">Withdrawal</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="cashflow-amount">Amount</label>
+            <input id="cashflow-amount" name="amount" type="number" step="any" min="0" required />
+          </div>
+          <div class="form-group">
+            <label for="cashflow-currency">Currency</label>
+            <input id="cashflow-currency" name="currency" placeholder="USDT" value="USDT" />
+          </div>
+          <div class="form-group">
+            <label for="cashflow-account">Account (optional)</label>
+            <input id="cashflow-account" name="account" placeholder="e.g. Binance" />
+          </div>
+          <div class="form-group">
+            <label for="cashflow-note">Note</label>
+            <input id="cashflow-note" name="note" placeholder="Reference" />
+          </div>
+          <button type="submit" class="button">Save entry</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+          <h3 style="margin: 0;">Recent cash flows</h3>
+          <span id="cashflow-summary" style="color: var(--muted);"></span>
+        </div>
+        <div class="table-wrapper">
+          <table class="compact" id="cashflow-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Type</th>
+                <th>Amount</th>
+                <th>Currency</th>
+                <th>Account</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
     <div class="page-section" data-page-section="alerts" hidden>
       <section class="card alerts">
         <h2>Alerts</h2>
@@ -545,6 +619,32 @@
               </article>
             {% endfor %}
           </div>
+          {% if grafana_account_dashboards %}
+            <h3 style="margin: 1.5rem 0 0.5rem;">Account equity</h3>
+            <div class="grafana-grid" style="margin-top: 0.75rem;">
+              {% for dashboard in grafana_account_dashboards %}
+                <article class="grafana-panel">
+                  <div class="grafana-panel__meta">
+                    <div>
+                      <h4 style="margin: 0 0 0.25rem;">{{ dashboard.title }}</h4>
+                      {% if dashboard.description %}
+                        <p style="margin: 0; color: var(--muted); font-size: 0.9rem;">{{ dashboard.description }}</p>
+                      {% endif %}
+                    </div>
+                    <a class="button secondary" href="{{ dashboard.url }}" target="_blank" rel="noopener">Open</a>
+                  </div>
+                  <iframe
+                    src="{{ dashboard.url }}"
+                    title="{{ dashboard.title }}"
+                    height="{{ dashboard.height }}"
+                    loading="lazy"
+                    referrerpolicy="no-referrer-when-downgrade"
+                    allowfullscreen
+                  ></iframe>
+                </article>
+              {% endfor %}
+            </div>
+          {% endif %}
         </section>
       </div>
     {% endif %}
@@ -638,6 +738,44 @@
       const size = number / 1024 ** exponent;
       const precision = exponent === 0 ? 0 : 2;
       return `${size.toFixed(precision)} ${units[exponent]}`;
+    };
+
+    const cashflowTableBody = document.querySelector('#cashflow-table tbody');
+    const cashflowSummary = document.getElementById('cashflow-summary');
+    const cashflowStatus = document.getElementById('cashflow-status');
+
+    const renderCashflows = (items) => {
+      if (!cashflowTableBody) return;
+      const rows = (Array.isArray(items) ? items : []).map((item) => {
+        const timestamp = item.timestamp ? new Date(item.timestamp).toLocaleString() : '-';
+        const signed = Number(item.signed_amount || 0);
+        const className = signed >= 0 ? 'gain' : 'loss';
+        return `<tr>
+          <td>${timestamp}</td>
+          <td>${item.type}</td>
+          <td class="${className}">${formatCurrency(item.amount)}</td>
+          <td>${item.currency}</td>
+          <td>${item.account || '-'}</td>
+          <td>${item.note || '-'}</td>
+        </tr>`;
+      });
+      cashflowTableBody.innerHTML = rows.join('') || '<tr><td colspan="6" style="color: var(--muted); text-align: center;">No cash flow records yet.</td></tr>';
+      const depositTotal = (items || []).filter((item) => item.type === 'deposit').reduce((sum, item) => sum + Number(item.amount || 0), 0);
+      const withdrawalTotal = (items || []).filter((item) => item.type === 'withdrawal').reduce((sum, item) => sum + Number(item.amount || 0), 0);
+      if (cashflowSummary) {
+        cashflowSummary.textContent = `Deposits ${formatCurrency(depositTotal)} | Withdrawals ${formatCurrency(withdrawalTotal)}`;
+      }
+    };
+
+    const loadCashflows = async () => {
+      try {
+        const response = await fetch('/api/cashflows?limit=100', { credentials: 'include' });
+        if (!response.ok) return;
+        const payload = await response.json();
+        renderCashflows(payload.items || []);
+      } catch (error) {
+        console.error('Failed to load cashflows', error);
+      }
     };
 
     const renderPortfolio = (snapshot) => {
@@ -1159,9 +1297,37 @@
         }
         const snapshot = await response.json();
         renderSnapshot(snapshot);
+        loadCashflows();
       } catch (error) {
         console.error("Failed to refresh snapshot", error);
       }
+    }
+
+    const cashflowForm = document.getElementById('cashflow-form');
+    if (cashflowForm) {
+      cashflowForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const data = new FormData(cashflowForm);
+        const payload = Object.fromEntries(data.entries());
+        showStatus(cashflowStatus, 'Saving cash flow...');
+        try {
+          const response = await fetch('/api/cashflows', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            throw new Error(error.detail || `Failed with status ${response.status}`);
+          }
+          showStatus(cashflowStatus, 'Cash flow saved.', 'success');
+          cashflowForm.reset();
+          loadCashflows();
+        } catch (error) {
+          showStatus(cashflowStatus, error.message, 'error');
+        }
+      });
     }
 
     async function triggerKillSwitch(accountName, button, symbol) {
@@ -1241,6 +1407,7 @@
     });
 
     setInterval(poll, REFRESH_INTERVAL_MS);
+    loadCashflows();
     poll();
   </script>
 {% endblock %}

--- a/risk_management/templates/trading_panel.html
+++ b/risk_management/templates/trading_panel.html
@@ -75,6 +75,7 @@
   <div style="display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;">
     <span class="badge">Logged in as {{ user }}</span>
     <a href="/" class="button secondary">Dashboard</a>
+    <a href="/api-keys" class="button secondary">API keys &amp; accounts</a>
     <form method="post" action="/logout">
       <button type="submit">Logout</button>
     </form>
@@ -165,6 +166,61 @@
         </div>
       </form>
     </section>
+
+    <section class="card" id="conditional-stop-card">
+      <h3 style="margin-top: 0;">Conditional stop losses</h3>
+      <p style="color: var(--muted);">Combine rule-based triggers with the hard drawdown threshold.</p>
+      <form id="conditional-form" style="display: flex; flex-direction: column; gap: 1rem;">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="conditional-name">Name</label>
+            <input id="conditional-name" name="name" placeholder="e.g. Equity floor" />
+          </div>
+          <div class="form-group">
+            <label for="conditional-metric">Metric</label>
+            <select id="conditional-metric" name="metric" required>
+              <option value="equity_below">Equity below amount</option>
+              <option value="balance_below">Balance below amount</option>
+              <option value="equity_drawdown_pct">Equity drawdown %</option>
+              <option value="unrealized_loss_pct">Unrealized PnL %</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label for="conditional-threshold">Threshold</label>
+            <input id="conditional-threshold" name="threshold" type="number" step="any" min="0" required />
+          </div>
+          <div class="form-group">
+            <label for="conditional-operator">Operator</label>
+            <select id="conditional-operator" name="operator">
+              <option value="lte">Less than / equal</option>
+              <option value="gte">Greater than / equal</option>
+            </select>
+          </div>
+        </div>
+        <div style="display: flex; gap: 1rem; align-items: center;">
+          <button type="submit" class="button">Add condition</button>
+          <button type="button" class="button secondary" id="conditional-clear">Clear all</button>
+          <div class="status-message" id="conditional-status" hidden></div>
+        </div>
+      </form>
+      <div class="table-wrapper" style="margin-top: 1rem;">
+        <table id="conditional-table" class="compact">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Metric</th>
+              <th>Threshold</th>
+              <th>Last</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
   </section>
 
   <section class="card" style="margin-top: 1.5rem;" id="positions-card">
@@ -238,6 +294,8 @@
     const stopLossSummary = document.getElementById("stop-loss-summary");
     const stopLossStatus = document.getElementById("stop-loss-status");
     const refreshButton = document.getElementById("refresh-button");
+    const conditionalTableBody = document.querySelector("#conditional-table tbody");
+    const conditionalStatus = document.getElementById("conditional-status");
 
     const formatCurrency = (value) => {
       const number = Number(value);
@@ -383,12 +441,45 @@
       }
     };
 
+    const renderConditionalStops = () => {
+      if (!conditionalTableBody) return;
+      const conditions = Array.isArray(state.snapshot.conditional_stop_losses)
+        ? state.snapshot.conditional_stop_losses
+        : [];
+      const rows = conditions
+        .map((condition) => {
+          const triggered = condition.triggered ? "Triggered" : "Active";
+          const statusClass = condition.triggered ? "loss" : "";
+          const lastValue = condition.last_value !== undefined && condition.last_value !== null
+            ? condition.metric.includes("pct")
+              ? `${Number(condition.last_value).toFixed(2)}%`
+              : formatCurrency(condition.last_value)
+            : "-";
+          const threshold = condition.metric.includes("pct")
+            ? `${Number(condition.threshold || 0).toFixed(2)}%`
+            : formatCurrency(condition.threshold || 0);
+          return `
+            <tr>
+              <td>${condition.name || condition.metric}</td>
+              <td>${condition.metric}</td>
+              <td>${threshold}</td>
+              <td>${lastValue}</td>
+              <td class="${statusClass}">${triggered}</td>
+              <td><button type="button" class="button secondary small" data-remove-condition="${condition.name}">Remove</button></td>
+            </tr>
+          `;
+        })
+        .join("");
+      conditionalTableBody.innerHTML = rows || '<tr><td colspan="6" style="text-align: center; color: var(--muted);">No conditional rules configured.</td></tr>';
+    };
+
     const renderAll = () => {
       renderAccountOptions();
       renderOrderTypes();
       renderPositions();
       renderOrders();
       renderStopLoss();
+      renderConditionalStops();
     };
 
     const parseParams = (raw) => {
@@ -539,6 +630,55 @@
       }
     });
 
+    document.getElementById("conditional-form").addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.currentTarget;
+      const payload = {
+        name: form.name.value,
+        metric: form.metric.value,
+        threshold: form.threshold.value,
+        operator: form.operator.value,
+      };
+      showStatus(conditionalStatus, "Saving condition...");
+      try {
+        const response = await fetch("/api/trading/portfolio/conditional-stop-loss", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => ({}));
+          throw new Error(errorPayload.detail || `Unable to save (${response.status})`);
+        }
+        showStatus(conditionalStatus, "Condition saved.", "success");
+        form.reset();
+        await refreshSnapshot();
+      } catch (error) {
+        console.error(error);
+        showStatus(conditionalStatus, error.message, "error");
+      }
+    });
+
+    document.getElementById("conditional-clear").addEventListener("click", async () => {
+      showStatus(conditionalStatus, "Clearing conditions...");
+      try {
+        const response = await fetch("/api/trading/portfolio/conditional-stop-loss", {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => ({}));
+          throw new Error(errorPayload.detail || `Unable to clear (${response.status})`);
+        }
+        showStatus(conditionalStatus, "All conditions cleared.", "success");
+        await refreshSnapshot();
+      } catch (error) {
+        console.error(error);
+        showStatus(conditionalStatus, error.message, "error");
+      }
+    });
+
     document.addEventListener("click", async (event) => {
       const cancelButton = event.target.closest("[data-cancel-order]");
       if (cancelButton) {
@@ -588,6 +728,30 @@
         } catch (error) {
           console.error(error);
           showStatus(orderStatus, error.message, "error");
+        }
+        return;
+      }
+      const removeCondition = event.target.closest("[data-remove-condition]");
+      if (removeCondition) {
+        const name = removeCondition.getAttribute("data-remove-condition");
+        showStatus(conditionalStatus, `Removing ${name || "condition"}...`);
+        try {
+          const response = await fetch(
+            `/api/trading/portfolio/conditional-stop-loss?name=${encodeURIComponent(name || "")}`,
+            {
+              method: "DELETE",
+              credentials: "include",
+            }
+          );
+          if (!response.ok) {
+            const errorPayload = await response.json().catch(() => ({}));
+            throw new Error(errorPayload.detail || `Unable to remove (${response.status})`);
+          }
+          showStatus(conditionalStatus, "Condition removed.", "success");
+          await refreshSnapshot();
+        } catch (error) {
+          console.error(error);
+          showStatus(conditionalStatus, error.message, "error");
         }
       }
     });


### PR DESCRIPTION
## Summary
- add API key and account editing page with FastAPI endpoints and persistence
- add cash flow CRUD endpoints and UI that records deposits/withdrawals in history
- support conditional portfolio stop-loss rules and Grafana account equity embeds

## Testing
- python -m compileall risk_management

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ea88f49f8832395aa3e009762b3de)