### PR TITLE
Add risk engine core utilities

### DIFF
--- a/risk_management/risk_engine/core.py
+++ b/risk_management/risk_engine/core.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class Position:
+    """Simple immutable representation of an open position."""
+
+    exchange: str
+    symbol: str
+    quantity: float
+    entry_price: float
+    mark_price: float
+    leverage: float = 1.0
+
+    def notional_value(self) -> float:
+        return abs(self.quantity) * self.mark_price
+
+    def unrealized_pnl(self) -> float:
+        return (self.mark_price - self.entry_price) * self.quantity
+
+
+@dataclass(frozen=True)
+class CashFlowEvent:
+    """Represents a balance-changing event unrelated to PnL."""
+
+    timestamp: int
+    amount: float  # positive for deposit, negative for withdrawal
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class ExchangeDrawdown:
+    exchange: str
+    drawdown: float
+    limit: float
+
+    @property
+    def breached(self) -> bool:
+        return self.drawdown > self.limit
+
+
+@dataclass(frozen=True)
+class LimitBreach:
+    exchange: str
+    symbol: str
+    kind: str
+    value: float
+    limit: float
+
+
+def total_unrealized_pnl(positions: Iterable[Position]) -> float:
+    """Return the sum of unrealized PnL across all positions."""
+
+    return sum(position.unrealized_pnl() for position in positions)
+
+
+def evaluate_exchange_drawdowns(
+    current_equity: Dict[str, float],
+    peak_equity: Dict[str, float],
+    limits: Dict[str, float],
+) -> List[ExchangeDrawdown]:
+    """Calculate drawdowns per exchange and whether they breach configured limits.
+
+    Drawdown is computed as (peak - current) / peak when peak is positive.
+    Exchanges absent from peak_equity are treated as having zero peak.
+    """
+
+    drawdowns: List[ExchangeDrawdown] = []
+    exchanges = set(current_equity) | set(peak_equity) | set(limits)
+    for exchange in exchanges:
+        peak = peak_equity.get(exchange, 0.0)
+        current = current_equity.get(exchange, 0.0)
+        limit = limits.get(exchange, 0.0)
+        if peak <= 0:
+            drawdown = 0.0
+        else:
+            drawdown = max(0.0, (peak - current) / peak)
+        drawdowns.append(ExchangeDrawdown(exchange, drawdown, limit))
+    return drawdowns
+
+
+def evaluate_position_limits(
+    positions: Iterable[Position],
+    notional_limits: Dict[str, float] | None = None,
+    leverage_limits: Dict[str, float] | None = None,
+) -> List[LimitBreach]:
+    """Check positions against notional and leverage caps per exchange.
+
+    The limit dictionaries are keyed by exchange. Missing entries imply no cap.
+    """
+
+    notional_limits = notional_limits or {}
+    leverage_limits = leverage_limits or {}
+    breaches: List[LimitBreach] = []
+    for position in positions:
+        notional_cap = notional_limits.get(position.exchange)
+        leverage_cap = leverage_limits.get(position.exchange)
+
+        if notional_cap is not None and position.notional_value() > notional_cap:
+            breaches.append(
+                LimitBreach(
+                    exchange=position.exchange,
+                    symbol=position.symbol,
+                    kind="notional",
+                    value=position.notional_value(),
+                    limit=notional_cap,
+                )
+            )
+
+        if leverage_cap is not None and position.leverage > leverage_cap:
+            breaches.append(
+                LimitBreach(
+                    exchange=position.exchange,
+                    symbol=position.symbol,
+                    kind="leverage",
+                    value=position.leverage,
+                    limit=leverage_cap,
+                )
+            )
+    return breaches
+
+
+def validate_one_way_mode(positions: Iterable[Position]) -> List[Tuple[str, str]]:
+    """Detect symbol conflicts that violate one-way mode.
+
+    Returns a list of (exchange, symbol) pairs where both long and short
+    exposure exists simultaneously.
+    """
+
+    exposures: Dict[Tuple[str, str], List[float]] = {}
+    for position in positions:
+        key = (position.exchange, position.symbol)
+        exposures.setdefault(key, []).append(position.quantity)
+
+    conflicts: List[Tuple[str, str]] = []
+    for (exchange, symbol), quantities in exposures.items():
+        has_long = any(q > 0 for q in quantities)
+        has_short = any(q < 0 for q in quantities)
+        if has_long and has_short:
+            conflicts.append((exchange, symbol))
+    return conflicts
+
+
+def separate_pnl_from_cash_flow(
+    starting_balance: float,
+    ending_balance: float,
+    cash_flow_events: Sequence[CashFlowEvent] | None = None,
+) -> Tuple[float, float]:
+    """Return (net_pnl, net_cash_flow).
+
+    Cash flow is the net of deposits (positive) and withdrawals (negative).
+    Net PnL is derived as the balance change minus cash flow.
+    """
+
+    cash_flow_events = cash_flow_events or []
+    net_cash_flow = sum(event.amount for event in cash_flow_events)
+    balance_change = ending_balance - starting_balance
+    net_pnl = balance_change - net_cash_flow
+    return net_pnl, net_cash_flow

--- a/tests/risk_engine/test_core.py
+++ b/tests/risk_engine/test_core.py
@@ -1,0 +1,106 @@
+import pytest
+
+from risk_management.risk_engine.core import (
+    CashFlowEvent,
+    ExchangeDrawdown,
+    LimitBreach,
+    Position,
+    evaluate_exchange_drawdowns,
+    evaluate_position_limits,
+    separate_pnl_from_cash_flow,
+    total_unrealized_pnl,
+    validate_one_way_mode,
+)
+
+
+def test_total_unrealized_pnl_with_zero_positions():
+    assert total_unrealized_pnl([]) == 0
+
+
+def test_total_unrealized_pnl_mixed_exchanges():
+    positions = [
+        Position(exchange="binance", symbol="BTCUSDT", quantity=0.5, entry_price=20000, mark_price=21000),
+        Position(exchange="bybit", symbol="ETHUSDT", quantity=-2, entry_price=1500, mark_price=1400),
+    ]
+    expected = (21000 - 20000) * 0.5 + (1400 - 1500) * -2
+    assert total_unrealized_pnl(positions) == expected
+
+
+def test_evaluate_exchange_drawdowns_handles_missing_peaks():
+    current_equity = {"binance": 9000, "bybit": 5000}
+    peak_equity = {"binance": 10000}
+    limits = {"binance": 0.1, "bybit": 0.2}
+
+    results = evaluate_exchange_drawdowns(current_equity, peak_equity, limits)
+    result_map = {res.exchange: res for res in results}
+
+    assert pytest.approx(result_map["binance"].drawdown) == 0.1
+    assert result_map["binance"].breached is False
+    assert result_map["bybit"].drawdown == 0
+    assert result_map["bybit"].breached is False
+
+
+def test_evaluate_position_limits_detects_notional_and_leverage():
+    positions = [
+        Position(
+            exchange="binance",
+            symbol="BTCUSDT",
+            quantity=1,
+            entry_price=20000,
+            mark_price=22000,
+            leverage=11,
+        ),
+        Position(
+            exchange="bybit",
+            symbol="ETHUSDT",
+            quantity=0.1,
+            entry_price=1500,
+            mark_price=1600,
+            leverage=2,
+        ),
+    ]
+
+    breaches = evaluate_position_limits(
+        positions,
+        notional_limits={"binance": 15000},
+        leverage_limits={"binance": 10, "bybit": 1},
+    )
+
+    kinds = {(b.exchange, b.kind) for b in breaches}
+    assert ("binance", "notional") in kinds
+    assert ("binance", "leverage") in kinds
+    assert ("bybit", "leverage") in kinds
+
+
+def test_validate_one_way_mode_conflict_detection():
+    positions = [
+        Position("binance", "BTCUSDT", 0.5, 20000, 21000),
+        Position("binance", "BTCUSDT", -0.3, 20000, 19000),
+        Position("bybit", "ETHUSDT", 2, 1500, 1525),
+    ]
+
+    conflicts = validate_one_way_mode(positions)
+    assert ("binance", "BTCUSDT") in conflicts
+    assert ("bybit", "ETHUSDT") not in conflicts
+
+
+def test_separate_pnl_from_cash_flow_handles_deposits_and_withdrawals():
+    events = [
+        CashFlowEvent(timestamp=1, amount=1000, description="deposit"),
+        CashFlowEvent(timestamp=2, amount=-200, description="withdrawal"),
+    ]
+
+    net_pnl, net_cash_flow = separate_pnl_from_cash_flow(5000, 6200, events)
+
+    assert net_cash_flow == 800
+    assert net_pnl == 400
+
+
+def test_exchange_drawdown_breach_flag():
+    results = evaluate_exchange_drawdowns(
+        current_equity={"binance": 5000},
+        peak_equity={"binance": 10000},
+        limits={"binance": 0.49},
+    )
+    assert results[0].breached is True
+


### PR DESCRIPTION
## Summary
- add core risk calculations and helper classes for positions, drawdowns, and cash flows
- provide validation for exchange drawdowns, notional/leverage caps, and one-way mode conflicts
- include unit tests covering risk engine calculations and cash flow handling

## Testing
- pytest tests/risk_engine/test_core.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d57b6bdcc83239707ca5aaf0b2314)