### PR TITLE
Fix risk dashboard kill switch delegation

### DIFF
--- a/risk_management/web.py
+++ b/risk_management/web.py
@@ -83,6 +83,81 @@ class RiskDashboardService:
     async def fetch_snapshot(self) -> Dict[str, Any]:
         return await self._service.fetch_snapshot()
 
+    async def trigger_kill_switch(
+        self, account_name: Optional[str] = None, symbol: Optional[str] = None
+    ) -> Mapping[str, Any]:
+        return await self._service.trigger_kill_switch(account_name, symbol)
+
+    async def place_order(
+        self,
+        account_name: str,
+        *,
+        symbol: str,
+        order_type: str,
+        side: str,
+        amount: float,
+        price: Optional[float] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        return await self._service.place_order(
+            account_name,
+            symbol=symbol,
+            order_type=order_type,
+            side=side,
+            amount=amount,
+            price=price,
+            params=params,
+        )
+
+    async def cancel_order(
+        self,
+        account_name: str,
+        order_id: str,
+        *,
+        symbol: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        return await self._service.cancel_order(
+            account_name,
+            order_id,
+            symbol=symbol,
+            params=params,
+        )
+
+    async def close_position(self, account_name: str, symbol: str) -> Mapping[str, Any]:
+        return await self._service.close_position(account_name, symbol)
+
+    async def list_order_types(self, account_name: str) -> Sequence[str]:
+        return await self._service.list_order_types(account_name)
+
+    def get_portfolio_stop_loss(self) -> Optional[Dict[str, Any]]:
+        return self._service.get_portfolio_stop_loss()
+
+    async def set_portfolio_stop_loss(self, threshold_pct: float) -> Dict[str, Any]:
+        return await self._service.set_portfolio_stop_loss(threshold_pct)
+
+    async def clear_portfolio_stop_loss(self) -> None:
+        await self._service.clear_portfolio_stop_loss()
+
+    def get_account_stop_loss(self, account_name: str) -> Optional[Dict[str, Any]]:
+        return self._service.get_account_stop_loss(account_name)
+
+    async def set_account_stop_loss(self, account_name: str, threshold_pct: float) -> Dict[str, Any]:
+        return await self._service.set_account_stop_loss(account_name, threshold_pct)
+
+    async def clear_account_stop_loss(self, account_name: str) -> None:
+        await self._service.clear_account_stop_loss(account_name)
+
+    async def cancel_all_orders(
+        self, account_name: str, symbol: Optional[str] = None
+    ) -> Mapping[str, Any]:
+        return await self._service.cancel_all_orders(account_name, symbol)
+
+    async def close_all_positions(
+        self, account_name: str, symbol: Optional[str] = None
+    ) -> Mapping[str, Any]:
+        return await self._service.close_all_positions(account_name, symbol)
+
     async def close(self) -> None:
         await self._service.close()
 

--- a/tests/test_risk_dashboard_service.py
+++ b/tests/test_risk_dashboard_service.py
@@ -1,0 +1,124 @@
+import pytest
+
+pytest.importorskip("fastapi")
+
+from risk_management.web import RiskDashboardService
+
+
+class _RecordingService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def fetch_snapshot(self):
+        self.calls.append(("fetch_snapshot",))
+        return {"snapshot": True}
+
+    async def trigger_kill_switch(self, account_name=None, symbol=None):
+        self.calls.append(("trigger_kill_switch", account_name, symbol))
+        return {"kill": True}
+
+    async def cancel_all_orders(self, account_name, symbol=None):
+        self.calls.append(("cancel_all_orders", account_name, symbol))
+        return {"cancelled": True}
+
+    async def close_all_positions(self, account_name, symbol=None):
+        self.calls.append(("close_all_positions", account_name, symbol))
+        return {"closed": True}
+
+    async def place_order(self, account_name, **kwargs):
+        self.calls.append(("place_order", account_name, kwargs))
+        return {"placed": True}
+
+    async def cancel_order(self, account_name, order_id, *, symbol=None, params=None):
+        self.calls.append(("cancel_order", account_name, order_id, symbol, params))
+        return {"cancelled_order": True}
+
+    async def close_position(self, account_name, symbol):
+        self.calls.append(("close_position", account_name, symbol))
+        return {"closed_position": True}
+
+    async def list_order_types(self, account_name):
+        self.calls.append(("list_order_types", account_name))
+        return ["limit"]
+
+    def get_portfolio_stop_loss(self):
+        self.calls.append(("get_portfolio_stop_loss",))
+        return {"active": False}
+
+    async def set_portfolio_stop_loss(self, threshold_pct):
+        self.calls.append(("set_portfolio_stop_loss", threshold_pct))
+        return {"threshold_pct": threshold_pct}
+
+    async def clear_portfolio_stop_loss(self):
+        self.calls.append(("clear_portfolio_stop_loss",))
+
+    def get_account_stop_loss(self, account_name):
+        self.calls.append(("get_account_stop_loss", account_name))
+        return None
+
+    async def set_account_stop_loss(self, account_name, threshold_pct):
+        self.calls.append(("set_account_stop_loss", account_name, threshold_pct))
+        return {"account": account_name, "threshold_pct": threshold_pct}
+
+    async def clear_account_stop_loss(self, account_name):
+        self.calls.append(("clear_account_stop_loss", account_name))
+
+    async def close(self):
+        self.calls.append(("close",))
+
+
+@pytest.mark.asyncio
+async def test_dashboard_service_delegates_calls():
+    underlying = _RecordingService()
+    dashboard = RiskDashboardService(underlying)
+
+    assert await dashboard.fetch_snapshot() == {"snapshot": True}
+    assert await dashboard.trigger_kill_switch("acc", "BTCUSDT") == {"kill": True}
+    assert await dashboard.cancel_all_orders("acc", "ETHUSDT") == {"cancelled": True}
+    assert await dashboard.close_all_positions("acc", None) == {"closed": True}
+    assert await dashboard.place_order(
+        "acc",
+        symbol="BTCUSDT",
+        order_type="limit",
+        side="buy",
+        amount=1.0,
+    ) == {"placed": True}
+    assert await dashboard.cancel_order("acc", "123", symbol="BTCUSDT", params=None) == {
+        "cancelled_order": True
+    }
+    assert await dashboard.close_position("acc", "BTCUSDT") == {"closed_position": True}
+    assert await dashboard.list_order_types("acc") == ["limit"]
+    assert dashboard.get_portfolio_stop_loss() == {"active": False}
+    assert await dashboard.set_portfolio_stop_loss(5.0) == {"threshold_pct": 5.0}
+    await dashboard.clear_portfolio_stop_loss()
+    assert dashboard.get_account_stop_loss("acc") is None
+    assert await dashboard.set_account_stop_loss("acc", 3.0) == {
+        "account": "acc",
+        "threshold_pct": 3.0,
+    }
+    await dashboard.clear_account_stop_loss("acc")
+    await dashboard.close()
+
+    expected_calls = [
+        ("fetch_snapshot",),
+        ("trigger_kill_switch", "acc", "BTCUSDT"),
+        ("cancel_all_orders", "acc", "ETHUSDT"),
+        ("close_all_positions", "acc", None),
+        (
+            "place_order",
+            "acc",
+            {"symbol": "BTCUSDT", "order_type": "limit", "side": "buy", "amount": 1.0},
+        ),
+        ("cancel_order", "acc", "123", "BTCUSDT", None),
+        ("close_position", "acc", "BTCUSDT"),
+        ("list_order_types", "acc"),
+        ("get_portfolio_stop_loss",),
+        ("set_portfolio_stop_loss", 5.0),
+        ("clear_portfolio_stop_loss",),
+        ("get_account_stop_loss", "acc"),
+        ("set_account_stop_loss", "acc", 3.0),
+        ("clear_account_stop_loss", "acc"),
+        ("close",),
+    ]
+
+    assert underlying.calls == expected_calls


### PR DESCRIPTION
## Summary
- delegate risk dashboard service methods (kill switch, order management, stop losses) to the underlying risk service
- add a unit test ensuring the dashboard service forwards all operations to the wrapped service

## Testing
- python -m pytest tests/test_risk_dashboard_service.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692c58ced9ac8323b896c86c67d58f9c)