### PR TITLE
Harden risk engine retries and equity accounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Risk CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Ruff (risk code and tests)
+        run: ruff check risk_management tests
+
+      - name: Black (check)
+        run: black --check risk_management tests
+
+      - name: Mypy (risk modules)
+        run: mypy risk_management
+
+      - name: Pytest with coverage
+        run: |
+          coverage run -m pytest
+          coverage report --include 'risk_management/*' --fail-under=90

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+black==24.4.2
+ruff==0.6.9
+mypy==1.11.1
+coverage==7.6.1

--- a/risk_management/risk_engine/__init__.py
+++ b/risk_management/risk_engine/__init__.py
@@ -1,0 +1,31 @@
+"""Risk engine components for realtime risk management.
+
+The package provides a minimal, testable surface for risk evaluation composed of
+exchange adapters, portfolio aggregation, rules evaluation, side-effectful
+action execution, and persistence of stateful thresholds.
+"""
+
+from .config import RiskEngineConfig, Settings
+from .exchange_client import ExchangeClientAdapter
+from .metrics import MetricRegistry
+from .portfolio_aggregator import PortfolioAggregator, PortfolioView
+from .risk_rules import RiskDecision, RiskDecisionLevel, RiskRulesEngine
+from .state_store import FileStateStore, StateStore
+from .action_executor import ActionExecutor
+from .risk_loop import risk_loop
+
+__all__ = [
+    "RiskEngineConfig",
+    "Settings",
+    "ExchangeClientAdapter",
+    "MetricRegistry",
+    "PortfolioAggregator",
+    "PortfolioView",
+    "RiskDecision",
+    "RiskDecisionLevel",
+    "RiskRulesEngine",
+    "FileStateStore",
+    "StateStore",
+    "ActionExecutor",
+    "risk_loop",
+]

--- a/risk_management/risk_engine/action_executor.py
+++ b/risk_management/risk_engine/action_executor.py
@@ -1,0 +1,173 @@
+"""Side-effectful execution of risk decisions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Iterable
+
+from risk_management._notifications import NotificationCoordinator
+from risk_management.account_clients import AccountClientProtocol
+
+from .config import RiskEngineConfig
+from .metrics import MetricRegistry
+from .portfolio_aggregator import PortfolioView
+from .risk_rules import RiskDecision, RiskDecisionLevel
+from .state_store import StateStore
+
+logger = logging.getLogger(__name__)
+
+
+class ActionExecutor:
+    """Perform actions with safety rails and optional dry-run."""
+
+    def __init__(
+        self,
+        config: RiskEngineConfig,
+        *,
+        state_store: StateStore,
+        notification_coordinator: NotificationCoordinator,
+        account_clients: Iterable[AccountClientProtocol],
+        metrics: MetricRegistry | None = None,
+    ) -> None:
+        self._config = config
+        self._state_store = state_store
+        self._notifications = notification_coordinator
+        self._account_clients = list(account_clients)
+        self._metrics = metrics or MetricRegistry()
+        self._failure_counts = {}
+
+    async def execute(self, decision: RiskDecision, view: PortfolioView) -> None:
+        logger.info(
+            "Executing risk decision",
+            extra={"decision": decision.level.value, "drawdown": decision.drawdown, "rationale": decision.rationale},
+        )
+        if decision.level is RiskDecisionLevel.NONE:
+            return
+        if decision.level is RiskDecisionLevel.ALERT:
+            self._emit(decision)
+            return
+        if decision.level is RiskDecisionLevel.CLOSE_POSITIONS:
+            await self._maybe_close_positions(decision, view)
+            return
+        if decision.level is RiskDecisionLevel.KILL_BOTS:
+            await self._maybe_kill_bots(decision)
+            return
+
+    def _emit(self, decision: RiskDecision) -> None:
+        subject = f"Risk alert: drawdown {decision.drawdown:.2%}"
+        body = decision.rationale
+        self._notifications.send_risk_signal(subject=subject, body=body, severity="warning")
+
+    async def _maybe_close_positions(self, decision: RiskDecision, view: PortfolioView) -> None:
+        action_key = f"close:{decision.breach_id}"
+        cooldown = self._config.actions.close_cooldown_seconds
+        if not self._state_store.should_execute(action_key, cooldown):
+            logger.info(
+                "Close positions already executed recently",
+                extra={"breach": decision.breach_id, "cooldown_seconds": cooldown},
+            )
+            return
+        if self._config.actions.dry_run:
+            logger.warning(
+                "[DRY-RUN] Would close positions",
+                extra={"breach": decision.breach_id, "rationale": decision.rationale},
+            )
+            self._emit(decision)
+            return
+        if self._config.actions.max_close_notional is not None:
+            total_notional = sum(position.notional for account in view.accounts for position in account.positions)
+            if total_notional > self._config.actions.max_close_notional:
+                logger.error(
+                    "Aborting close positions due to notional limit",
+                    extra={
+                        "breach": decision.breach_id,
+                        "limit": self._config.actions.max_close_notional,
+                        "total_notional": total_notional,
+                    },
+                )
+                return
+            logger.info(
+                "Within max close notional", extra={"total_notional": total_notional, "limit": self._config.actions.max_close_notional}
+            )
+        tasks = []
+        for client in self._account_clients:
+            client_name = self._client_name(client)
+            logger.info(
+                "Closing positions",
+                extra={"exchange": client_name, "rationale": decision.rationale, "breach": decision.breach_id},
+            )
+            tasks.append(self._close_with_backoff(client, action_key))
+        if tasks:
+            await asyncio.gather(*tasks)
+        self._state_store.record_action(action_key)
+        self._emit(decision)
+
+    async def _maybe_kill_bots(self, decision: RiskDecision) -> None:
+        action_key = f"kill:{decision.breach_id}"
+        cooldown = self._config.actions.kill_cooldown_seconds
+        if not self._state_store.should_execute(action_key, cooldown):
+            logger.info("Kill switch already executed recently for breach %s", decision.breach_id)
+            return
+        if self._config.actions.dry_run:
+            logger.warning("[DRY-RUN] Would trigger kill switch due to %s", decision.rationale)
+            self._emit(decision)
+            return
+        tasks = []
+        for client in self._account_clients:
+            client_name = self._client_name(client)
+            logger.critical("Executing kill switch for %s: %s", client_name, decision.rationale)
+            tasks.append(client.kill_switch())
+        if tasks:
+            try:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            except Exception as exc:  # pragma: no cover
+                logger.error("Error while executing kill switch: %s", exc, exc_info=True)
+        self._state_store.record_action(action_key)
+        self._emit(decision)
+
+    async def _close_with_backoff(self, client: AccountClientProtocol, action_key: str) -> None:
+        attempts = self._config.actions.close_retry_attempts
+        client_name = self._client_name(client)
+        for attempt in range(1, attempts + 1):
+            try:
+                await client.close_all_positions()
+                self._failure_counts.pop(client_name, None)
+                return
+            except Exception as exc:  # pragma: no cover - defensive
+                failures = self._failure_counts.get(client_name, 0) + 1
+                self._failure_counts[client_name] = failures
+                backoff = min(
+                    self._config.actions.backoff_seconds * failures,
+                    self._config.actions.max_backoff_seconds,
+                )
+                self._metrics.inc(
+                    "exchange_api_errors_total",
+                    labels={"exchange": client_name, "op": "close_all_positions", "code": getattr(exc, "code", "unknown")},
+                )
+                logger.error(
+                    "Close positions failed",
+                    extra={
+                        "exchange": client_name,
+                        "failure_count": failures,
+                        "backoff_seconds": backoff,
+                        "action": action_key,
+                        "error": str(exc),
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                    },
+                    exc_info=True,
+                )
+                if attempt >= attempts:
+                    logger.error(
+                        "Exhausted close position retries",
+                        extra={"exchange": client_name, "action": action_key, "attempts": attempts},
+                    )
+                    return
+                await asyncio.sleep(backoff)
+
+    def _client_name(self, client: AccountClientProtocol) -> str:
+        cfg = getattr(client, "config", None)
+        if cfg and getattr(cfg, "name", None):
+            return str(cfg.name)
+        return getattr(client, "name", "unknown")

--- a/risk_management/risk_engine/config.py
+++ b/risk_management/risk_engine/config.py
@@ -1,0 +1,162 @@
+"""Configuration schema for the refactored risk engine."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+from risk_management.configuration import RealtimeConfig
+
+
+@dataclass
+class ThresholdConfig:
+    """Alert and enforcement thresholds expressed as drawdown ratios."""
+
+    alert_drawdown: float = -0.03
+    close_positions_drawdown: float = -0.08
+    kill_bots_drawdown: float = -0.12
+
+
+@dataclass
+class ActionConfig:
+    """Action execution safety rails."""
+
+    dry_run: bool = False
+    close_cooldown_seconds: int = 900
+    kill_cooldown_seconds: int = 1800
+    max_close_notional: Optional[float] = None
+    backoff_seconds: float = 5.0
+    max_backoff_seconds: float = 60.0
+    close_retry_attempts: int = 3
+
+
+@dataclass
+class RiskEngineConfig:
+    """Unified configuration for risk rules and execution layers."""
+
+    thresholds: ThresholdConfig = field(default_factory=ThresholdConfig)
+    actions: ActionConfig = field(default_factory=ActionConfig)
+    state_path: Optional[Path] = None
+
+    @classmethod
+    def from_realtime_config(cls, config: RealtimeConfig) -> "RiskEngineConfig":
+        """Populate defaults from the existing realtime configuration."""
+
+        thresholds = ThresholdConfig()
+        # ``loss_threshold_pct`` is historically represented as a decimal (e.g., -0.08).
+        loss_threshold = config.alert_thresholds.get("loss_threshold_pct") if isinstance(
+            getattr(config, "alert_thresholds", None), dict
+        ) else None
+        if isinstance(loss_threshold, (int, float)):
+            thresholds.close_positions_drawdown = float(loss_threshold)
+            # Use a less aggressive alert threshold when only one value is supplied.
+            thresholds.alert_drawdown = float(loss_threshold) / 2
+        max_drawdown = config.alert_thresholds.get("max_drawdown_pct") if isinstance(
+            getattr(config, "alert_thresholds", None), dict
+        ) else None
+        if isinstance(max_drawdown, (int, float)) and max_drawdown > 0:
+            # Convert positive percentage into negative drawdown ratio.
+            thresholds.kill_bots_drawdown = -abs(float(max_drawdown))
+
+        reports_dir = config.reports_dir
+        state_path: Optional[Path] = None
+        if reports_dir:
+            state_path = Path(reports_dir) / "risk_state.json"
+
+        actions = ActionConfig()
+        return cls(thresholds=thresholds, actions=actions, state_path=state_path)
+
+
+@dataclass
+class Settings:
+    """Single entry point for risk configuration with environment overrides."""
+
+    risk: RiskEngineConfig
+    exchange_modes: Dict[str, bool] = field(default_factory=dict)
+    telegram_token: Optional[str] = None
+    telegram_chat_id: Optional[str] = None
+
+    @classmethod
+    def from_environment(
+        cls, *, realtime: Optional[RealtimeConfig] = None, env: Optional[Dict[str, str]] = None
+    ) -> "Settings":
+        env = env or os.environ
+        realtime = realtime or RealtimeConfig()
+        base = RiskEngineConfig.from_realtime_config(realtime)
+
+        alert_dd = _env_float(env.get("RISK_ALERT_DRAWDOWN"))
+        close_dd = _env_float(env.get("RISK_CLOSE_DRAWDOWN"))
+        kill_dd = _env_float(env.get("RISK_KILL_DRAWDOWN"))
+        if alert_dd is not None:
+            base.thresholds.alert_drawdown = alert_dd
+        if close_dd is not None:
+            base.thresholds.close_positions_drawdown = close_dd
+        if kill_dd is not None:
+            base.thresholds.kill_bots_drawdown = kill_dd
+
+        dry_run = _env_bool(env.get("RISK_DRY_RUN"))
+        if dry_run is not None:
+            base.actions.dry_run = dry_run
+        close_cooldown = _env_int(env.get("RISK_CLOSE_COOLDOWN_SECONDS"))
+        kill_cooldown = _env_int(env.get("RISK_KILL_COOLDOWN_SECONDS"))
+        if close_cooldown is not None:
+            base.actions.close_cooldown_seconds = close_cooldown
+        if kill_cooldown is not None:
+            base.actions.kill_cooldown_seconds = kill_cooldown
+        max_notional = _env_float(env.get("RISK_MAX_CLOSE_NOTIONAL"))
+        if max_notional is not None:
+            base.actions.max_close_notional = max_notional
+
+        backoff = _env_float(env.get("RISK_BACKOFF_SECONDS"))
+        max_backoff = _env_float(env.get("RISK_MAX_BACKOFF_SECONDS"))
+        retry_attempts = _env_int(env.get("RISK_CLOSE_RETRY_ATTEMPTS"))
+        if backoff is not None:
+            base.actions.backoff_seconds = backoff
+        if max_backoff is not None:
+            base.actions.max_backoff_seconds = max_backoff
+        if retry_attempts is not None and retry_attempts > 0:
+            base.actions.close_retry_attempts = retry_attempts
+
+        telegram_token = env.get("RISK_TELEGRAM_TOKEN") or getattr(realtime, "tg_bot_token", None)
+        telegram_chat_id = env.get("RISK_TELEGRAM_CHAT_ID") or getattr(realtime, "tg_bot_chat_id", None)
+
+        exchange_modes: Dict[str, bool] = {}
+        for name, cfg in realtime.accounts.items():
+            exchange_modes[name] = bool(getattr(cfg, "one_way_mode", True))
+        for key, value in env.items():
+            if key.startswith("RISK_EXCHANGE_ONE_WAY_"):
+                exchange_name = key.replace("RISK_EXCHANGE_ONE_WAY_", "").lower()
+                exchange_modes[exchange_name] = _env_bool(value) if value is not None else True
+
+        return cls(
+            risk=base,
+            exchange_modes=exchange_modes,
+            telegram_token=telegram_token,
+            telegram_chat_id=telegram_chat_id,
+        )
+
+
+def _env_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _env_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _env_bool(value: Optional[str]) -> Optional[bool]:
+    if value is None:
+        return None
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}

--- a/risk_management/risk_engine/exchange_client.py
+++ b/risk_management/risk_engine/exchange_client.py
@@ -1,0 +1,133 @@
+"""Adapters that wrap account clients with one-way safe operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+from risk_management.account_clients import AccountClientProtocol
+
+from .metrics import MetricRegistry, Timer
+
+logger = logging.getLogger(__name__)
+
+ONE_WAY_ERROR_CODES = {"-4061", "-4164"}
+
+
+class ExchangeClientAdapter:
+    """Thin adapter around :class:`AccountClientProtocol` with Binance one-way guards."""
+
+    def __init__(
+        self, client: AccountClientProtocol, *, one_way_mode: bool = True, metrics: Optional[MetricRegistry] = None
+    ) -> None:
+        self._client = client
+        self._one_way_mode = one_way_mode
+        self._metrics = metrics or MetricRegistry()
+
+    @property
+    def name(self) -> str:
+        return self._client.config.name
+
+    @property
+    def config(self):  # pragma: no cover - passthrough for legacy callers
+        return self._client.config
+
+    async def fetch(self) -> Mapping[str, Any]:
+        with Timer(self._metrics, "exchange_api_latency_seconds", labels={"exchange": self.name, "op": "fetch"}):
+            try:
+                return await self._client.fetch()
+            except Exception as exc:  # pragma: no cover - metrics/logging
+                self._metrics.inc(
+                    "exchange_api_errors_total", labels={"exchange": self.name, "op": "fetch", "code": _error_code(exc)}
+                )
+                logger.error(
+                    "Failed to fetch account snapshot",
+                    extra={"exchange": self.name, "error": str(exc), "op": "fetch"},
+                )
+                raise
+
+    async def kill_switch(self, symbol: Optional[str] = None) -> Mapping[str, Any]:
+        with Timer(self._metrics, "exchange_api_latency_seconds", labels={"exchange": self.name, "op": "kill_switch"}):
+            return await self._client.kill_switch(symbol)
+
+    async def close_all_positions(self, symbol: Optional[str] = None) -> Mapping[str, Any]:
+        with Timer(
+            self._metrics,
+            "exchange_api_latency_seconds",
+            labels={"exchange": self.name, "op": "close_all_positions"},
+        ):
+            return await self._client.close_all_positions(symbol)
+
+    async def cancel_all_orders(self, symbol: Optional[str] = None) -> Mapping[str, Any]:
+        with Timer(
+            self._metrics,
+            "exchange_api_latency_seconds",
+            labels={"exchange": self.name, "op": "cancel_all_orders"},
+        ):
+            return await self._client.cancel_all_orders(symbol)
+
+    async def create_order(
+        self,
+        symbol: str,
+        order_type: str,
+        side: str,
+        amount: float,
+        price: Optional[float] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        """Place an order while stripping ``positionSide`` in one-way mode.
+
+        Binance one-way mode rejects orders when ``positionSide`` is provided. We
+        defensively drop the parameter and retry when ccxt propagates -4061 or
+        -4164 errors to avoid "position side does not match" failures.
+        """
+
+        cleaned_params: MutableMapping[str, Any] = {}
+        if isinstance(params, Mapping):
+            cleaned_params.update(params)
+        if self._one_way_mode:
+            cleaned_params.pop("positionSide", None)
+        labels = {"exchange": self.name, "op": "create_order"}
+        with Timer(self._metrics, "exchange_api_latency_seconds", labels=labels):
+            try:
+                return await self._client.create_order(
+                    symbol, order_type, side, amount, price, params=cleaned_params
+                )
+            except Exception as exc:
+                code = _error_code(exc)
+                message = str(exc)
+                if self._one_way_mode and code in ONE_WAY_ERROR_CODES:
+                    logger.warning(
+                        "Retrying order without positionSide in one-way mode",
+                        extra={"exchange": self.name, "symbol": symbol, "side": side, "error": message},
+                    )
+                    cleaned_params.pop("positionSide", None)
+                    return await self._client.create_order(
+                        symbol, order_type, side, amount, price, params=cleaned_params
+                    )
+                self._metrics.inc("exchange_api_errors_total", labels={**labels, "code": code})
+                logger.error(
+                    "Exchange order failed",
+                    extra={"exchange": self.name, "symbol": symbol, "side": side, "error_code": code, "error": message},
+                )
+                raise
+
+    async def close_position(self, symbol: str) -> Mapping[str, Any]:
+        with Timer(self._metrics, "exchange_api_latency_seconds", labels={"exchange": self.name, "op": "close_position"}):
+            return await self._client.close_position(symbol)
+
+    async def list_order_types(self) -> Sequence[str]:
+        return await self._client.list_order_types()
+
+
+def _error_code(exc: Exception) -> str:
+    code = getattr(exc, "code", None)
+    if isinstance(code, (int, str)):
+        code_str = str(code)
+        if code_str:
+            return code_str
+    message = str(exc)
+    for token in ONE_WAY_ERROR_CODES:
+        if token in message:
+            return token
+    return "unknown"

--- a/risk_management/risk_engine/metrics.py
+++ b/risk_management/risk_engine/metrics.py
@@ -1,0 +1,52 @@
+"""Lightweight metrics registry for the risk engine."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, MutableMapping, Tuple
+
+
+@dataclass
+class MetricRegistry:
+    """A minimal Prometheus-style collector used for in-process accounting."""
+
+    counters: MutableMapping[Tuple[str, Tuple[Tuple[str, str], ...]], float] = field(
+        default_factory=lambda: defaultdict(float)
+    )
+    histograms: MutableMapping[Tuple[str, Tuple[Tuple[str, str], ...]], list] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+    def inc(self, name: str, *, labels: Mapping[str, str] | None = None, amount: float = 1.0) -> None:
+        key = self._key(name, labels)
+        self.counters[key] += amount
+
+    def observe(self, name: str, value: float, *, labels: Mapping[str, str] | None = None) -> None:
+        key = self._key(name, labels)
+        self.histograms[key].append(value)
+
+    def _key(self, name: str, labels: Mapping[str, str] | None) -> Tuple[str, Tuple[Tuple[str, str], ...]]:
+        sorted_labels = tuple(sorted((labels or {}).items()))
+        return name, sorted_labels
+
+
+class Timer:
+    """Context manager to record elapsed time into a histogram."""
+
+    def __init__(self, registry: MetricRegistry, name: str, *, labels: Mapping[str, str] | None = None) -> None:
+        self._registry = registry
+        self._name = name
+        self._labels = labels
+        self._start: float | None = None
+
+    def __enter__(self) -> "Timer":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._start is None:
+            return
+        duration = time.perf_counter() - self._start
+        self._registry.observe(self._name, duration, labels=self._labels)

--- a/risk_management/risk_engine/portfolio_aggregator.py
+++ b/risk_management/risk_engine/portfolio_aggregator.py
@@ -1,0 +1,140 @@
+"""Aggregate cross-exchange snapshots into a portfolio view."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PositionBreakdown:
+    symbol: str
+    notional: float
+    unrealized_pnl: float
+
+    def to_payload(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class AccountBreakdown:
+    name: str
+    balance: float
+    equity: float
+    unrealized_pnl: float
+    realized_pnl: float
+    positions: List[PositionBreakdown] = field(default_factory=list)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["positions"] = [position.to_payload() for position in self.positions]
+        return payload
+
+
+@dataclass
+class PortfolioView:
+    total_balance: float
+    total_equity: float
+    total_unrealized_pnl: float
+    total_realized_pnl: float
+    net_cashflow: float
+    accounts: List[AccountBreakdown] = field(default_factory=list)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["accounts"] = [account.to_payload() for account in self.accounts]
+        return payload
+
+
+class PortfolioAggregator:
+    """Compute a consolidated portfolio view from account snapshots."""
+
+    def aggregate(
+        self, accounts_payload: Iterable[Mapping[str, Any]], cashflow_events: Iterable[Mapping[str, Any]]
+    ) -> PortfolioView:
+        account_breakdowns: List[AccountBreakdown] = []
+        total_balance = 0.0
+        total_unrealized = 0.0
+        total_realized = 0.0
+        for account in accounts_payload:
+            if not isinstance(account, Mapping):
+                continue
+            name = str(account.get("name", ""))
+            balance = _coerce_float(account.get("balance"), fallback=0.0)
+            unrealized = self._sum_unrealized(account.get("positions"))
+            realized = _coerce_float(account.get("realized_pnl"), fallback=0.0)
+            total_balance += balance
+            total_unrealized += unrealized
+            total_realized += realized
+            equity = balance + unrealized + realized
+            positions = self._positions(account.get("positions"))
+            account_breakdowns.append(
+                AccountBreakdown(
+                    name=name,
+                    balance=balance,
+                    equity=equity,
+                    unrealized_pnl=unrealized,
+                    realized_pnl=realized,
+                    positions=positions,
+                )
+            )
+        net_cashflow = self._net_cashflow(cashflow_events)
+        total_equity = total_balance + total_unrealized + total_realized
+        return PortfolioView(
+            total_balance=total_balance,
+            total_equity=total_equity,
+            total_unrealized_pnl=total_unrealized,
+            total_realized_pnl=total_realized,
+            net_cashflow=net_cashflow,
+            accounts=account_breakdowns,
+        )
+
+    def _sum_unrealized(self, positions: Any) -> float:
+        unrealized = 0.0
+        for position in positions or []:
+            if not isinstance(position, Mapping):
+                continue
+            unrealized += _coerce_float(position.get("unrealized_pnl") or position.get("pnl"), fallback=0.0)
+        return unrealized
+
+    def _positions(self, positions: Any) -> List[PositionBreakdown]:
+        breakdowns: List[PositionBreakdown] = []
+        for position in positions or []:
+            if not isinstance(position, Mapping):
+                continue
+            symbol = str(position.get("symbol") or position.get("pair") or "").strip()
+            if not symbol:
+                continue
+            notional = _coerce_float(position.get("signed_notional") or position.get("notional"), fallback=0.0)
+            unrealized = _coerce_float(position.get("unrealized_pnl") or position.get("pnl"), fallback=0.0)
+            breakdowns.append(PositionBreakdown(symbol=symbol, notional=abs(notional), unrealized_pnl=unrealized))
+        return breakdowns
+
+    def _net_cashflow(self, events: Iterable[Mapping[str, Any]]) -> float:
+        net = 0.0
+        for event in events or []:
+            if not isinstance(event, Mapping):
+                continue
+            try:
+                amount = float(event.get("amount", 0.0))
+            except (TypeError, ValueError):
+                continue
+            event_type = str(event.get("type") or "").lower()
+            if event_type == "deposit":
+                net += amount
+            elif event_type == "withdrawal":
+                net -= amount
+        return net
+
+
+def _coerce_float(value: Any, *, fallback: float = 0.0) -> float:
+    try:
+        if value is None:
+            return fallback
+        return float(value)
+    except (TypeError, ValueError):
+        logger.debug("Failed to coerce %r to float; using fallback %s", value, fallback)
+        return fallback

--- a/risk_management/risk_engine/risk_loop.py
+++ b/risk_management/risk_engine/risk_loop.py
@@ -1,0 +1,102 @@
+"""Top-level orchestration for the risk engine loop."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, Mapping, MutableSequence, Optional, Tuple
+
+from .action_executor import ActionExecutor
+from .config import RiskEngineConfig
+from .exchange_client import ExchangeClientAdapter
+from .metrics import MetricRegistry, Timer
+from .portfolio_aggregator import PortfolioAggregator, PortfolioView
+from .risk_rules import RiskDecision, RiskRulesEngine
+from .state_store import StateStore
+
+logger = logging.getLogger(__name__)
+
+
+async def risk_loop(
+    clients: Dict[str, ExchangeClientAdapter],
+    rules_engine: RiskRulesEngine,
+    action_executor: ActionExecutor,
+    state_store: StateStore,
+    config: RiskEngineConfig,
+    *,
+    aggregator: Optional[PortfolioAggregator] = None,
+    metrics: Optional[MetricRegistry] = None,
+) -> Tuple[RiskDecision, PortfolioView]:
+    """Run a single iteration of the risk pipeline.
+
+    Steps:
+    1. Fetch snapshots from each exchange client (dropping any that fail).
+    2. Aggregate snapshots into a portfolio view while separating cashflows from PnL.
+    3. Evaluate drawdown rules using the provided ``rules_engine`` and ``state_store``.
+    4. Execute resulting actions via ``action_executor`` with its configured safety rails.
+    5. Return the decision and aggregated portfolio view for observability.
+    """
+
+    aggregator = aggregator or PortfolioAggregator()
+    metrics = metrics or MetricRegistry()
+    account_payloads: MutableSequence[Mapping[str, object]] = []
+    cashflow_events: MutableSequence[Mapping[str, object]] = []
+
+    loop_start = time.perf_counter()
+    for name, client in clients.items():
+        try:
+            with Timer(metrics, "exchange_api_latency_seconds", labels={"exchange": name, "op": "fetch_snapshot"}):
+                snapshot = await client.fetch()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            metrics.inc("exchange_api_errors_total", labels={"exchange": name, "op": "fetch_snapshot", "code": getattr(exc, "code", "unknown") or "unknown"})
+            logger.error(
+                "Failed to fetch snapshot",
+                extra={"exchange": name, "error": str(exc), "op": "fetch_snapshot"},
+                exc_info=True,
+            )
+            continue
+
+        if not isinstance(snapshot, Mapping):
+            metrics.inc(
+                "exchange_api_errors_total",
+                labels={"exchange": name, "op": "fetch_snapshot", "code": "malformed"},
+            )
+            logger.warning(
+                "Ignoring malformed snapshot",
+                extra={"exchange": name, "type": str(type(snapshot)), "op": "fetch_snapshot"},
+            )
+            continue
+
+        account_payload = snapshot.get("account") if "account" in snapshot else snapshot
+        if isinstance(account_payload, Mapping):
+            account_payloads.append(account_payload)
+        else:
+            metrics.inc(
+                "exchange_api_errors_total",
+                labels={"exchange": name, "op": "fetch_snapshot", "code": "missing_account"},
+            )
+            logger.warning(
+                "Snapshot missing account payload",
+                extra={"exchange": name, "op": "fetch_snapshot"},
+            )
+
+        cashflows = snapshot.get("cashflow_events") or snapshot.get("cashflows") or []
+        if isinstance(cashflows, list):
+            cashflow_events.extend([cf for cf in cashflows if isinstance(cf, Mapping)])
+
+    portfolio_view = aggregator.aggregate(account_payloads, cashflow_events)
+    decision = rules_engine.evaluate(portfolio_view, state_store)
+    metrics.inc("risk_actions_total", labels={"action": decision.level.value})
+    await action_executor.execute(decision, portfolio_view)
+    duration = time.perf_counter() - loop_start
+    metrics.observe("risk_loop_latency_seconds", duration)
+    logger.info(
+        "Risk loop completed",
+        extra={
+            "decision": decision.level.value,
+            "drawdown": round(decision.drawdown, 4),
+            "equity": round(decision.adjusted_equity, 2),
+            "duration": duration,
+        },
+    )
+    return decision, portfolio_view

--- a/risk_management/risk_engine/risk_rules.py
+++ b/risk_management/risk_engine/risk_rules.py
@@ -1,0 +1,102 @@
+"""Pure risk decision logic based on aggregated portfolio data."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Dict
+
+from .config import RiskEngineConfig
+from .portfolio_aggregator import PortfolioView
+from .state_store import StateStore
+
+logger = logging.getLogger(__name__)
+
+
+class RiskDecisionLevel(str, Enum):
+    NONE = "none"
+    ALERT = "alert"
+    CLOSE_POSITIONS = "close_positions"
+    KILL_BOTS = "kill_bots"
+
+
+@dataclass
+class RiskDecision:
+    level: RiskDecisionLevel
+    drawdown: float
+    adjusted_equity: float
+    high_water: float
+    rationale: str
+    breach_id: str
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["level"] = self.level.value
+        return payload
+
+
+class RiskRulesEngine:
+    """Evaluate drawdown rules without side effects."""
+
+    def __init__(self, config: RiskEngineConfig) -> None:
+        self._config = config
+
+    def evaluate(self, view: PortfolioView, state_store: StateStore) -> RiskDecision:
+        state = state_store.load()
+        adjusted_equity = view.total_equity - view.net_cashflow
+        if view.net_cashflow:
+            logger.info(
+                "Adjusting equity for net cashflow",
+                extra={"net_cashflow": view.net_cashflow, "raw_equity": view.total_equity, "adjusted_equity": adjusted_equity},
+            )
+        high_water = state.high_water or adjusted_equity
+        high_water = max(high_water, adjusted_equity)
+        drawdown = 0.0
+        if high_water > 0:
+            drawdown = (high_water - adjusted_equity) / high_water
+
+        state_store.save(high_water=high_water, baseline_equity=state.baseline_equity or adjusted_equity)
+
+        decision_level = RiskDecisionLevel.NONE
+        rationale = ""
+        thresholds = self._config.thresholds
+        if drawdown >= abs(thresholds.kill_bots_drawdown):
+            decision_level = RiskDecisionLevel.KILL_BOTS
+            rationale = f"Drawdown {drawdown:.2%} exceeds kill threshold {abs(thresholds.kill_bots_drawdown):.2%}"
+        elif drawdown >= abs(thresholds.close_positions_drawdown):
+            decision_level = RiskDecisionLevel.CLOSE_POSITIONS
+            rationale = (
+                f"Drawdown {drawdown:.2%} exceeds close threshold {abs(thresholds.close_positions_drawdown):.2%}"
+            )
+        elif drawdown >= abs(thresholds.alert_drawdown):
+            decision_level = RiskDecisionLevel.ALERT
+            rationale = f"Drawdown {drawdown:.2%} exceeds alert threshold {abs(thresholds.alert_drawdown):.2%}"
+        else:
+            rationale = "Drawdown within tolerance"
+
+        breach_id = state_store.breach_id(drawdown, high_water)
+        log_level = logging.INFO
+        if decision_level is RiskDecisionLevel.ALERT:
+            log_level = logging.WARNING
+        elif decision_level in (RiskDecisionLevel.CLOSE_POSITIONS, RiskDecisionLevel.KILL_BOTS):
+            log_level = logging.ERROR
+        logger.log(
+            log_level,
+            "Evaluated risk decision",
+            extra={
+                "decision": decision_level.value,
+                "drawdown": drawdown,
+                "rationale": rationale,
+                "adjusted_equity": adjusted_equity,
+                "high_water": high_water,
+            },
+        )
+        return RiskDecision(
+            level=decision_level,
+            drawdown=drawdown,
+            adjusted_equity=adjusted_equity,
+            high_water=high_water,
+            rationale=rationale,
+            breach_id=breach_id,
+        )

--- a/risk_management/risk_engine/state_store.py
+++ b/risk_management/risk_engine/state_store.py
@@ -1,0 +1,112 @@
+"""Persistence for drawdown baselines and executed actions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from time import time
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RiskState:
+    baseline_equity: Optional[float]
+    high_water: Optional[float]
+    actions: Dict[str, float]
+
+
+class StateStore:
+    def load(self) -> RiskState:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def save(self, *, baseline_equity: Optional[float], high_water: Optional[float]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def record_action(self, action_key: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def should_execute(self, action_key: str, cooldown_seconds: int) -> bool:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def breach_id(self, drawdown: float, high_water: float) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class FileStateStore(StateStore):
+    """Simple JSON-backed persistence for risk decisions."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> RiskState:
+        if not self._path.exists():
+            return RiskState(baseline_equity=None, high_water=None, actions={})
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to read risk state file %s: %s", self._path, exc)
+            return RiskState(baseline_equity=None, high_water=None, actions={})
+        return RiskState(
+            baseline_equity=payload.get("baseline_equity"),
+            high_water=payload.get("high_water"),
+            actions={k: float(v) for k, v in (payload.get("actions") or {}).items()},
+        )
+
+    def save(self, *, baseline_equity: Optional[float], high_water: Optional[float]) -> None:
+        state = self.load()
+        if baseline_equity is not None:
+            state.baseline_equity = baseline_equity
+        if high_water is not None:
+            state.high_water = high_water
+        payload = {
+            "baseline_equity": state.baseline_equity,
+            "high_water": state.high_water,
+            "actions": state.actions,
+        }
+        try:
+            _atomic_write(self._path, json.dumps(payload, indent=2))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to persist risk state %s: %s", self._path, exc)
+
+    def record_action(self, action_key: str) -> None:
+        state = self.load()
+        state.actions[action_key] = time()
+        payload = {
+            "baseline_equity": state.baseline_equity,
+            "high_water": state.high_water,
+            "actions": state.actions,
+        }
+        try:
+            _atomic_write(self._path, json.dumps(payload, indent=2))
+        except Exception as exc:  # pragma: no cover
+            logger.error("Failed to persist action state %s: %s", self._path, exc)
+
+    def should_execute(self, action_key: str, cooldown_seconds: int) -> bool:
+        state = self.load()
+        last = state.actions.get(action_key)
+        if last is None:
+            return True
+        return (time() - last) >= cooldown_seconds
+
+    def breach_id(self, drawdown: float, high_water: float) -> str:
+        drawdown_bucket = round(drawdown, 3)
+        high_water_bucket = round(high_water or 0.0, 1)
+        return f"dd:{drawdown_bucket:.3f}|hw:{high_water_bucket:.1f}"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, dir=path.parent, encoding="utf-8")
+    try:
+        with tmp as f:
+            f.write(content)
+            f.flush()
+        Path(tmp.name).replace(path)
+    except Exception:
+        Path(tmp.name).unlink(missing_ok=True)  # type: ignore[arg-type]
+        raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,9 @@ import types
 # Ensure we can import modules from the src/ directory as "downloader"
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 SRC_DIR = os.path.join(ROOT_DIR, "src")
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 if SRC_DIR not in sys.path:
     sys.path.insert(0, SRC_DIR)
 

--- a/tests/risk_management/test_risk_engine_action_executor.py
+++ b/tests/risk_management/test_risk_engine_action_executor.py
@@ -1,0 +1,144 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import pytest
+
+from risk_management.risk_engine.action_executor import ActionExecutor
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+from risk_management.risk_engine.action_executor import ActionExecutor
+from risk_management.risk_engine.config import ActionConfig, RiskEngineConfig
+from risk_management.risk_engine.portfolio_aggregator import AccountBreakdown, PortfolioView
+from risk_management.risk_engine.risk_rules import RiskDecision, RiskDecisionLevel
+from risk_management.risk_engine.state_store import StateStore, RiskState
+
+
+class InMemoryStore(StateStore):
+    def __init__(self):
+        self.actions: Dict[str, float] = {}
+
+    def load(self) -> RiskState:
+        return RiskState(baseline_equity=None, high_water=None, actions=self.actions)
+
+    def save(self, *, baseline_equity: Optional[float], high_water: Optional[float]) -> None:
+        return None
+
+    def record_action(self, action_key: str) -> None:
+        self.actions[action_key] = 0
+
+    def should_execute(self, action_key: str, cooldown_seconds: int) -> bool:
+        return action_key not in self.actions
+
+    def breach_id(self, drawdown: float, high_water: float) -> str:
+        return f"{drawdown:.2f}:{high_water:.2f}"
+
+
+class DummyNotifier:
+    def __init__(self):
+        self.messages = []
+
+    def send_risk_signal(self, *, subject: str, body: str, severity: str = "info") -> None:
+        self.messages.append({"subject": subject, "body": body, "severity": severity})
+
+
+class DummyClient:
+    def __init__(self, name: str):
+        self.config = SimpleNamespace(name=name)
+        self.closed = 0
+        self.killed = 0
+
+    async def close_all_positions(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        self.closed += 1
+        return {"symbol": symbol}
+
+    async def kill_switch(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        self.killed += 1
+        return {"symbol": symbol}
+
+
+def test_alert_emits_notification_only():
+    notifier = DummyNotifier()
+    store = InMemoryStore()
+    config = RiskEngineConfig(actions=ActionConfig(dry_run=False))
+    executor = ActionExecutor(config, state_store=store, notification_coordinator=notifier, account_clients=[])
+    decision = RiskDecision(
+        level=RiskDecisionLevel.ALERT,
+        drawdown=0.05,
+        adjusted_equity=900,
+        high_water=1000,
+        rationale="alert",
+        breach_id="id1",
+    )
+
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+
+    assert notifier.messages and notifier.messages[0]["severity"] == "warning"
+
+
+def test_close_positions_respects_dry_run_and_cooldown():
+    notifier = DummyNotifier()
+    store = InMemoryStore()
+    config = RiskEngineConfig(actions=ActionConfig(dry_run=True, close_cooldown_seconds=999))
+    client = DummyClient("binance")
+    executor = ActionExecutor(config, state_store=store, notification_coordinator=notifier, account_clients=[client])
+    decision = RiskDecision(
+        level=RiskDecisionLevel.CLOSE_POSITIONS,
+        drawdown=0.1,
+        adjusted_equity=800,
+        high_water=1000,
+        rationale="close",
+        breach_id="breach",
+    )
+
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+
+    assert client.closed == 0  # dry-run prevents execution
+    assert len(notifier.messages) == 2  # both executions emit signal
+
+
+def test_close_positions_executes_once_per_breach():
+    notifier = DummyNotifier()
+    store = InMemoryStore()
+    config = RiskEngineConfig(actions=ActionConfig(dry_run=False, close_cooldown_seconds=999))
+    client = DummyClient("bybit")
+    executor = ActionExecutor(config, state_store=store, notification_coordinator=notifier, account_clients=[client])
+    decision = RiskDecision(
+        level=RiskDecisionLevel.CLOSE_POSITIONS,
+        drawdown=0.2,
+        adjusted_equity=500,
+        high_water=1000,
+        rationale="breach",
+        breach_id="breach-1",
+    )
+
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+
+    assert client.closed == 1
+    assert any(msg["severity"] == "warning" for msg in notifier.messages)
+
+
+def test_kill_bots_respects_cooldown():
+    notifier = DummyNotifier()
+    store = InMemoryStore()
+    config = RiskEngineConfig(actions=ActionConfig(dry_run=False, kill_cooldown_seconds=999))
+    client = DummyClient("okx")
+    executor = ActionExecutor(config, state_store=store, notification_coordinator=notifier, account_clients=[client])
+    decision = RiskDecision(
+        level=RiskDecisionLevel.KILL_BOTS,
+        drawdown=0.3,
+        adjusted_equity=400,
+        high_water=1000,
+        rationale="kill",
+        breach_id="breach-2",
+    )
+
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+    asyncio.run(executor.execute(decision, PortfolioView(0, 0, 0, 0, 0)))
+
+    assert client.killed == 1
+    assert notifier.messages

--- a/tests/risk_management/test_risk_engine_exchange_client.py
+++ b/tests/risk_management/test_risk_engine_exchange_client.py
@@ -1,0 +1,97 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Mapping, Optional, Sequence
+
+import pytest
+
+from risk_management.risk_engine.exchange_client import ExchangeClientAdapter, ONE_WAY_ERROR_CODES
+
+
+class DummyClient:
+    def __init__(self):
+        self.config = SimpleNamespace(name="dummy")
+        self.calls = []
+        self.side_effects = []
+
+    async def fetch(self) -> Mapping[str, Any]:  # pragma: no cover - unused
+        return {}
+
+    async def close(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def kill_switch(self, symbol: Optional[str] = None) -> Mapping[str, Any]:  # pragma: no cover - unused
+        return {"symbol": symbol}
+
+    async def close_all_positions(self, symbol: Optional[str] = None) -> Mapping[str, Any]:  # pragma: no cover - unused
+        return {"closed": symbol}
+
+    async def cancel_all_orders(self, symbol: Optional[str] = None) -> Mapping[str, Any]:  # pragma: no cover - unused
+        return {"cancelled": symbol}
+
+    async def list_order_types(self) -> Sequence[str]:  # pragma: no cover - unused
+        return ["market"]
+
+    async def close_position(self, symbol: str) -> Mapping[str, Any]:  # pragma: no cover - unused
+        return {"closed": symbol}
+
+    async def create_order(
+        self,
+        symbol: str,
+        order_type: str,
+        side: str,
+        amount: float,
+        price: Optional[float] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        self.calls.append({"symbol": symbol, "params": params})
+        if self.side_effects:
+            effect = self.side_effects.pop(0)
+            if isinstance(effect, BaseException):
+                raise effect
+        return {"symbol": symbol, "params": params}
+
+
+def test_one_way_strips_position_side():
+    client = DummyClient()
+    adapter = ExchangeClientAdapter(client, one_way_mode=True)
+
+    result = asyncio.run(
+        adapter.create_order(
+            "BTC/USDT", "market", "buy", 1, params={"positionSide": "LONG", "foo": "bar"}
+        )
+    )
+
+    assert client.calls[-1]["params"].get("positionSide") is None
+    assert result["params"].get("positionSide") is None
+    assert client.calls[-1]["params"].get("foo") == "bar"
+
+
+def test_one_way_retries_on_position_side_errors():
+    client = DummyClient()
+    client.side_effects.append(Exception("-4061 position side does not match"))
+    adapter = ExchangeClientAdapter(client, one_way_mode=True)
+
+    result = asyncio.run(
+        adapter.create_order(
+            "ETH/USDT", "limit", "sell", 2, price=1000, params={"positionSide": "SHORT"}
+        )
+    )
+
+    assert len(client.calls) == 2  # retry once
+    for call in client.calls:
+        assert call["params"].get("positionSide") is None
+    assert result["params"].get("positionSide") is None
+
+
+def test_hedge_mode_preserves_position_side_and_does_not_retry():
+    client = DummyClient()
+    adapter = ExchangeClientAdapter(client, one_way_mode=False)
+
+    asyncio.run(
+        adapter.create_order(
+            "ETH/USDT", "limit", "sell", 1, price=900, params={"positionSide": "SHORT"}
+        )
+    )
+
+    assert len(client.calls) == 1
+    assert client.calls[0]["params"].get("positionSide") == "SHORT"

--- a/tests/risk_management/test_risk_engine_portfolio_aggregator.py
+++ b/tests/risk_management/test_risk_engine_portfolio_aggregator.py
@@ -1,0 +1,87 @@
+import pytest
+
+from risk_management.risk_engine.portfolio_aggregator import PortfolioAggregator, PortfolioView
+
+
+def test_aggregate_multiple_exchanges():
+    aggregator = PortfolioAggregator()
+    accounts = [
+        {
+            "name": "binance",
+            "balance": 1000,
+            "positions": [
+                {"symbol": "BTC/USDT", "signed_notional": 500, "unrealized_pnl": 50},
+                {"symbol": "ETH/USDT", "signed_notional": -200, "unrealized_pnl": -10},
+            ],
+            "realized_pnl": 20,
+        },
+        {
+            "name": "bybit",
+            "balance": 800,
+            "positions": [
+                {"symbol": "BTC/USDT", "signed_notional": 300, "unrealized_pnl": 30},
+            ],
+            "realized_pnl": -5,
+        },
+    ]
+    cashflows = [
+        {"type": "deposit", "amount": 100},
+        {"type": "withdrawal", "amount": 50},
+    ]
+
+    view = aggregator.aggregate(accounts, cashflows)
+
+    assert isinstance(view, PortfolioView)
+    assert view.total_balance == pytest.approx(1800)
+    assert view.total_unrealized_pnl == pytest.approx(70)
+    assert view.total_realized_pnl == pytest.approx(15)
+    assert view.total_equity == pytest.approx(1885)
+    assert view.net_cashflow == pytest.approx(50)
+    assert len(view.accounts) == 2
+    assert view.accounts[0].equity == pytest.approx(1060)
+    assert view.accounts[1].equity == pytest.approx(825)
+
+
+def test_aggregate_handles_missing_or_down_accounts():
+    aggregator = PortfolioAggregator()
+    accounts = [
+        None,
+        {
+            "name": "okx",
+            "balance": 500,
+            "positions": [],
+        },
+    ]
+
+    view = aggregator.aggregate(accounts, cashflow_events=[])
+
+    assert view.total_balance == pytest.approx(500)
+    assert view.total_unrealized_pnl == pytest.approx(0)
+    assert view.total_equity == pytest.approx(500)
+    assert view.net_cashflow == pytest.approx(0)
+    assert len(view.accounts) == 1
+
+
+def test_aggregate_negative_unrealized_on_single_exchange():
+    aggregator = PortfolioAggregator()
+    accounts = [
+        {
+            "name": "binance",
+            "balance": 1000,
+            "positions": [
+                {"symbol": "SOL/USDT", "signed_notional": 400, "unrealized_pnl": -100},
+            ],
+        },
+        {
+            "name": "bybit",
+            "balance": 1200,
+            "positions": [],
+        },
+    ]
+
+    view = aggregator.aggregate(accounts, cashflow_events=[])
+
+    assert view.total_balance == pytest.approx(2200)
+    assert view.total_unrealized_pnl == pytest.approx(-100)
+    assert view.total_equity == pytest.approx(2100)
+    assert any(pos.symbol == "SOL/USDT" for pos in view.accounts[0].positions)

--- a/tests/risk_management/test_risk_engine_risk_loop_e2e.py
+++ b/tests/risk_management/test_risk_engine_risk_loop_e2e.py
@@ -1,0 +1,220 @@
+import asyncio
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from risk_management.risk_engine import (
+    ActionExecutor,
+    ExchangeClientAdapter,
+    PortfolioAggregator,
+    RiskDecisionLevel,
+    RiskEngineConfig,
+    RiskRulesEngine,
+    risk_loop,
+)
+from risk_management.risk_engine.state_store import RiskState, StateStore
+
+
+@dataclass
+class _AccountConfig:
+    name: str
+
+
+class FakeNotificationCoordinator:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def send_risk_signal(self, *, subject: str, body: str, severity: str) -> None:
+        self.messages.append({"subject": subject, "body": body, "severity": severity})
+
+
+class FakeStateStore(StateStore):
+    def __init__(self, baseline_equity=None, high_water=None) -> None:
+        self._state = RiskState(baseline_equity=baseline_equity, high_water=high_water, actions={})
+
+    def load(self) -> RiskState:
+        return self._state
+
+    def save(self, *, baseline_equity, high_water) -> None:
+        if baseline_equity is not None:
+            self._state.baseline_equity = baseline_equity
+        if high_water is not None:
+            self._state.high_water = high_water
+
+    def record_action(self, action_key: str) -> None:
+        self._state.actions[action_key] = time.time()
+
+    def should_execute(self, action_key: str, cooldown_seconds: int) -> bool:
+        last = self._state.actions.get(action_key)
+        if last is None:
+            return True
+        return (time.time() - last) >= cooldown_seconds
+
+    def breach_id(self, drawdown: float, high_water: float) -> str:
+        return f"test|{drawdown:.4f}|{high_water:.2f}"
+
+
+class FakeAccountClient:
+    def __init__(self, name: str, balance: float, *, unrealized: float = 0.0, cashflows=None, fail_close=False):
+        self.config = _AccountConfig(name=name)
+        self.balance = balance
+        self.unrealized = unrealized
+        self.cashflows = cashflows or []
+        self.fail_close = fail_close
+        self.closes = 0
+
+    async def fetch(self):
+        return {
+            "name": self.config.name,
+            "balance": self.balance,
+            "positions": [
+                {"symbol": "BTCUSDT", "unrealized_pnl": self.unrealized, "signed_notional": 100}
+            ],
+            "realized_pnl": 0.0,
+            "cashflow_events": list(self.cashflows),
+        }
+
+    async def close_all_positions(self, symbol=None):
+        self.closes += 1
+        if self.fail_close:
+            raise Exception("-4061 position side does not match")
+        return {"status": "closed"}
+
+    async def kill_switch(self, symbol=None):
+        return {}
+
+    async def create_order(self, *args, **kwargs):  # pragma: no cover - unused
+        return {}
+
+    async def cancel_order(self, *args, **kwargs):  # pragma: no cover - unused
+        return {}
+
+    async def close_position(self, *args, **kwargs):  # pragma: no cover - unused
+        return {}
+
+    async def list_order_types(self):  # pragma: no cover - unused
+        return []
+
+    async def cancel_all_orders(self, *args, **kwargs):  # pragma: no cover - unused
+        return {}
+
+    async def close(self):  # pragma: no cover - unused
+        return None
+
+
+def _build_action_executor(config: RiskEngineConfig, store: StateStore, *clients):
+    notifier = FakeNotificationCoordinator()
+    return notifier, ActionExecutor(
+        config,
+        state_store=store,
+        notification_coordinator=notifier,
+        account_clients=clients,
+    )
+
+
+def test_drawdown_alert_triggers_notification_only():
+    config = RiskEngineConfig()
+    state_store = FakeStateStore(baseline_equity=100, high_water=100)
+    client = FakeAccountClient("binance", balance=97)
+    notifier, executor = _build_action_executor(config, state_store, client)
+    aggregator = PortfolioAggregator()
+
+    decision, view = asyncio.run(
+        risk_loop(
+            {"binance": ExchangeClientAdapter(client)},
+            RiskRulesEngine(config),
+            executor,
+            state_store,
+            config,
+            aggregator=aggregator,
+        )
+    )
+
+    assert decision.level is RiskDecisionLevel.ALERT
+    assert notifier.messages, "Telegram alert should have been sent"
+    assert client.closes == 0
+    assert pytest.approx(view.total_equity, rel=1e-3) == 97
+
+
+def test_close_positions_executes_for_all_clients():
+    config = RiskEngineConfig()
+    state_store = FakeStateStore(baseline_equity=200, high_water=200)
+    client_a = FakeAccountClient("binance", balance=90)
+    client_b = FakeAccountClient("okx", balance=92)
+    notifier, executor = _build_action_executor(config, state_store, client_a, client_b)
+
+    decision, _ = asyncio.run(
+        risk_loop(
+            {
+                "binance": ExchangeClientAdapter(client_a),
+                "okx": ExchangeClientAdapter(client_b),
+            },
+            RiskRulesEngine(config),
+            executor,
+            state_store,
+            config,
+        )
+    )
+
+    assert decision.level is RiskDecisionLevel.CLOSE_POSITIONS
+    assert client_a.closes == 1
+    assert client_b.closes == 1
+    assert notifier.messages, "Alert should accompany close action"
+
+
+def test_close_positions_logs_failure_and_continues(caplog):
+    caplog.set_level("ERROR")
+    config = RiskEngineConfig()
+    state_store = FakeStateStore(baseline_equity=200, high_water=200)
+    failing_client = FakeAccountClient("binance", balance=90, fail_close=True)
+    healthy_client = FakeAccountClient("bybit", balance=91)
+    notifier, executor = _build_action_executor(config, state_store, failing_client, healthy_client)
+
+    decision, _ = asyncio.run(
+        risk_loop(
+            {
+                "binance": ExchangeClientAdapter(failing_client),
+                "bybit": ExchangeClientAdapter(healthy_client),
+            },
+            RiskRulesEngine(config),
+            executor,
+            state_store,
+            config,
+        )
+    )
+
+    assert decision.level is RiskDecisionLevel.CLOSE_POSITIONS
+    assert healthy_client.closes == 1
+    assert failing_client.closes >= config.actions.close_retry_attempts
+    assert any("-4061" in message for message in caplog.text.splitlines())
+    assert notifier.messages, "Alert should still be emitted"
+
+
+def test_deposit_updates_baseline_without_triggering_breach():
+    config = RiskEngineConfig()
+    state_store = FakeStateStore()
+    client = FakeAccountClient(
+        "binance",
+        balance=120,
+        cashflows=[{"type": "deposit", "amount": 20}],
+    )
+    notifier, executor = _build_action_executor(config, state_store, client)
+    aggregator = PortfolioAggregator()
+
+    decision, view = asyncio.run(
+        risk_loop(
+            {"binance": ExchangeClientAdapter(client)},
+            RiskRulesEngine(config),
+            executor,
+            state_store,
+            config,
+            aggregator=aggregator,
+        )
+    )
+
+    assert decision.level is RiskDecisionLevel.NONE
+    assert not notifier.messages
+    assert pytest.approx(view.net_cashflow, rel=1e-6) == 20.0
+    assert pytest.approx(state_store.load().high_water, rel=1e-6) == 100.0
+

--- a/tests/risk_management/test_risk_engine_risk_rules.py
+++ b/tests/risk_management/test_risk_engine_risk_rules.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pytest
+
+from risk_management.risk_engine.config import RiskEngineConfig, ThresholdConfig
+from risk_management.risk_engine.portfolio_aggregator import PortfolioView
+from risk_management.risk_engine.risk_rules import RiskDecisionLevel, RiskRulesEngine
+from risk_management.risk_engine.state_store import StateStore, RiskState
+
+
+@dataclass
+class InMemoryState(StateStore):
+    baseline_equity: Optional[float] = None
+    high_water: Optional[float] = None
+    actions: Dict[str, float] = None
+
+    def load(self) -> RiskState:
+        return RiskState(self.baseline_equity, self.high_water, self.actions or {})
+
+    def save(self, *, baseline_equity: Optional[float], high_water: Optional[float]) -> None:
+        if baseline_equity is not None:
+            self.baseline_equity = baseline_equity
+        if high_water is not None:
+            self.high_water = high_water
+
+    def record_action(self, action_key: str) -> None:  # pragma: no cover - not needed
+        (self.actions or {}).update({action_key: 0})
+
+    def should_execute(self, action_key: str, cooldown_seconds: int) -> bool:  # pragma: no cover - not needed
+        return True
+
+    def breach_id(self, drawdown: float, high_water: float) -> str:
+        return f"{drawdown:.4f}:{high_water:.2f}"
+
+
+def make_view(total_equity: float, net_cashflow: float = 0.0) -> PortfolioView:
+    return PortfolioView(
+        total_balance=total_equity,
+        total_equity=total_equity,
+        total_unrealized_pnl=0.0,
+        total_realized_pnl=0.0,
+        net_cashflow=net_cashflow,
+    )
+
+
+def test_no_breach_returns_none():
+    engine = RiskRulesEngine(RiskEngineConfig())
+    store = InMemoryState()
+    view = make_view(1000)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.NONE
+    assert decision.drawdown == pytest.approx(0)
+    assert store.high_water == pytest.approx(1000)
+
+
+def test_alert_on_drawdown_threshold():
+    engine = RiskRulesEngine(RiskEngineConfig(thresholds=ThresholdConfig(alert_drawdown=-0.03)))
+    store = InMemoryState(high_water=1000)
+    view = make_view(970)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.ALERT
+    assert pytest.approx(decision.drawdown, rel=1e-3) == 0.03
+
+
+def test_close_positions_on_severe_drawdown():
+    engine = RiskRulesEngine(RiskEngineConfig(thresholds=ThresholdConfig(close_positions_drawdown=-0.08)))
+    store = InMemoryState(high_water=1000)
+    view = make_view(900)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.CLOSE_POSITIONS
+    assert decision.drawdown == pytest.approx(0.10)
+
+
+def test_kill_bots_when_configured():
+    engine = RiskRulesEngine(
+        RiskEngineConfig(thresholds=ThresholdConfig(close_positions_drawdown=-0.05, kill_bots_drawdown=-0.1))
+    )
+    store = InMemoryState(high_water=1000)
+    view = make_view(800)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.KILL_BOTS
+    assert decision.drawdown == pytest.approx(0.20)
+
+
+def test_deposits_do_not_reduce_drawdown():
+    engine = RiskRulesEngine(RiskEngineConfig())
+    store = InMemoryState(high_water=1000)
+    view = make_view(total_equity=1100, net_cashflow=100)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.NONE
+    assert decision.adjusted_equity == pytest.approx(1000)
+
+
+def test_withdrawals_do_not_trigger_false_loss():
+    engine = RiskRulesEngine(RiskEngineConfig())
+    store = InMemoryState(high_water=1000)
+    view = make_view(total_equity=900, net_cashflow=-200)
+
+    decision = engine.evaluate(view, store)
+
+    assert decision.level is RiskDecisionLevel.NONE
+    assert decision.adjusted_equity == pytest.approx(1100)


### PR DESCRIPTION
## Summary
- add configurable retries/backoff for closing positions with structured logging and error metrics
- include realized PnL in portfolio equity while logging cashflow adjustments and tracking malformed snapshots in metrics
- write state updates atomically, bucket breach identifiers to reduce alert churn, and update tests for the new accounting

## Testing
- pytest tests/risk_management -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692585e9abcc8323bb7641108fefe641)