### PR TITLE
Fix risk management test imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,11 @@ import os
 import sys
 import types
 
-# Ensure we can import modules from the src/ directory as "downloader"
+# Ensure we can import modules from the repository root and ``src/`` directory
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 SRC_DIR = os.path.join(ROOT_DIR, "src")
 if SRC_DIR not in sys.path:
     sys.path.insert(0, SRC_DIR)


### PR DESCRIPTION
## Summary
- add the repository root to the test sys.path configuration so the local risk_management package is used
- retain src/ insertion to keep existing imports working

## Testing
- pytest tests/risk_management -q
- pytest -q *(fails: missing optional dependencies such as numpy/ccxt due to installation restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fdb6b35348323bdfe21e24ce776cc)