### PR TITLE
Fix realtime notifications and configuration imports

### DIFF
--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -62,7 +62,7 @@ def _configure_default_logging(debug_level: int = 1) -> bool:
     already_configured = bool(root_logger.handlers)
 
     if not already_configured:
-        configurator = _resolve_passivbot_logging_configurator()
+        configurator = _passivbot_logging_configurator()
         if configurator is not None:
             configurator(debug=debug_level)
         else:
@@ -87,24 +87,14 @@ def _ensure_debug_logging_enabled() -> None:
     _ensure_logger_level(risk_logger, logging.DEBUG)
 
 
-def _coerce_bool(value: Any, default: bool = False) -> bool:
-    """Return a boolean for ``value`` supporting common string representations."""
+def _debug_to_logging_level(debug_level: int) -> int:
+    """Map a debug verbosity integer to a logging level."""
 
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return bool(value)
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"", "default", "auto"}:
-            return default
-        if lowered in {"1", "true", "yes", "on", "enabled", "enable"}:
-            return True
-        if lowered in {"0", "false", "no", "off", "disabled", "disable"}:
-            return False
-    return bool(value)
+    if debug_level <= 0:
+        return logging.WARNING
+    if debug_level == 1:
+        return logging.INFO
+    return logging.DEBUG
 
 
 @dataclass()

--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional, Set
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set
 
 from risk_management.config.models import (
     AccountConfig,

--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -298,13 +298,11 @@ class RealtimeDataFetcher:
         if conditional_state:
             snapshot["conditional_stop_losses"] = conditional_state
 
-        await self._maybe_send_daily_balance_snapshot(snapshot, portfolio_balance)
-        await self._dispatch_notifications(snapshot)
-
         violations = list(self._policy_evaluator(snapshot))
         if violations:
             snapshot["policy_violations"] = [violation.as_dict() for violation in violations]
-        self._maybe_send_daily_balance_snapshot(snapshot, portfolio_balance)
+        await self._maybe_send_daily_balance_snapshot(snapshot, portfolio_balance)
+        await self._dispatch_notifications(violations, snapshot)
         if self._kill_switch_handler is not None:
             try:
                 await self._kill_switch_handler(violations, snapshot)
@@ -343,9 +341,7 @@ class RealtimeDataFetcher:
         return results
 
 
-    async def _dispatch_notifications(self, snapshot: Mapping[str, Any]) -> None:
-
-    def _dispatch_notifications(
+    async def _dispatch_notifications(
         self, violations: Sequence[RiskViolation], snapshot: Mapping[str, Any]
     ) -> None:
 


### PR DESCRIPTION
## Summary
- add missing dataclass and logging imports to risk management configuration module
- correct realtime notification dispatch definition and call order

## Testing
- pytest tests/risk_management/test_configuration.py tests/risk_management/test_balance_extraction.py -q *(fails: missing dependency `pydantic` in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693419e8c8a48323ae05d95aee8b6e19)