### PR TITLE
Respect order parameters when discovering cancellations

### DIFF
--- a/risk_management/account_clients.py
+++ b/risk_management/account_clients.py
@@ -1083,8 +1083,13 @@ class CCXTAccountClient(AccountClientProtocol):
                     " but open orders could not be inspected to determine targets."
                 )
 
+        fetch_params = self._orders_params or self._close_params or None
+
         try:
-            open_orders = await fetch_open_orders()
+            if fetch_params:
+                open_orders = await fetch_open_orders(params=fetch_params)
+            else:
+                open_orders = await fetch_open_orders()
         except BaseError as exc:
             raise self._translate_ccxt_error(exc)
 


### PR DESCRIPTION
## Summary
- ensure `cancel_all_orders` forwards order/close parameters when discovering open orders
- add coverage for exchanges that require a market type during open order discovery

## Testing
- pytest tests/test_risk_management_account_clients.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929cd66c8fc8323ae82f75133fa7e2f)