### PR TITLE
Add exchange adapters with one-way validation

### DIFF
--- a/services/exchanges/__init__.py
+++ b/services/exchanges/__init__.py
@@ -1,0 +1,14 @@
+"""Exchange adapter interfaces and implementations."""
+
+from .base import AccountStateAdapter, HedgedPositionViolation
+from .binance import BinanceExchangeAdapter
+from .bybit import BybitExchangeAdapter
+from .okx import OKXExchangeAdapter
+
+__all__ = [
+    "AccountStateAdapter",
+    "HedgedPositionViolation",
+    "BinanceExchangeAdapter",
+    "BybitExchangeAdapter",
+    "OKXExchangeAdapter",
+]

--- a/services/exchanges/base.py
+++ b/services/exchanges/base.py
@@ -1,0 +1,181 @@
+"""Exchange adapter interface enforcing one-way mode account operations."""
+
+from __future__ import annotations
+import abc
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from risk_management.account_clients import _extract_position_details
+from risk_management.models import AccountState, Balance, ExchangeId, Position
+from risk_management.realtime import _extract_balance, _parse_position
+
+logger = logging.getLogger(__name__)
+
+
+class HedgedPositionViolation(RuntimeError):
+    """Raised when hedged (dual-side) positions are discovered on an account."""
+
+    def __init__(self, exchange: ExchangeId, violations: Sequence[Mapping[str, Any]]):
+        self.exchange = exchange
+        self.violations = tuple(violations)
+        symbols = ", ".join(str(item.get("symbol")) for item in self.violations)
+        message = f"{exchange.value} returned hedged positions for symbols: {symbols}"
+        super().__init__(message)
+
+
+class AccountStateAdapter(abc.ABC):
+    """Asynchronous interface for exchange account interactions.
+
+    Implementations must operate in one-way (non-hedged) position mode. Any detected
+    hedged positions should be rejected with :class:`HedgedPositionViolation`.
+    """
+
+    exchange: ExchangeId
+    settle_currency: str
+
+    @abc.abstractmethod
+    async def fetch_account_state(self) -> AccountState:
+        """Return the current account state, including balance and open positions."""
+
+    @abc.abstractmethod
+    async def close_positions(self, symbols: Optional[Sequence[str]] = None) -> Sequence[str]:
+        """Close open positions for ``symbols`` (or all when ``None``)."""
+
+    async def set_leverage(self, symbol: str, leverage: int) -> None:
+        """Set leverage for ``symbol`` when supported by the adapter."""
+        raise NotImplementedError
+
+
+@dataclass
+class _CcxtParams:
+    balance: MutableMapping[str, Any]
+    positions: MutableMapping[str, Any]
+    close: MutableMapping[str, Any]
+    leverage: MutableMapping[str, Any]
+
+
+class _CcxtAdapter(AccountStateAdapter):
+    """Shared CCXT-backed adapter logic for specific exchanges."""
+
+    def __init__(
+        self,
+        name: str,
+        client: Any,
+        exchange: ExchangeId,
+        settle_currency: str = "USDT",
+        *,
+        params: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    ) -> None:
+        self.name = name
+        self.client = client
+        self.exchange = exchange
+        self.settle_currency = settle_currency
+        self._markets_lock: Optional[asyncio.Lock] = None
+        base_params = params or {}
+        self._params = _CcxtParams(
+            balance=dict(base_params.get("balance", {})),
+            positions=dict(base_params.get("positions", {})),
+            close=dict(base_params.get("close", {})),
+            leverage=dict(base_params.get("leverage", {})),
+        )
+
+    async def _ensure_markets(self) -> None:
+        lock = self._markets_lock
+        if lock is None:
+            lock = asyncio.Lock()
+            self._markets_lock = lock
+        async with lock:
+            if getattr(self.client, "markets", None):
+                return
+            if hasattr(self.client, "load_markets"):
+                await self.client.load_markets()
+
+    def _validate_positions(self, positions: Iterable[Mapping[str, Any]]) -> None:
+        violations: list[Mapping[str, Any]] = []
+        for position in positions or []:
+            position_side, position_idx = _extract_position_details(position)
+            if position_side in {"LONG", "SHORT"} or position_idx in {1, 2}:
+                symbol = position.get("symbol") or position.get("id") or "unknown"
+                violations.append(
+                    {"symbol": symbol, "positionSide": position_side, "positionIdx": position_idx}
+                )
+        if violations:
+            logger.error("Detected hedged positions on %s: %s", self.exchange.value, violations)
+            raise HedgedPositionViolation(self.exchange, violations)
+
+    async def _fetch_positions(self) -> Sequence[Mapping[str, Any]]:
+        if not hasattr(self.client, "fetch_positions"):
+            return []
+        positions = await self.client.fetch_positions(params=self._params.positions)
+        self._validate_positions(positions or [])
+        return list(positions or [])
+
+    def _parse_positions(self, positions_raw: Iterable[Mapping[str, Any]], balance: float) -> list[Position]:
+        parsed: list[Position] = []
+        for position in positions_raw:
+            normalized = _parse_position(position, balance)
+            if normalized is None:
+                continue
+            position_side, position_idx = _extract_position_details(position)
+            if position_side:
+                normalized["position_side"] = position_side
+            if position_idx is not None:
+                normalized["position_idx"] = position_idx
+            parsed.append(Position(**normalized))
+        return parsed
+
+    async def fetch_account_state(self) -> AccountState:
+        await self._ensure_markets()
+        balance_raw = await self.client.fetch_balance(params=self._params.balance)
+        balance_value = _extract_balance(balance_raw, self.settle_currency)
+        positions_raw = await self._fetch_positions()
+        positions = self._parse_positions(positions_raw, balance_value)
+        balance_model = Balance(balance=balance_value, currency=self.settle_currency)
+        return AccountState(
+            name=self.name,
+            balance=balance_model,
+            positions=positions,
+            exchange=self.exchange,
+        )
+
+    async def close_positions(self, symbols: Optional[Sequence[str]] = None) -> Sequence[str]:
+        await self._ensure_markets()
+        positions = await self._fetch_positions()
+        closed: list[str] = []
+        for position in positions:
+            size_raw = position.get("contracts") or position.get("size") or position.get("amount")
+            symbol = position.get("symbol") or position.get("id")
+            if not symbol:
+                continue
+            if symbols and symbol not in symbols:
+                continue
+            try:
+                size = float(size_raw)
+            except (TypeError, ValueError):
+                continue
+            if abs(size) < 1e-12:
+                continue
+            side = "sell" if size > 0 else "buy"
+            amount = abs(size)
+            params = dict(self._params.close)
+            position_side, position_idx = _extract_position_details(position)
+            if position_side:
+                params.setdefault("positionSide", position_side)
+            if position_idx is not None:
+                params.setdefault("positionIdx", position_idx)
+            params.setdefault("reduceOnly", True)
+            try:
+                await self.client.create_order(symbol, "market", side, amount, params=params)
+                closed.append(symbol)
+            except Exception:
+                logger.warning("Failed to close position %s on %s", symbol, self.exchange.value, exc_info=True)
+        return closed
+
+    async def set_leverage(self, symbol: str, leverage: int) -> None:
+        if not hasattr(self.client, "set_leverage"):
+            logger.debug("set_leverage not supported on %s", self.exchange.value)
+            return
+        params = dict(self._params.leverage)
+        await self.client.set_leverage(leverage, symbol, params)

--- a/services/exchanges/binance.py
+++ b/services/exchanges/binance.py
@@ -1,0 +1,29 @@
+"""Binance exchange adapter leveraging CCXT client."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from risk_management.models import ExchangeId
+
+from .base import _CcxtAdapter
+
+
+class BinanceExchangeAdapter(_CcxtAdapter):
+    """One-way mode adapter for Binance futures accounts."""
+
+    def __init__(
+        self,
+        name: str,
+        client: Any,
+        *,
+        settle_currency: str = "USDT",
+        params: Optional[Mapping[str, Mapping[str, object]]] = None,
+    ) -> None:
+        super().__init__(
+            name,
+            client,
+            ExchangeId.BINANCE,
+            settle_currency,
+            params=params,
+        )

--- a/services/exchanges/bybit.py
+++ b/services/exchanges/bybit.py
@@ -1,0 +1,38 @@
+"""Bybit exchange adapter leveraging CCXT client."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from risk_management.models import ExchangeId
+
+from .base import _CcxtAdapter
+
+
+class BybitExchangeAdapter(_CcxtAdapter):
+    """One-way mode adapter for Bybit USDT derivatives."""
+
+    def __init__(
+        self,
+        name: str,
+        client: Any,
+        *,
+        settle_currency: str = "USDT",
+        params: Optional[Mapping[str, Mapping[str, object]]] = None,
+    ) -> None:
+        merged_params = {"positions": {"type": "swap"}, **(params or {})}
+        super().__init__(
+            name,
+            client,
+            ExchangeId.BYBIT,
+            settle_currency,
+            params=merged_params,
+        )
+
+    async def set_leverage(self, symbol: str, leverage: int) -> None:
+        if not hasattr(self.client, "set_leverage"):
+            return
+        params = dict(self._params.leverage)
+        params.setdefault("buyLeverage", leverage)
+        params.setdefault("sellLeverage", leverage)
+        await self.client.set_leverage(leverage, symbol, params)

--- a/services/exchanges/okx.py
+++ b/services/exchanges/okx.py
@@ -1,0 +1,37 @@
+"""OKX exchange adapter leveraging CCXT client."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from risk_management.models import ExchangeId
+
+from .base import _CcxtAdapter
+
+
+class OKXExchangeAdapter(_CcxtAdapter):
+    """One-way mode adapter for OKX perpetual instruments."""
+
+    def __init__(
+        self,
+        name: str,
+        client: Any,
+        *,
+        settle_currency: str = "USDT",
+        params: Optional[Mapping[str, Mapping[str, object]]] = None,
+    ) -> None:
+        merged_params = {"positions": {"instType": "SWAP"}, **(params or {})}
+        super().__init__(
+            name,
+            client,
+            ExchangeId.OKX,
+            settle_currency,
+            params=merged_params,
+        )
+
+    async def set_leverage(self, symbol: str, leverage: int) -> None:
+        if not hasattr(self.client, "set_leverage"):
+            return
+        params = dict(self._params.leverage)
+        params.setdefault("mgnMode", "cross")
+        await self.client.set_leverage(leverage, symbol, params)

--- a/tests/services/exchanges/fixtures/binance_account.json
+++ b/tests/services/exchanges/fixtures/binance_account.json
@@ -1,0 +1,17 @@
+{
+  "balance": {
+    "total": {"USDT": 1250.5},
+    "info": {"asset": "USDT"}
+  },
+  "positions": [
+    {
+      "symbol": "BTCUSDT",
+      "contracts": "0.01",
+      "entryPrice": "20000",
+      "markPrice": "20100",
+      "unrealizedPnl": "1",
+      "liquidationPrice": "15000",
+      "positionSide": "BOTH"
+    }
+  ]
+}

--- a/tests/services/exchanges/fixtures/bybit_account.json
+++ b/tests/services/exchanges/fixtures/bybit_account.json
@@ -1,0 +1,17 @@
+{
+  "balance": {
+    "total": {"USDT": 2200.0},
+    "info": {"result": {"equity": "2200"}}
+  },
+  "positions": [
+    {
+      "symbol": "ETH/USDT:USDT",
+      "size": -2,
+      "entryPrice": "1800",
+      "markPrice": "1785",
+      "unrealizedPnl": "30",
+      "liquidationPrice": "2000",
+      "info": {"positionIdx": 0, "positionSide": "BOTH"}
+    }
+  ]
+}

--- a/tests/services/exchanges/fixtures/hedged_position.json
+++ b/tests/services/exchanges/fixtures/hedged_position.json
@@ -1,0 +1,12 @@
+{
+  "balance": {"total": {"USDT": 1000}},
+  "positions": [
+    {
+      "symbol": "BTCUSDT",
+      "contracts": 1,
+      "entryPrice": "30000",
+      "markPrice": "30100",
+      "positionSide": "LONG"
+    }
+  ]
+}

--- a/tests/services/exchanges/fixtures/okx_account.json
+++ b/tests/services/exchanges/fixtures/okx_account.json
@@ -1,0 +1,18 @@
+{
+  "balance": {
+    "total": {"USDT": 980.25},
+    "info": {"data": [{"totalEq": "980.25"}]}
+  },
+  "positions": [
+    {
+      "symbol": "LTC/USDT:USDT",
+      "amount": 3,
+      "entryPrice": "90",
+      "markPrice": "95",
+      "unrealisedPnl": "15",
+      "liquidationPrice": "60",
+      "info": {"positionSide": "BOTH", "positionIdx": 0, "last": "95"},
+      "notional": "285"
+    }
+  ]
+}

--- a/tests/services/exchanges/test_adapters.py
+++ b/tests/services/exchanges/test_adapters.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from services.exchanges import (
+    BinanceExchangeAdapter,
+    BybitExchangeAdapter,
+    OKXExchangeAdapter,
+)
+from services.exchanges.base import HedgedPositionViolation
+from risk_management.models import ExchangeId
+
+
+class DummyCcxtClient:
+    def __init__(self, balance_payload, positions_payload):
+        self._balance_payload = balance_payload
+        self._positions_payload = positions_payload
+        self.markets = None
+        self.orders = []
+        self.leverage_updates = []
+        self.balance_params = None
+        self.positions_params = None
+
+    async def load_markets(self):
+        self.markets = True
+
+    async def fetch_balance(self, params=None):
+        self.balance_params = params or {}
+        return self._balance_payload
+
+    async def fetch_positions(self, params=None):
+        self.positions_params = params or {}
+        return self._positions_payload
+
+    async def create_order(self, symbol, order_type, side, amount, price=None, params=None):
+        self.orders.append(
+            {
+                "symbol": symbol,
+                "type": order_type,
+                "side": side,
+                "amount": amount,
+                "price": price,
+                "params": params or {},
+            }
+        )
+        return {"id": "order-1"}
+
+    async def set_leverage(self, leverage, symbol=None, params=None):
+        self.leverage_updates.append({"symbol": symbol, "leverage": leverage, "params": params or {}})
+        return {"symbol": symbol, "leverage": leverage}
+
+
+@pytest.fixture
+def fixture_path() -> Path:
+    return Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(path: Path, name: str) -> dict:
+    payload = path.joinpath(f"{name}.json").read_text(encoding="utf-8")
+    return json.loads(payload)
+
+
+@pytest.mark.asyncio
+async def test_binance_adapter_fetch_and_close(fixture_path: Path):
+    payload = _load_fixture(fixture_path, "binance_account")
+    client = DummyCcxtClient(payload["balance"], payload["positions"])
+    adapter = BinanceExchangeAdapter("Binance", client)
+
+    state = await adapter.fetch_account_state()
+
+    assert state.exchange == ExchangeId.BINANCE
+    assert state.balance.total == pytest.approx(1250.5)
+    assert len(state.positions) == 1
+    position = state.positions[0]
+    assert position.symbol == "BTCUSDT"
+    assert position.side == "long"
+    assert position.position_side == "BOTH"
+
+    closed = await adapter.close_positions()
+    assert closed == ["BTCUSDT"]
+    assert client.orders[0]["params"]["reduceOnly"] is True
+
+    await adapter.set_leverage("BTCUSDT", 7)
+    assert client.leverage_updates == [
+        {"symbol": "BTCUSDT", "leverage": 7, "params": {}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bybit_adapter_closes_shorts_with_params(fixture_path: Path):
+    payload = _load_fixture(fixture_path, "bybit_account")
+    client = DummyCcxtClient(payload["balance"], payload["positions"])
+    adapter = BybitExchangeAdapter("Bybit", client)
+
+    state = await adapter.fetch_account_state()
+    assert state.exchange == ExchangeId.BYBIT
+    assert state.balance.total == pytest.approx(2200.0)
+    assert state.positions[0].side == "short"
+
+    closed = await adapter.close_positions()
+    assert closed == ["ETH/USDT:USDT"]
+    params = client.orders[0]["params"]
+    assert params["positionSide"] == "BOTH"
+    assert params["reduceOnly"] is True
+
+    await adapter.set_leverage("ETH/USDT:USDT", 5)
+    assert client.leverage_updates[0]["params"]["buyLeverage"] == 5
+    assert client.positions_params.get("type") == "swap"
+
+
+@pytest.mark.asyncio
+async def test_okx_adapter_fetches_positions_with_inst_type(fixture_path: Path):
+    payload = _load_fixture(fixture_path, "okx_account")
+    client = DummyCcxtClient(payload["balance"], payload["positions"])
+    adapter = OKXExchangeAdapter("OKX", client)
+
+    state = await adapter.fetch_account_state()
+    assert state.exchange == ExchangeId.OKX
+    assert state.balance.total == pytest.approx(980.25)
+    assert state.positions[0].symbol == "LTC/USDT:USDT"
+    assert state.positions[0].side == "long"
+
+    closed = await adapter.close_positions()
+    assert closed == ["LTC/USDT:USDT"]
+    assert client.positions_params["instType"] == "SWAP"
+
+
+@pytest.mark.asyncio
+async def test_rejects_hedged_positions(fixture_path: Path, caplog: pytest.LogCaptureFixture):
+    payload = _load_fixture(fixture_path, "hedged_position")
+    client = DummyCcxtClient(payload["balance"], payload["positions"])
+    adapter = BinanceExchangeAdapter("Binance", client)
+
+    caplog.set_level("ERROR")
+    with pytest.raises(HedgedPositionViolation):
+        await adapter.fetch_account_state()
+
+    assert any("hedged positions" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- add a shared async account adapter interface that enforces one-way (non-hedged) positions
- implement Binance, Bybit, and OKX adapters on top of the shared CCXT transport helpers
- provide fixture-backed integration tests that cover parsing, closing, leverage, and hedged-position rejection

## Testing
- pytest tests/services/exchanges -q *(fails: missing dependency pydantic in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d668125308323bde184732bcc4494)