### PR TITLE
Ensure portfolio aggregator initialized during snapshot fetch

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -179,7 +179,17 @@ class RealtimeDataFetcher:
             account_clients=self._exchange_clients,
         )
 
+    def _ensure_portfolio_aggregator(self) -> None:
+        """Instantiate a portfolio aggregator if the attribute is missing."""
+
+        if not hasattr(self, "_portfolio_aggregator"):
+            logger.debug(
+                "Portfolio aggregator attribute missing; creating a new instance for fetch cycle"
+            )
+            self._portfolio_aggregator = PortfolioAggregator()
+
     async def fetch_snapshot(self) -> Dict[str, Any]:
+        self._ensure_portfolio_aggregator()
         tasks = [client.fetch() for client in self._account_clients]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         accounts_payload: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- guard snapshot fetch with a lazy portfolio aggregator initialization
- add debug log when rebuilding the aggregator during runtime

## Testing
- pytest tests/risk_management/test_realtime.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925a275fb1c8323afe27574fa50f30d)