### PR TITLE
Decouple risk management from pydantic

### DIFF
--- a/risk_management/config/__init__.py
+++ b/risk_management/config/__init__.py
@@ -1,4 +1,4 @@
-"""Pydantic models describing realtime risk management configuration."""
+"""Dataclass-based models describing realtime risk management configuration."""
 
 from . import models
 from .models import *  # noqa: F401,F403

--- a/risk_management/config/models.py
+++ b/risk_management/config/models.py
@@ -1,47 +1,37 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import BaseModel, Field, root_validator, validator
+from services.telemetry import ResiliencePolicy
 
 
-class _BaseModel(BaseModel):
-    class Config:
-        extra = "forbid"
-        arbitrary_types_allowed = True
-
-
-class CustomEndpointSettings(_BaseModel):
+@dataclass()
+class CustomEndpointSettings:
     """Settings controlling how custom endpoint overrides are loaded."""
 
     path: Optional[str] = None
     autodiscover: bool = True
 
 
-class AccountConfig(_BaseModel):
+@dataclass()
+class AccountConfig:
     """Configuration for a single exchange account."""
 
     name: str
     exchange: str
     settle_currency: str = "USDT"
     api_key_id: Optional[str] = None
-    credentials: Dict[str, Any] = Field(default_factory=dict)
+    credentials: Dict[str, Any] = field(default_factory=dict)
     symbols: Optional[List[str]] = None
-    params: Dict[str, Any] = Field(default_factory=dict)
+    params: Dict[str, Any] = field(default_factory=dict)
     enabled: bool = True
     debug_api_payloads: bool = False
 
-    @validator("name", "exchange", "settle_currency")
-    def _strip_values(cls, value: str) -> str:
-        if isinstance(value, str):
-            value = value.strip()
-        if not value:
-            raise ValueError("Fields 'name', 'exchange', and 'settle_currency' must be non-empty strings.")
-        return value
 
-
-class AuthConfig(_BaseModel):
+@dataclass()
+class AuthConfig:
     """Settings for session authentication in the web dashboard."""
 
     secret_key: str
@@ -49,20 +39,9 @@ class AuthConfig(_BaseModel):
     session_cookie_name: str = "risk_dashboard_session"
     https_only: bool = True
 
-    @validator("secret_key", "session_cookie_name")
-    def _require_strings(cls, value: str) -> str:
-        if not value or not str(value).strip():
-            raise ValueError("Authentication configuration requires non-empty strings.")
-        return str(value)
 
-    @validator("users")
-    def _ensure_users(cls, value: Mapping[str, str]) -> Mapping[str, str]:
-        if not value:
-            raise ValueError("Authentication configuration requires at least one user entry.")
-        return {str(username): str(password) for username, password in value.items()}
-
-
-class EmailSettings(_BaseModel):
+@dataclass()
+class EmailSettings:
     """SMTP configuration used to dispatch alert emails."""
 
     host: str
@@ -73,14 +52,9 @@ class EmailSettings(_BaseModel):
     use_ssl: bool = False
     sender: Optional[str] = None
 
-    @validator("host")
-    def _strip_host(cls, value: str) -> str:
-        if not value or not str(value).strip():
-            raise ValueError("Email settings must include a non-empty 'host'.")
-        return str(value).strip()
 
-
-class GrafanaDashboardConfig(_BaseModel):
+@dataclass()
+class GrafanaDashboardConfig:
     """Description of a Grafana dashboard or panel to embed."""
 
     title: str
@@ -88,75 +62,49 @@ class GrafanaDashboardConfig(_BaseModel):
     description: Optional[str] = None
     height: Optional[int] = None
 
-    @validator("title", "url")
-    def _require_non_empty(cls, value: str) -> str:
-        if not value or not str(value).strip():
-            raise ValueError("Grafana dashboard entries require a non-empty 'title' and 'url'.")
-        return str(value).strip()
 
-    @validator("height")
-    def _validate_height(cls, value: Optional[int]) -> Optional[int]:
-        if value is None:
-            return value
-        if value <= 0:
-            raise ValueError("Grafana dashboard 'height' must be greater than zero when provided.")
-        return value
-
-
-class GrafanaConfig(_BaseModel):
+@dataclass()
+class GrafanaConfig:
     """Settings for embedding Grafana dashboards in the web UI."""
 
-    dashboards: List[GrafanaDashboardConfig] = Field(default_factory=list)
+    dashboards: List[GrafanaDashboardConfig] = field(default_factory=list)
     default_height: int = 600
     theme: str = "dark"
     base_url: Optional[str] = None
     account_equity_template: Optional[str] = None
 
-    @validator("default_height")
-    def _validate_default_height(cls, value: int) -> int:
-        if value <= 0:
-            raise ValueError("Grafana 'default_height' must be greater than zero.")
-        return value
 
-
-class AlertLimits(_BaseModel):
+@dataclass()
+class AlertLimits:
     wallet_exposure_pct: float = 0.6
     position_wallet_exposure_pct: float = 0.25
     max_drawdown_pct: float = 0.3
     loss_threshold_pct: float = -0.12
 
 
-class NotificationSettings(_BaseModel):
-    channels: List[str] = Field(default_factory=list)
-
-    @validator("channels", each_item=True)
-    def _strip_channel(cls, value: str) -> str:
-        return str(value).strip()
+@dataclass()
+class NotificationSettings:
+    channels: List[str] = field(default_factory=list)
 
 
-class RealtimeConfig(_BaseModel):
+@dataclass()
+class RealtimeConfig:
     """Top level realtime configuration."""
 
     accounts: List[AccountConfig]
-    alert_thresholds: AlertLimits = Field(default_factory=AlertLimits)
-    notification_channels: List[str] = Field(default_factory=list)
+    alert_thresholds: AlertLimits = field(default_factory=AlertLimits)
+    notification_channels: List[str] = field(default_factory=list)
     auth: Optional[AuthConfig] = None
-    account_messages: Dict[str, str] = Field(default_factory=dict)
+    account_messages: Dict[str, str] = field(default_factory=dict)
     custom_endpoints: Optional[CustomEndpointSettings] = None
     email: Optional[EmailSettings] = None
+    resilience: ResiliencePolicy = field(default_factory=ResiliencePolicy)
     config_root: Optional[Path] = None
     debug_api_payloads: bool = False
     reports_dir: Optional[Path] = None
     grafana: Optional[GrafanaConfig] = None
     api_keys_path: Optional[Path] = None
     config_path: Optional[Path] = None
-
-    @root_validator
-    def _require_accounts(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        accounts = values.get("accounts") or []
-        if not accounts:
-            raise ValueError("Realtime configuration must include at least one enabled account entry.")
-        return values
 
 
 __all__ = [

--- a/risk_management/configuration.py
+++ b/risk_management/configuration.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set
@@ -95,93 +94,6 @@ def _debug_to_logging_level(debug_level: int) -> int:
     if debug_level == 1:
         return logging.INFO
     return logging.DEBUG
-
-
-@dataclass()
-class CustomEndpointSettings:
-    """Settings controlling how custom endpoint overrides are loaded."""
-
-    path: Optional[str] = None
-    autodiscover: bool = True
-
-
-@dataclass()
-class AccountConfig:
-    """Configuration for a single exchange account."""
-
-    name: str
-    exchange: str
-    settle_currency: str = "USDT"
-    api_key_id: Optional[str] = None
-    credentials: Dict[str, Any] = field(default_factory=dict)
-    symbols: Optional[List[str]] = None
-    params: Dict[str, Any] = field(default_factory=dict)
-    enabled: bool = True
-    debug_api_payloads: bool = False
-
-
-@dataclass()
-class AuthConfig:
-    """Settings for session authentication in the web dashboard."""
-
-    secret_key: str
-    users: Mapping[str, str]
-    session_cookie_name: str = "risk_dashboard_session"
-    https_only: bool = True
-
-
-@dataclass()
-class EmailSettings:
-    """SMTP configuration used to dispatch alert emails."""
-
-    host: str
-    port: int = 587
-    username: Optional[str] = None
-    password: Optional[str] = None
-    use_tls: bool = True
-    use_ssl: bool = False
-    sender: Optional[str] = None
-
-
-@dataclass()
-class GrafanaDashboardConfig:
-    """Description of a Grafana dashboard or panel to embed."""
-
-    title: str
-    url: str
-    description: Optional[str] = None
-    height: Optional[int] = None
-
-
-@dataclass()
-class GrafanaConfig:
-    """Settings for embedding Grafana dashboards in the web UI."""
-
-    dashboards: List[GrafanaDashboardConfig] = field(default_factory=list)
-    default_height: int = 600
-    theme: str = "dark"
-    base_url: Optional[str] = None
-    account_equity_template: Optional[str] = None
-
-
-@dataclass()
-class RealtimeConfig:
-    """Top level realtime configuration."""
-
-    accounts: List[AccountConfig]
-    alert_thresholds: Dict[str, float] = field(default_factory=dict)
-    notification_channels: List[str] = field(default_factory=list)
-    auth: Optional[AuthConfig] = None
-    account_messages: Dict[str, str] = field(default_factory=dict)
-    custom_endpoints: Optional[CustomEndpointSettings] = None
-    email: Optional[EmailSettings] = None
-    resilience: ResiliencePolicy = field(default_factory=ResiliencePolicy)
-    config_root: Optional[Path] = None
-    debug_api_payloads: bool = False
-    reports_dir: Optional[Path] = None
-    grafana: Optional[GrafanaConfig] = None
-    api_keys_path: Optional[Path] = None
-    config_path: Optional[Path] = None
 
 
 


### PR DESCRIPTION
## Summary
- replace risk management configuration models with lightweight dataclasses to remove the pydantic dependency
- reimplement runtime risk models with manual coercion to keep snapshot parsing functional without external packages
- adjust realtime fetcher to configure provided account clients, simplify resilience for custom clients, and await notification handlers

## Testing
- pytest tests/risk_management -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69341dbc43c4832396a7819d9e6b9028)