### PR TITLE
Clean realtime imports and add import smoke test

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone, date, time
-from types import TracebackType
+from datetime import date, datetime, time, timezone
 from pathlib import Path
-
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
-
-from typing import Any, Awaitable, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+from types import TracebackType
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Sequence
 
 from zoneinfo import ZoneInfo
 

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_import_risk_management_realtime() -> None:
+    module = importlib.import_module("risk_management.realtime")
+    assert hasattr(module, "RealtimeDataFetcher")


### PR DESCRIPTION
## Summary
- deduplicate and reorder typing imports in `risk_management/realtime.py` while keeping required types
- add a smoke test to ensure `risk_management.realtime` imports cleanly

## Testing
- ruff check risk_management/realtime.py
- pytest tests/test_import_smoke.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935655332e883238430055725ca85e6)