### PR TITLE
Fix realtime risk fetcher missing config initialization

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -189,10 +189,21 @@ class RealtimeDataFetcher:
             self._portfolio_aggregator = PortfolioAggregator()
 
 
+    def _ensure_risk_config(self) -> None:
+        """Instantiate a risk config if the attribute is missing."""
+
+        if not hasattr(self, "_risk_config"):
+            logger.debug(
+                "Risk config attribute missing; rebuilding from realtime config for fetch cycle",
+            )
+            self._risk_config = RiskEngineConfig.from_realtime_config(self.config)
+
+
     def _ensure_risk_rules_engine(self) -> None:
         """Instantiate a risk rules engine if the attribute is missing."""
 
         if not hasattr(self, "_risk_rules_engine"):
+            self._ensure_risk_config()
             logger.debug(
                 "Risk rules engine attribute missing; creating a new instance for fetch cycle"
             )


### PR DESCRIPTION
## Summary
- add a safeguard to rebuild risk engine config when missing
- ensure risk rules engine reinitialization works after reloads

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929723709348323929b4ac49e18726d)