### PR TITLE
Harden web server script entrypoint and add typo guard test

### DIFF
--- a/risk_management/web_server.py
+++ b/risk_management/web_server.py
@@ -9,9 +9,17 @@ import logging
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 
-from .audit import get_audit_logger
-from .configuration import CustomEndpointSettings, load_realtime_config
-from .letsencrypt import LetsEncryptError, ensure_certificate
+if __name__ == "__main__" and __package__ in {None, ""}:  # pragma: no cover - script execution guard
+    import sys
+
+    # Ensure the package root is importable when executed as ``python risk_management/web_server.py``.
+    PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+    if str(PACKAGE_ROOT) not in sys.path:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+
+from risk_management.audit import get_audit_logger
+from risk_management.configuration import CustomEndpointSettings, load_realtime_config
+from risk_management.letsencrypt import LetsEncryptError, ensure_certificate
 
 if TYPE_CHECKING:  # pragma: no cover - used only for type hints
     import uvicorn

--- a/tests/risk_management/test_compilation.py
+++ b/tests/risk_management/test_compilation.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+
+
+def test_risk_management_sources_parse() -> None:
+    """Ensure all risk management modules remain free of syntax errors/typos."""
+
+    package_root = Path(__file__).resolve().parents[2] / "risk_management"
+    failures: list[tuple[Path, str]] = []
+
+    for path in package_root.rglob("*.py"):
+        try:
+            py_compile.compile(str(path), doraise=True)
+        except py_compile.PyCompileError as exc:  # pragma: no cover - defensive check
+            failures.append((path, exc.msg))
+
+    assert not failures, "\n".join(f"{path}: {message}" for path, message in failures)

--- a/tests/risk_management/test_web_server.py
+++ b/tests/risk_management/test_web_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import sys
 import types
 
@@ -125,3 +126,19 @@ def test_apply_https_only_policy_ignored_when_not_requested(caplog) -> None:
     assert not enforced
     assert config.auth.https_only is False
     assert not caplog.messages
+
+
+def test_web_server_script_can_display_help() -> None:
+    """Ensure the CLI entrypoint works when executed as a script."""
+
+    # Use the repo root so ``risk_management`` is importable without installation.
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "risk_management" / "web_server.py"), "--help"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Launch the risk dashboard web UI" in result.stdout


### PR DESCRIPTION
## Summary
- harden the web server script path guard to avoid side effects during normal imports while preserving direct execution
- add a compilation test to catch syntax typos across the risk_management package

## Testing
- pytest tests/risk_management -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692312ef32548323bcc8d3c402d5390c)