### PR TITLE
Ensure risk rules engine initialized for realtime snapshots

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -203,10 +203,6 @@ class RealtimeDataFetcher:
         self._ensure_risk_rules_engine()
 
 
-    async def fetch_snapshot(self) -> Dict[str, Any]:
-        self._ensure_portfolio_aggregator()
-
-
         tasks = [client.fetch() for client in self._account_clients]
         results = await asyncio.gather(*tasks, return_exceptions=True)
         accounts_payload: List[Dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- remove the duplicate `fetch_snapshot` definition in `RealtimeDataFetcher`
- ensure the risk rules engine is initialized before evaluating risk snapshots to avoid missing attribute errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6926928893d48323b34557ba05b5310f)