### PR TITLE
Fix syntax error in account parsing error handling

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -970,11 +970,6 @@ def _parse_accounts(
                     f"Account '{raw.get('name')}' references unknown api_key_id '{api_key_id}'."
                     + available_message
                     + suggestion_message
-
-                raise ValueError(
-                    f"Account '{raw.get('name')}' references unknown api_key_id '{api_key_id}'."
-                    + available_message
-
                 )
             key_payload = api_keys[api_key_id]
             if not exchange:


### PR DESCRIPTION
## Summary
- remove a duplicated ValueError block in `_parse_accounts` that introduced a syntax error

## Testing
- `python -m risk_management.web_server --config risk_management/realtime_config.json --host 0.0.0.0 --port 8000` *(fails: missing fastapi dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69246ee95d5483238fc1042a7270e01f)