### PR TITLE
Add account management controls to risk dashboard

### DIFF
--- a/risk_management/templates/api_keys.html
+++ b/risk_management/templates/api_keys.html
@@ -165,7 +165,8 @@
       const rows = Array.isArray(data)
         ? data.map((account) => {
             const keyId = account.api_key_id || '-';
-            return `<tr><td>${account.name}</td><td>${account.exchange}</td><td>${keyId}</td><td><button class="button secondary small" data-fill-account='${JSON.stringify(account)}'>Edit</button></td></tr>`;
+            const serialized = encodeURIComponent(JSON.stringify(account));
+            return `<tr><td>${account.name}</td><td>${account.exchange}</td><td>${keyId}</td><td style="display: flex; gap: 0.35rem; flex-wrap: wrap;"><button class="button secondary small" data-fill-account="${serialized}">Edit</button><button class="button danger small" data-delete-account="${account.name}">Delete</button></td></tr>`;
           })
         : [];
       accountsTableBody.innerHTML = rows.join('') || '<tr><td colspan="4" style="color: var(--muted); text-align: center;">No accounts configured.</td></tr>';
@@ -236,7 +237,9 @@
       const fillButton = event.target.closest('[data-fill-account]');
       if (fillButton) {
         try {
-          const data = JSON.parse(fillButton.getAttribute('data-fill-account'));
+          const serialized = fillButton.getAttribute('data-fill-account');
+          const decoded = serialized ? decodeURIComponent(serialized) : '{}';
+          const data = JSON.parse(decoded);
           document.getElementById('account-name').value = data.name || '';
           document.getElementById('account-exchange').value = data.exchange || '';
           document.getElementById('account-key-id').value = data.api_key_id || '';
@@ -247,6 +250,32 @@
         } catch (error) {
           showStatus(accountsStatus, 'Unable to load account into form.', 'error');
         }
+      }
+
+      const deleteAccount = event.target.closest('[data-delete-account]');
+      if (deleteAccount) {
+        const accountName = deleteAccount.getAttribute('data-delete-account');
+        if (!accountName) return;
+        showStatus(accountsStatus, `Deleting ${accountName}...`);
+        fetch(`/api/admin/accounts/${encodeURIComponent(accountName)}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        })
+          .then(async (response) => {
+            if (!response.ok) {
+              const error = await response.json().catch(() => ({}));
+              throw new Error(error.detail || `Failed with ${response.status}`);
+            }
+            return fetch('/api/admin/accounts', { credentials: 'include' });
+          })
+          .then((response) => response.json())
+          .then((payload) => {
+            renderAccounts(payload.accounts);
+            showStatus(accountsStatus, 'Account removed.', 'success');
+          })
+          .catch((error) => {
+            showStatus(accountsStatus, error.message, 'error');
+          });
       }
     });
 
@@ -290,6 +319,8 @@
         const updated = await (await fetch('/api/admin/accounts', { credentials: 'include' })).json();
         renderAccounts(updated.accounts);
         showStatus(accountsStatus, 'Account saved.', 'success');
+        form.reset();
+        document.getElementById('account-settle').value = 'USDT';
       } catch (error) {
         showStatus(accountsStatus, error.message, 'error');
       }

--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -908,6 +908,36 @@ def create_app(
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
         return JSONResponse({"account": clean_entry}, status_code=status.HTTP_201_CREATED)
 
+    @app.delete("/api/admin/accounts/{account_name}", response_class=JSONResponse)
+    async def api_delete_account(account_name: str, _: str = Depends(require_user)) -> JSONResponse:
+        try:
+            config_payload = _load_config_payload()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+        accounts = config_payload.get("accounts") if isinstance(config_payload, Mapping) else None
+        if not isinstance(accounts, list):
+            accounts = []
+
+        updated_accounts: list[Mapping[str, Any]] = []
+        removed = False
+        for entry in accounts:
+            if isinstance(entry, Mapping) and entry.get("name") == account_name:
+                removed = True
+                continue
+            updated_accounts.append(entry)
+
+        if not removed:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Account '{account_name}' not found")
+
+        config_payload["accounts"] = updated_accounts
+        try:
+            _save_config_payload(config_payload)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+        return JSONResponse({"deleted": account_name})
+
     @app.on_event("shutdown")
     async def shutdown() -> None:  # pragma: no cover - FastAPI lifecycle
         await service.close()


### PR DESCRIPTION
## Summary
- add FastAPI endpoint to delete accounts from the realtime configuration
- extend the API keys & accounts UI to support deleting accounts and safer form population
- reset the account form after saves to streamline multiple updates

## Testing
- python -m compileall risk_management

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921badde97883238b92fa9b25e9b756)