### PR TITLE
Increase risk management coverage and CI enforcement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
-      - run: pip install -e .[dev] ruff black mypy coverage
-      - run: ruff check .
-      - run: black --check .
-      - run: mypy .
-      - run: coverage run -m pytest && coverage xml
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -e .[dev] ruff black mypy coverage
+      - name: Lint
+        run: ruff check .
+      - name: Format
+        run: black --check .
+      - name: Type check
+        run: mypy .
+      - name: Test with coverage
+        run: |
+          coverage run -m pytest
+          coverage report --include="risk_management/email_notifications.py,risk_management/telegram_notifications.py,risk_management/reporting.py,risk_management/snapshot_utils.py,risk_management/view_helpers.py,risk_management/history.py" --fail-under=100
+          coverage xml
       - uses: codecov/codecov-action@v4

--- a/tests/risk_management/test_email_and_telegram_notifications.py
+++ b/tests/risk_management/test_email_and_telegram_notifications.py
@@ -1,0 +1,147 @@
+import types
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from risk_management.configuration import EmailSettings
+from risk_management.email_notifications import EmailAlertSender
+from risk_management.telegram_notifications import TelegramNotifier
+
+
+class DummySMTP:
+    def __init__(self):
+        self.started_tls = False
+        self.login_calls: list[tuple[str, str]] = []
+        self.sent_messages: list[tuple] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def starttls(self):
+        self.started_tls = True
+
+    def login(self, username, password):
+        self.login_calls.append((username, password))
+
+    def send_message(self, message, from_addr=None, to_addrs=None):
+        self.sent_messages.append((message, from_addr, tuple(to_addrs or ())))
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, text="ok"):
+        self.status_code = status_code
+        self.text = text
+
+
+class DummyClient:
+    def __init__(self, response: DummyResponse):
+        self.response = response
+        self.calls: list[tuple[str, dict]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json):
+        self.calls.append((url, json))
+        return self.response
+
+
+@pytest.mark.parametrize("use_ssl", [True, False])
+def test_email_sender_dispatches_with_auth(monkeypatch, use_ssl):
+    sender = DummySMTP()
+
+    if use_ssl:
+        monkeypatch.setattr(
+            "risk_management.email_notifications.smtplib.SMTP_SSL",
+            lambda host, port, timeout=None: sender,
+        )
+    else:
+        monkeypatch.setattr(
+            "risk_management.email_notifications.smtplib.SMTP",
+            lambda host, port, timeout=None: sender,
+        )
+
+    settings = EmailSettings(
+        host="localhost",
+        port=2525,
+        username="alerts@example.com",
+        password="secret",
+        use_tls=not use_ssl,
+        use_ssl=use_ssl,
+        sender=None,
+    )
+    alert_sender = EmailAlertSender(settings)
+    alert_sender.send("Subject", "Body", ["user@example.com", ""])
+
+    if use_ssl:
+        assert sender.started_tls is False
+    else:
+        assert sender.started_tls is True
+    assert sender.login_calls == [("alerts@example.com", "secret")]
+    assert sender.sent_messages
+    message, from_addr, recipients = sender.sent_messages[0]
+    assert message["Subject"] == "Subject"
+    assert from_addr == "alerts@example.com"
+    assert recipients == ("user@example.com",)
+
+
+def test_email_sender_uses_explicit_sender(monkeypatch):
+    sender = DummySMTP()
+    monkeypatch.setattr(
+        "risk_management.email_notifications.smtplib.SMTP",
+        lambda host, port, timeout=None: sender,
+    )
+    alert_sender = EmailAlertSender(
+        EmailSettings(host="localhost", sender="robot@example.com", use_tls=False)
+    )
+    alert_sender.send("Notice", "Hi", [])
+    assert sender.sent_messages == []
+
+    alert_sender.send("Notice", "Hi", ["user@example.com"])
+    message, from_addr, _ = sender.sent_messages[0]
+    assert from_addr == "robot@example.com"
+    assert message["From"] == "robot@example.com"
+
+
+def test_telegram_notifier_posts_and_logs(monkeypatch, caplog):
+    response = DummyResponse(status_code=500, text="fail")
+    client = DummyClient(response)
+
+    def client_factory(timeout):
+        assert timeout == 5.0
+        return client
+
+    fake_httpx = types.SimpleNamespace(Client=client_factory)
+    monkeypatch.setattr("risk_management.telegram_notifications.httpx", fake_httpx)
+
+    notifier = TelegramNotifier(timeout=5.0)
+    notifier.send("token", "123", "hello")
+
+    assert client.calls == [
+        ("https://api.telegram.org/bottoken/sendMessage", {"chat_id": "123", "text": "hello"})
+    ]
+    assert any("status 500" in record.message for record in caplog.records)
+
+
+def test_telegram_notifier_ignores_missing_inputs(monkeypatch):
+    called = False
+
+    def _unexpected_client(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("HTTP client should not be invoked")
+
+    monkeypatch.setattr("risk_management.telegram_notifications.httpx", types.SimpleNamespace(Client=_unexpected_client))
+
+    notifier = TelegramNotifier(timeout=1)
+    notifier.send("", "", "")
+    assert called is False
+
+

--- a/tests/risk_management/test_history_alias.py
+++ b/tests/risk_management/test_history_alias.py
@@ -1,0 +1,6 @@
+from risk_management import history
+from services.persistence.history import PortfolioHistoryStore
+
+
+def test_history_alias_exposes_store():
+    assert history.PortfolioHistoryStore is PortfolioHistoryStore

--- a/tests/risk_management/test_reporting.py
+++ b/tests/risk_management/test_reporting.py
@@ -1,0 +1,122 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from risk_management.reporting import ReportManager
+
+
+def sample_snapshot() -> dict:
+    return {
+        "generated_at": "2024-01-01T00:00:00+00:00",
+        "portfolio": {"balance": 2000.0},
+        "alerts": ["breach"],
+        "accounts": [
+            {
+                "name": "Main",
+                "balance": 1500.0,
+                "gross_exposure_notional": 600.0,
+                "gross_exposure": 0.4,
+                "net_exposure_notional": 200.0,
+                "net_exposure": 0.1333,
+                "unrealized_pnl": 50.0,
+                "symbol_exposures": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "gross_notional": 400.0,
+                        "gross_pct": 0.2666,
+                        "net_notional": 100.0,
+                        "net_pct": 0.0666,
+                    }
+                ],
+                "positions": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "side": "long",
+                        "notional": 400.0,
+                        "exposure": 0.2,
+                        "unrealized_pnl": 25.0,
+                        "pnl_pct": 0.05,
+                        "entry_price": 20000,
+                        "mark_price": 21000,
+                        "liquidation_price": 15000,
+                        "take_profit_price": 22000,
+                        "stop_loss_price": 18000,
+                    }
+                ],
+                "orders": [
+                    {
+                        "order_id": "1",
+                        "symbol": "BTCUSDT",
+                        "side": "buy",
+                        "type": "limit",
+                        "price": 21000,
+                        "amount": 0.01,
+                        "remaining": 0.01,
+                        "status": "open",
+                        "reduce_only": False,
+                        "notional": 210.0,
+                        "stop_price": None,
+                        "created_at": "2024-01-01T00:00:00Z",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_report_creation_and_listing(tmp_path: Path):
+    manager = ReportManager(tmp_path)
+    report = asyncio.run(manager.create_account_report("Main", sample_snapshot()))
+
+    assert report.path.exists()
+    assert report.account == "Main"
+    assert report.report_id
+    listed = asyncio.run(manager.list_reports("Main"))
+    assert len(listed) == 1
+    assert listed[0].report_id == report.report_id
+
+    path = asyncio.run(manager.get_report_path("Main", report.report_id))
+    assert path == report.path
+
+
+def test_report_sync_helpers_cover_edge_cases(tmp_path: Path):
+    manager = ReportManager(tmp_path)
+
+    with pytest.raises(ValueError):
+        manager._create_account_report_sync("Unknown", sample_snapshot())
+
+    empty_snapshot = {"accounts": "not-a-sequence"}
+    with pytest.raises(ValueError):
+        manager._create_account_report_sync("Unknown", empty_snapshot)
+
+    valid_name = manager._account_directory("Spaced Name")
+    assert valid_name.name == "Spaced_Name"
+
+    old_file = valid_name / "20240101T010101000000Z.csv"
+    new_file = valid_name / "20240101T020202Z.csv"
+    valid_name.mkdir(parents=True, exist_ok=True)
+    old_file.write_text("old")
+    new_file.write_text("new")
+
+    reports = manager._list_reports_sync("Spaced Name")
+    assert [r.report_id for r in reports] == ["20240101T020202Z", "20240101T010101000000Z"]
+    assert manager._get_report_path_sync("Spaced Name", "missing") is None
+    assert manager._get_report_path_sync("Spaced Name", "20240101T010101000000Z") == old_file
+
+    assert manager._format_currency("oops") == "-"
+    assert manager._format_pct("oops") == "0.00%"
+    assert manager._format_price("oops") == "-"
+
+
+def test_report_rows_cover_empty_states(tmp_path: Path):
+    manager = ReportManager(tmp_path)
+    snapshot = sample_snapshot()
+    snapshot["accounts"][0].update({"symbol_exposures": None, "positions": None, "orders": None})
+    report = manager._create_account_report_sync("Main", snapshot)
+    rows = report.path.read_text().splitlines()
+    assert any("No symbol exposure" in row for row in rows)
+    assert any("No open positions" in row for row in rows)
+    assert any("No open orders" in row for row in rows)
+
+

--- a/tests/risk_management/test_snapshot_utils.py
+++ b/tests/risk_management/test_snapshot_utils.py
@@ -1,0 +1,127 @@
+import datetime
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from risk_management import snapshot_utils
+from risk_management.dashboard import Account, AlertThresholds, Order, Position
+from risk_management.models import Balance
+
+
+def build_sample_account(name: str, *, message: str | None = None) -> tuple[Account, dict[str, str]]:
+    positions = [
+        Position(
+            symbol="BTCUSDT",
+            side="long",
+            notional=200.0,
+            entry_price=20_000,
+            mark_price=21_000,
+            liquidation_price=10_000,
+            wallet_exposure_pct=0.2,
+            unrealized_pnl=25.0,
+            max_drawdown_pct=0.05,
+            take_profit_price=22_000,
+            stop_loss_price=18_000,
+            size=0.01,
+            signed_notional=200.0,
+            volatility={"1h": 0.3, "4h": 0.5},
+            funding_rates={"1h": 0.001, "4h": 0.002},
+            daily_realized_pnl=5.0,
+        ),
+        Position(
+            symbol="ETHUSDT",
+            side="short",
+            notional=120.0,
+            entry_price=2_000,
+            mark_price=1_950,
+            liquidation_price=2_400,
+            wallet_exposure_pct=0.1,
+            unrealized_pnl=-15.0,
+            max_drawdown_pct=0.02,
+            take_profit_price=1_800,
+            stop_loss_price=2_200,
+            size=0.06,
+            signed_notional=-120.0,
+            volatility={"1h": 0.2},
+            funding_rates={"1h": -0.001},
+            daily_realized_pnl=-3.0,
+        ),
+    ]
+    orders = [
+        Order(
+            symbol="BTCUSDT",
+            side="sell",
+            type="limit",
+            price=21_500,
+            amount=0.01,
+            remaining=0.01,
+            status="open",
+            reduce_only=False,
+            stop_price=None,
+            notional=215.0,
+            order_id="abc",
+            created_at="2024-01-01T00:00:00Z",
+        )
+    ]
+    account = Account(name=name, balance=Balance(balance=1000.0), positions=positions, orders=orders)
+    message_mapping = {name: message} if message else {}
+    return account, message_mapping
+
+
+def test_build_presentable_snapshot_splits_hidden_accounts():
+    visible_account, visible_message = build_sample_account("Visible")
+    hidden_account, hidden_message = build_sample_account("Hidden", message="Maintenance")
+
+    snapshot = {
+        "generated_at": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc).isoformat(),
+        "accounts": [visible_account, hidden_account],
+        "alert_thresholds": AlertThresholds(),
+        "notification_channels": ["email"],
+        "account_messages": {**visible_message, **hidden_message},
+        "portfolio_stop_loss": {"enabled": True, "threshold": -0.15},
+        "conditional_stop_losses": [{"symbol": "BTCUSDT", "threshold": -0.1}],
+        "policy_violations": ["drawdown"],
+    }
+
+    payload = snapshot_utils.build_presentable_snapshot(snapshot)
+
+    assert payload["generated_at"].startswith("2024-01-01")
+    assert payload["alerts"] == []
+    assert payload["accounts"][0]["name"] == "Visible"
+    assert payload["hidden_accounts"] == [{"name": "Hidden", "message": "Maintenance"}]
+    assert payload["notifications"] == ["email"]
+    assert payload["portfolio_stop_loss"] == {"enabled": True, "threshold": -0.15}
+    assert payload["conditional_stop_losses"] == [{"symbol": "BTCUSDT", "threshold": -0.1}]
+    assert payload["policy_violations"] == ["drawdown"]
+
+    portfolio = payload["portfolio"]
+    assert portfolio["balance"] == 2000.0
+    assert portfolio["gross_exposure"] == 320.0
+    assert portfolio["net_exposure"] == 80.0
+    assert portfolio["volatility"]["1h"] == pytest.approx((0.3 * 200 + 0.2 * 120) / 320)
+    assert portfolio["funding_rates"]["1h"] == pytest.approx((0.001 * 200 - 0.001 * 120) / 320)
+
+
+def test_symbol_and_position_views_are_sorted_and_formatted():
+    account, messages = build_sample_account("Trader")
+    payload = snapshot_utils.build_presentable_snapshot(
+        {
+            "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "accounts": [account],
+            "alert_thresholds": AlertThresholds(loss_threshold_pct=-1.0),
+            "account_messages": messages,
+        }
+    )
+
+    account_view = payload["accounts"][0]
+    exposures = account_view["symbol_exposures"]
+    assert [entry["symbol"] for entry in exposures] == ["BTCUSDT", "ETHUSDT"]
+    assert account_view["positions"][0]["volatility"] == {"1h": 0.3, "4h": 0.5}
+    assert account_view["orders"][0]["order_id"] == "abc"
+    assert account_view["volatility"]["1h"] == pytest.approx((0.3 * 200 + 0.2 * 120) / 320)
+    assert account_view["funding_rates"]["1h"] == pytest.approx((0.001 * 200 - 0.001 * 120) / 320)
+
+    portfolio_symbols = payload["portfolio"]["symbols"]
+    assert portfolio_symbols[0]["symbol"] == "BTCUSDT"
+    assert portfolio_symbols[1]["symbol"] == "ETHUSDT"

--- a/tests/risk_management/test_view_helpers.py
+++ b/tests/risk_management/test_view_helpers.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from risk_management import view_helpers
+
+
+def test_dashboard_context_includes_grafana():
+    request = SimpleNamespace()
+    context = view_helpers.dashboard_context(
+        request,
+        "user",
+        {"accounts": []},
+        {"dashboards": [1], "account_dashboards": [2], "theme": "dark"},
+    )
+    assert context["request"] is request
+    assert context["user"] == "user"
+    assert context["grafana_dashboards"] == [1]
+    assert context["grafana_account_dashboards"] == [2]
+    assert context["grafana_theme"] == "dark"
+
+
+def test_api_keys_context_includes_paths():
+    request = SimpleNamespace()
+    context = view_helpers.api_keys_context(
+        request,
+        "user",
+        {"api": "keys"},
+        [{"name": "acc"}],
+        "/path/config",
+        "/path/api_keys",
+        {"dashboards": [3], "theme": "light"},
+    )
+    assert context["api_keys"] == {"api": "keys"}
+    assert context["accounts"] == [{"name": "acc"}]
+    assert context["config_path"] == "/path/config"
+    assert context["api_keys_path"] == "/path/api_keys"
+    assert context["grafana_dashboards"] == [3]
+    assert context["grafana_theme"] == "light"


### PR DESCRIPTION
## Summary
- add coverage-focused tests for risk management snapshot formatting, notifications, reporting, view helpers, and the history alias
- enforce coverage for critical risk management utilities and cache pip dependencies in CI

## Testing
- pytest tests/risk_management/test_reporting.py tests/risk_management/test_view_helpers.py tests/risk_management/test_history_alias.py -q
- pytest tests/risk_management/test_email_and_telegram_notifications.py -q
- pytest tests/risk_management/test_snapshot_utils.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69341259ae5c8323a0e63e82f43dc085)