### PR TITLE
Ensure accounts with messages appear in dashboard listings

### DIFF
--- a/risk_management/snapshot_utils.py
+++ b/risk_management/snapshot_utils.py
@@ -251,7 +251,6 @@ def _build_account_views(
         )
         if view["message"]:
             hidden_accounts.append({"name": view["name"], "message": view["message"]})
-            continue
         visible_accounts.append(view)
 
     return {"visible": visible_accounts, "hidden": hidden_accounts}


### PR DESCRIPTION
## Summary
- keep accounts with status messages in the dashboard payload so they remain visible for actions

## Testing
- python -m compileall risk_management

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69244b8cd2b483238868327f58b68735)