### PR TITLE
Refactor realtime monitoring components with clearer interfaces

### DIFF
--- a/risk_management/realtime.py
+++ b/risk_management/realtime.py
@@ -5,15 +5,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone, date, time
+from datetime import datetime, timezone
 from types import TracebackType
 from pathlib import Path
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
-
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
 
-from zoneinfo import ZoneInfo
 
 from custom_endpoint_overrides import (
     CustomEndpointConfigError,
@@ -34,10 +31,16 @@ from risk_engine.policies import RiskViolation
 
 from .account_clients import AccountClientProtocol, CCXTAccountClient
 from .configuration import CustomEndpointSettings, RealtimeConfig
-from .dashboard import evaluate_alerts, parse_snapshot
 from .email_notifications import EmailAlertSender
 from .telegram_notifications import TelegramNotifier
 from services.telemetry import ResiliencePolicy, Telemetry
+from .realtime_components import (
+    ClientOrchestrator,
+    KillSwitchExecutor,
+    NotificationDispatcher,
+    ResilientExecutor,
+    SnapshotPolicyEvaluator,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,14 +110,15 @@ class RealtimeDataFetcher:
         self,
         config: RealtimeConfig,
         account_clients: Optional[Sequence[AccountClientProtocol]] = None,
-
         telemetry: Optional[Telemetry] = None,
-
         *,
         policy_evaluator: Optional[PolicyEvaluator] = None,
         notification_handler: Optional[NotificationHandler] = None,
         kill_switch_handler: Optional[KillSwitchHandler] = None,
-
+        orchestrator: Optional[ClientOrchestrator] = None,
+        notification_dispatcher: Optional[NotificationDispatcher] = None,
+        kill_switch_executor: Optional[KillSwitchExecutor] = None,
+        executor: Optional[ResilientExecutor] = None,
     ) -> None:
         self.config = config
         self.telemetry = telemetry or Telemetry(policy=config.resilience)
@@ -148,7 +152,6 @@ class RealtimeDataFetcher:
                 circuit_breaker_reset_s=config.resilience.circuit_breaker_reset_s,
             )
             self.telemetry.policy = self.resilience_policy
-        self._last_auth_errors: Dict[str, str] = {}
         if config.debug_api_payloads:
             logger.info(
                 "Exchange API payload debug logging enabled for realtime fetcher"
@@ -158,31 +161,38 @@ class RealtimeDataFetcher:
                 logger.info(
                     "Debug API payload logging enabled for account %s", account.name
                 )
+        self._executor = executor or ResilientExecutor(self.telemetry, self.resilience_policy)
+        self._orchestrator = orchestrator or ClientOrchestrator(
+            self._account_clients,
+            self._executor,
+            account_messages=config.account_messages,
+        )
         self._email_sender = EmailAlertSender(config.email) if config.email else None
         self._email_recipients = self._extract_email_recipients()
         self._telegram_targets = self._extract_telegram_targets()
         self._telegram_notifier = TelegramNotifier() if self._telegram_targets else None
-        self._active_alerts: set[str] = set()
-        self._daily_snapshot_tz = ZoneInfo("America/New_York")
-        self._daily_snapshot_sent_date: Optional[date] = None
         self._portfolio_stop_loss: Optional[Dict[str, Any]] = None
         self._last_portfolio_balance: Optional[float] = None
         self._conditional_stop_losses: list[Dict[str, Any]] = []
-        self._policy_evaluator: PolicyEvaluator = (
-            policy_evaluator if policy_evaluator is not None else self._evaluate_snapshot_policies
+        self._policy_evaluator: PolicyEvaluator = policy_evaluator or SnapshotPolicyEvaluator()
+        self._notification_dispatcher = notification_dispatcher or NotificationDispatcher(
+            self._executor,
+            email_sender=self._email_sender,
+            email_recipients=self._email_recipients,
+            telegram_notifier=self._telegram_notifier,
+            telegram_targets=self._telegram_targets,
         )
-        self._notification_handler: NotificationHandler = (
-            notification_handler if notification_handler is not None else self._dispatch_notifications
-        )
+        self._notification_handler: NotificationHandler = notification_handler or self._notification_dispatcher.dispatch
         self._kill_switch_handler = kill_switch_handler
+        self._kill_switch_executor = kill_switch_executor or KillSwitchExecutor(
+            self._account_clients, self._executor
+        )
 
     async def _resilient_call(self, name: str, func: Callable[[], Any]) -> Any:
-        return await self.telemetry.execute_with_resilience(
-            name, func, policy=self.resilience_policy
-        )
+        return await self._executor.execute(name, func)
 
     async def _resilient_threaded_call(self, name: str, func: Callable[[], Any]) -> Any:
-        return await self._resilient_call(name, lambda: asyncio.to_thread(func))
+        return await self._executor.execute_threaded(name, lambda: asyncio.to_thread(func))
 
     def _extract_email_recipients(self) -> List[str]:
         recipients: List[str] = []
@@ -219,73 +229,8 @@ class RealtimeDataFetcher:
                 targets.append((token, chat_id))
         return targets
 
-    def _evaluate_snapshot_policies(self, snapshot: Mapping[str, Any]) -> List[RiskViolation]:
-        try:
-            _, accounts, thresholds, _ = parse_snapshot(dict(snapshot))
-            alerts = evaluate_alerts(accounts, thresholds)
-        except Exception:  # pragma: no cover - defensive fall back
-            return []
-        return [RiskViolation("alert_threshold", alert) for alert in alerts]
-
     async def fetch_snapshot(self) -> Dict[str, Any]:
-        tasks = [
-            self._resilient_call(
-                f"account:{client.config.name}:fetch",
-                lambda client=client: client.fetch(),
-            )
-            for client in self._account_clients
-        ]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        accounts_payload: List[Dict[str, Any]] = []
-        account_messages: Dict[str, str] = dict(self.config.account_messages)
-        for account_config, result in zip(self.config.accounts, results):
-            if isinstance(result, Exception):
-                if isinstance(result, AuthenticationError):
-                    message = (
-                        f"{account_config.name}: authentication failed - {result}"
-                    )
-
-                    error_message = str(result)
-                    previous_error = self._last_auth_errors.get(account_config.name)
-                    if previous_error != error_message:
-                        logger.warning(
-                            "Authentication failed for %s: %s",
-                            account_config.name,
-                            result,
-                        )
-                        self._last_auth_errors[account_config.name] = error_message
-                    else:
-                        logger.debug(
-                            "Authentication failure for %s unchanged: %s",
-                            account_config.name,
-                            result,
-                        )
-
-                else:
-                    message = f"{account_config.name}: {result}"
-                    logger.error(
-                        "Failed to fetch snapshot for %s",
-                        account_config.name,
-                        exc_info=_exception_info(result),
-                    )
-                account_messages[account_config.name] = message
-                accounts_payload.append(
-                    {
-                        "name": account_config.name,
-                        "balance": 0.0,
-                        "positions": [],
-                        "exchange": account_config.exchange,
-                    }
-                )
-            else:
-                account_payload = dict(result)
-                account_payload.setdefault("exchange", account_config.exchange)
-                accounts_payload.append(account_payload)
-                if account_config.name in self._last_auth_errors:
-                    logger.info(
-                        "Authentication for %s restored", account_config.name
-                    )
-                    self._last_auth_errors.pop(account_config.name, None)
+        accounts_payload, account_messages = await self._orchestrator.fetch()
         snapshot = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "accounts": accounts_payload,
@@ -312,8 +257,6 @@ class RealtimeDataFetcher:
         violations = list(self._policy_evaluator(snapshot))
         if violations:
             snapshot["policy_violations"] = [violation.as_dict() for violation in violations]
-        await self._maybe_send_daily_balance_snapshot(snapshot, portfolio_balance)
-        await self._dispatch_notifications(violations, snapshot)
         if self._kill_switch_handler is not None:
             try:
                 await self._kill_switch_handler(violations, snapshot)
@@ -331,102 +274,8 @@ class RealtimeDataFetcher:
     async def execute_kill_switch(
         self, account_name: Optional[str] = None, symbol: Optional[str] = None
     ) -> Dict[str, Any]:
-        scope = account_name or "all accounts"
-        symbol_desc = f" for {symbol}" if symbol else ""
-        logger.info("Kill switch requested for %s%s", scope, symbol_desc)
-        targets: List[AccountClientProtocol] = []
-        for client in self._account_clients:
-            if account_name is None or client.config.name == account_name:
-                targets.append(client)
-        if account_name is not None and not targets:
-            raise ValueError(f"Account '{account_name}' is not configured for realtime monitoring.")
-        results: Dict[str, Any] = {}
-        for client in targets:
-            try:
-                results[client.config.name] = await self._resilient_call(
-                    f"account:{client.config.name}:kill_switch",
-                    lambda client=client: client.kill_switch(symbol),
-                )
-            except Exception as exc:  # pragma: no cover - defensive logging
-                logger.exception("Kill switch failed for %s", client.config.name, exc_info=True)
-                results[client.config.name] = {"error": str(exc)}
-        logger.info("Kill switch completed for %s", scope)
-        return results
+        return await self._kill_switch_executor.execute(account_name, symbol)
 
-
-    async def _dispatch_notifications(
-        self, violations: Sequence[RiskViolation], snapshot: Mapping[str, Any]
-    ) -> None:
-
-        if not (self._email_sender or self._telegram_notifier):
-            return
-        alerts = [violation.message for violation in violations]
-        alerts_set = set(alerts)
-        new_alerts = [alert for alert in alerts if alert not in self._active_alerts]
-        self._active_alerts = alerts_set
-        if not new_alerts:
-            return
-        generated_at = snapshot.get("generated_at")
-        timestamp = (
-            generated_at
-            if isinstance(generated_at, str)
-            else datetime.now(timezone.utc).isoformat()
-        )
-        lines = [f"Exposure thresholds were exceeded at {timestamp}.", "", "Alerts:"]
-        lines.extend(f"- {alert}" for alert in new_alerts)
-        body = "\n".join(lines)
-        subject = "Risk alert: exposure threshold breached"
-        if self._email_sender and self._email_recipients:
-            await self._resilient_threaded_call(
-                "notification:email",
-                lambda: self._email_sender.send(subject, body, self._email_recipients),
-            )
-        if self._telegram_notifier and self._telegram_targets:
-            message = f"Exposure alert at {timestamp}\n" + "\n".join(new_alerts)
-            for token, chat_id in self._telegram_targets:
-                await self._resilient_threaded_call(
-                    f"notification:telegram:{chat_id}",
-                    lambda token=token, chat_id=chat_id: self._telegram_notifier.send(
-                        token, chat_id, message
-                    ),
-                )
-
-    async def _maybe_send_daily_balance_snapshot(
-        self, snapshot: Mapping[str, Any], portfolio_balance: float
-    ) -> None:
-        if not self._email_sender or not self._email_recipients:
-            return
-        now_ny = datetime.now(self._daily_snapshot_tz)
-        current_date = now_ny.date()
-        if self._daily_snapshot_sent_date and current_date > self._daily_snapshot_sent_date:
-            self._daily_snapshot_sent_date = None
-        if now_ny.time() < time(16, 0):
-            return
-        if self._daily_snapshot_sent_date == current_date:
-            return
-        accounts = snapshot.get("accounts", [])
-        lines = [
-            f"Daily portfolio snapshot ({now_ny.strftime('%Y-%m-%d')} 16:00 ET)",
-            f"Total balance: ${portfolio_balance:,.2f}",
-            "",
-            "Accounts:",
-        ]
-        for account in accounts or []:
-            if not isinstance(account, Mapping):
-                continue
-            name = str(account.get("name", "unknown"))
-            balance = float(account.get("balance", 0.0))
-            realised = float(account.get("daily_realized_pnl", 0.0))
-            lines.append(
-                f"- {name}: balance ${balance:,.2f}, daily realised PnL ${realised:,.2f}"
-            )
-        body = "\n".join(lines)
-        subject = "Daily portfolio balance snapshot"
-        await self._resilient_threaded_call(
-            "notification:email.daily",
-            lambda: self._email_sender.send(subject, body, self._email_recipients),
-        )
-        self._daily_snapshot_sent_date = current_date
 
     def _update_portfolio_stop_loss_state(
         self, portfolio_balance: float

--- a/risk_management/realtime_components.py
+++ b/risk_management/realtime_components.py
@@ -1,0 +1,258 @@
+"""Composable realtime components with clear interfaces for testing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, date, time, timezone
+from typing import Any, Callable, Mapping, Optional, Sequence
+from zoneinfo import ZoneInfo
+
+from risk_engine.policies import RiskViolation
+
+from .dashboard import evaluate_alerts, parse_snapshot
+from .email_notifications import EmailAlertSender
+from .telegram_notifications import TelegramNotifier
+from .account_clients import AccountClientProtocol
+from services.telemetry import ResiliencePolicy, Telemetry
+
+logger = logging.getLogger(__name__)
+
+
+class ResilientExecutor:
+    """Adapter that wraps ``Telemetry.execute_with_resilience`` for DI."""
+
+    def __init__(self, telemetry: Telemetry, policy: Optional[ResiliencePolicy] = None) -> None:
+        self.telemetry = telemetry
+        self.policy = policy or telemetry.policy
+
+    async def execute(self, name: str, func: Callable[[], Any]) -> Any:
+        async def _invoke() -> Any:
+            result = func()
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
+
+        return await self.telemetry.execute_with_resilience(name, _invoke, policy=self.policy)
+
+    async def execute_threaded(self, name: str, func: Callable[[], Any]) -> Any:
+        return await self.execute(name, lambda: asyncio.to_thread(func))
+
+
+class ClientOrchestrator:
+    """Fetch snapshots from clients while handling resilience concerns."""
+
+    def __init__(
+        self,
+        clients: Sequence[AccountClientProtocol],
+        executor: ResilientExecutor,
+        *,
+        account_messages: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self._clients = list(clients)
+        self._executor = executor
+        self._last_auth_errors: dict[str, str] = {}
+        self._account_messages = dict(account_messages or {})
+
+    async def fetch(self) -> tuple[list[dict[str, Any]], dict[str, str]]:
+        tasks = [
+            self._executor.execute(
+                f"account:{client.config.name}:fetch", lambda client=client: client.fetch()
+            )
+            for client in self._clients
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        accounts_payload: list[dict[str, Any]] = []
+        account_messages: dict[str, str] = dict(self._account_messages)
+        for client, result in zip(self._clients, results):
+            if isinstance(result, Exception):
+                message = self._format_error_message(client.config.name, result)
+                account_messages[client.config.name] = message
+                accounts_payload.append(
+                    {
+                        "name": client.config.name,
+                        "balance": 0.0,
+                        "positions": [],
+                        "exchange": client.config.exchange,
+                    }
+                )
+            else:
+                payload = dict(result)
+                payload.setdefault("exchange", client.config.exchange)
+                accounts_payload.append(payload)
+                self._reset_auth_error(client.config.name)
+
+        return accounts_payload, account_messages
+
+    def _format_error_message(self, account_name: str, exc: Exception) -> str:
+        auth_error_names = {"AuthenticationError"}
+        try:
+            from ccxt.base.errors import AuthenticationError as CCXTAuthenticationError
+        except Exception:  # pragma: no cover - optional dependency
+            CCXTAuthenticationError = None
+
+        is_auth_error = exc.__class__.__name__ in auth_error_names
+        if CCXTAuthenticationError is not None and isinstance(exc, CCXTAuthenticationError):
+            is_auth_error = True
+
+        if is_auth_error:
+            message = f"{account_name}: authentication failed - {exc}"
+            error_message = str(exc)
+            previous_error = self._last_auth_errors.get(account_name)
+            if previous_error != error_message:
+                logger.warning("Authentication failed for %s: %s", account_name, exc)
+                self._last_auth_errors[account_name] = error_message
+            else:
+                logger.debug("Authentication failure for %s unchanged: %s", account_name, exc)
+            return message
+
+        logger.error(
+            "Failed to fetch snapshot for %s", account_name, exc_info=(type(exc), exc, exc.__traceback__)
+        )
+        return f"{account_name}: {exc}"
+
+    def _reset_auth_error(self, account_name: str) -> None:
+        if account_name in self._last_auth_errors:
+            logger.info("Authentication for %s restored", account_name)
+            self._last_auth_errors.pop(account_name, None)
+
+
+class SnapshotPolicyEvaluator:
+    """Evaluate alert policies for a snapshot."""
+
+    def __call__(self, snapshot: Mapping[str, Any]) -> Sequence[RiskViolation]:
+        try:
+            _, accounts, thresholds, _ = parse_snapshot(dict(snapshot))
+            alerts = evaluate_alerts(accounts, thresholds)
+        except Exception:  # pragma: no cover - defensive fall back
+            return []
+        return [RiskViolation("alert_threshold", alert) for alert in alerts]
+
+
+class NotificationDispatcher:
+    """Send notifications while deduplicating alerts and scheduling snapshots."""
+
+    def __init__(
+        self,
+        executor: ResilientExecutor,
+        *,
+        email_sender: Optional[EmailAlertSender] = None,
+        email_recipients: Optional[Sequence[str]] = None,
+        telegram_notifier: Optional[TelegramNotifier] = None,
+        telegram_targets: Optional[Sequence[tuple[str, str]]] = None,
+        timezone_name: str = "America/New_York",
+    ) -> None:
+        self._executor = executor
+        self._email_sender = email_sender
+        self._email_recipients = list(email_recipients or [])
+        self._telegram_notifier = telegram_notifier
+        self._telegram_targets = list(telegram_targets or [])
+        self._active_alerts: set[str] = set()
+        self._tz = ZoneInfo(timezone_name)
+        self._daily_snapshot_sent_date: Optional[date] = None
+
+    async def dispatch(self, violations: Sequence[RiskViolation], snapshot: Mapping[str, Any]) -> None:
+        await self._maybe_send_daily_snapshot(snapshot)
+        await self._send_alerts(violations, snapshot)
+
+    async def _send_alerts(self, violations: Sequence[RiskViolation], snapshot: Mapping[str, Any]) -> None:
+        if not (self._email_sender or self._telegram_notifier):
+            return
+        alerts = [violation.message for violation in violations]
+        alerts_set = set(alerts)
+        new_alerts = [alert for alert in alerts if alert not in self._active_alerts]
+        self._active_alerts = alerts_set
+        if not new_alerts:
+            return
+        generated_at = snapshot.get("generated_at")
+        timestamp = generated_at if isinstance(generated_at, str) else datetime.now(timezone.utc).isoformat()
+        lines = [f"Exposure thresholds were exceeded at {timestamp}.", "", "Alerts:"]
+        lines.extend(f"- {alert}" for alert in new_alerts)
+        body = "\n".join(lines)
+        subject = "Risk alert: exposure threshold breached"
+        if self._email_sender and self._email_recipients:
+            await self._executor.execute_threaded(
+                "notification:email", lambda: self._email_sender.send(subject, body, self._email_recipients)
+            )
+        if self._telegram_notifier and self._telegram_targets:
+            message = f"Exposure alert at {timestamp}\n" + "\n".join(new_alerts)
+            await asyncio.gather(
+                *[
+                    self._executor.execute_threaded(
+                        f"notification:telegram:{chat_id}",
+                        lambda token=token, chat_id=chat_id: self._telegram_notifier.send(token, chat_id, message),
+                    )
+                    for token, chat_id in self._telegram_targets
+                ]
+            )
+
+    async def _maybe_send_daily_snapshot(self, snapshot: Mapping[str, Any]) -> None:
+        if not self._email_sender or not self._email_recipients:
+            return
+        now_ny = datetime.now(self._tz)
+        current_date = now_ny.date()
+        if self._daily_snapshot_sent_date and current_date > self._daily_snapshot_sent_date:
+            self._daily_snapshot_sent_date = None
+        if now_ny.time() < time(16, 0):
+            return
+        if self._daily_snapshot_sent_date == current_date:
+            return
+
+        accounts = snapshot.get("accounts", [])
+        portfolio_balance = sum(float(account.get("balance", 0.0)) for account in accounts if isinstance(account, Mapping))
+        lines = [
+            f"Daily portfolio snapshot ({now_ny.strftime('%Y-%m-%d')} 16:00 ET)",
+            f"Total balance: ${portfolio_balance:,.2f}",
+            "",
+            "Accounts:",
+        ]
+        for account in accounts or []:
+            if not isinstance(account, Mapping):
+                continue
+            name = str(account.get("name", "unknown"))
+            balance = float(account.get("balance", 0.0))
+            realised = float(account.get("daily_realized_pnl", 0.0))
+            lines.append(f"- {name}: balance ${balance:,.2f}, daily realised PnL ${realised:,.2f}")
+        body = "\n".join(lines)
+        subject = "Daily portfolio balance snapshot"
+        await self._executor.execute_threaded(
+            "notification:email.daily", lambda: self._email_sender.send(subject, body, self._email_recipients)
+        )
+        self._daily_snapshot_sent_date = current_date
+
+
+class KillSwitchExecutor:
+    """Execute kill-switch actions across account clients."""
+
+    def __init__(self, clients: Sequence[AccountClientProtocol], executor: ResilientExecutor) -> None:
+        self._clients = list(clients)
+        self._executor = executor
+
+    async def execute(self, account_name: Optional[str] = None, symbol: Optional[str] = None) -> dict[str, Any]:
+        scope = account_name or "all accounts"
+        symbol_desc = f" for {symbol}" if symbol else ""
+        logger.info("Kill switch requested for %s%s", scope, symbol_desc)
+        targets: list[AccountClientProtocol] = []
+        for client in self._clients:
+            if account_name is None or client.config.name == account_name:
+                targets.append(client)
+        if account_name is not None and not targets:
+            raise ValueError(f"Account '{account_name}' is not configured for realtime monitoring.")
+        results: dict[str, Any] = {}
+        for client in targets:
+            try:
+                results[client.config.name] = await self._executor.execute(
+                    f"account:{client.config.name}:kill_switch", lambda client=client: client.kill_switch(symbol)
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Kill switch failed for %s", client.config.name, exc_info=True)
+                results[client.config.name] = {"error": str(exc)}
+        logger.info("Kill switch completed for %s", scope)
+        return results
+
+
+async def _noop_async(*_: Any, **__: Any) -> None:  # pragma: no cover - helper for defaults
+    return None
+
+

--- a/tests/risk_management/test_realtime_components.py
+++ b/tests/risk_management/test_realtime_components.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from risk_engine.policies import RiskViolation
+
+from risk_management.configuration import AccountConfig
+from risk_management.realtime import AuthenticationError
+from risk_management.realtime_components import (
+    ClientOrchestrator,
+    KillSwitchExecutor,
+    NotificationDispatcher,
+    ResilientExecutor,
+    SnapshotPolicyEvaluator,
+)
+from services.telemetry import ResiliencePolicy, Telemetry
+
+
+class FakeEmailSender:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, tuple[str, ...]]] = []
+
+    def send(self, subject: str, body: str, recipients: list[str]) -> None:
+        self.sent.append((subject, body, tuple(recipients)))
+
+
+class FakeTelegramNotifier:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send(self, token: str, chat_id: str, message: str) -> None:
+        self.sent.append((token, chat_id, message))
+
+
+class OutcomeClient:
+    def __init__(self, config: AccountConfig, outcomes: list[Any]) -> None:
+        self.config = config
+        self._outcomes = list(outcomes)
+        self.calls = 0
+        self.kill_calls = 0
+
+    async def fetch(self) -> Any:
+        self.calls += 1
+        if not self._outcomes:
+            raise RuntimeError("no more outcomes configured")
+        result = self._outcomes.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def kill_switch(self, symbol: str | None = None) -> dict[str, Any]:
+        self.kill_calls += 1
+        return {"symbol": symbol or "*"}
+
+
+def test_resilient_executor_retries_and_succeeds() -> None:
+    telemetry = Telemetry(policy=ResiliencePolicy(max_retries=1, retry_backoff=0))
+    executor = ResilientExecutor(telemetry)
+
+    attempts = 0
+
+    async def flaky_call() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient")
+        return "ok"
+
+    result = asyncio.run(executor.execute("flaky", flaky_call))
+
+    assert result == "ok"
+    assert attempts == 2
+
+
+def test_client_orchestrator_handles_authentication_errors(caplog: pytest.LogCaptureFixture) -> None:
+    config = AccountConfig(name="Auth", exchange="binance")
+    client = OutcomeClient(config, [AuthenticationError("invalid"), AuthenticationError("invalid")])
+    executor = ResilientExecutor(Telemetry(policy=ResiliencePolicy(max_retries=0)))
+    orchestrator = ClientOrchestrator([client], executor)
+
+    caplog.set_level("WARNING")
+
+    accounts, messages = asyncio.run(orchestrator.fetch())
+    _, messages_second = asyncio.run(orchestrator.fetch())
+
+    assert messages["Auth"].startswith("Auth: authentication failed")
+    assert messages_second["Auth"].startswith("Auth: authentication failed")
+    assert accounts[0]["balance"] == 0
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warnings) == 1
+
+
+def test_snapshot_policy_evaluator_emits_policy_violations() -> None:
+    snapshot = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "accounts": [
+            {
+                "name": "Test",
+                "balance": 1000.0,
+                "positions": [
+                    {
+                        "symbol": "BTC",
+                        "side": "long",
+                        "wallet_exposure_pct": 0.6,
+                        "notional": 600,
+                        "entry_price": 1.0,
+                        "mark_price": 1.0,
+                        "unrealized_pnl": 0.0,
+                        "max_drawdown_pct": 0.0,
+                    }
+                ],
+            }
+        ],
+        "alert_thresholds": {
+            "wallet_exposure_pct": 0.5,
+            "position_wallet_exposure_pct": 0.3,
+            "max_drawdown_pct": 0.4,
+            "loss_threshold_pct": -0.2,
+        },
+        "notification_channels": [],
+    }
+
+    evaluator = SnapshotPolicyEvaluator()
+    violations = evaluator(snapshot)
+
+    assert violations
+    assert violations[0].policy == "alert_threshold"
+
+
+def test_notification_dispatcher_deduplicates_and_schedules(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry = Telemetry(policy=ResiliencePolicy(max_retries=0, retry_backoff=0))
+    executor = ResilientExecutor(telemetry)
+    email = FakeEmailSender()
+    telegram = FakeTelegramNotifier()
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return datetime(2024, 1, 1, 17, 0, tzinfo=tz or timezone.utc)
+
+    monkeypatch.setattr("risk_management.realtime_components.datetime", FixedDateTime)
+
+    dispatcher = NotificationDispatcher(
+        executor,
+        email_sender=email,
+        email_recipients=["alert@example.com"],
+        telegram_notifier=telegram,
+        telegram_targets=[("token", "chat")],
+        timezone_name="UTC",
+    )
+    violations = [RiskViolation("breach", "alert one")]
+    snapshot = {
+        "generated_at": FixedDateTime.now(timezone.utc).isoformat(),
+        "accounts": [{"name": "A", "balance": 50.0, "positions": []}],
+    }
+
+    asyncio.run(dispatcher.dispatch(violations, snapshot))
+    asyncio.run(dispatcher.dispatch(violations, snapshot))
+
+    assert len(email.sent) == 2  # daily snapshot + initial alert
+    assert len(telegram.sent) == 1
+
+
+def test_kill_switch_executor_invokes_clients() -> None:
+    config = AccountConfig(name="Kill", exchange="binance")
+    client = OutcomeClient(config, [ {"name": "Kill", "balance": 0, "positions": []} ])
+    executor = ResilientExecutor(Telemetry())
+    kill_executor = KillSwitchExecutor([client], executor)
+
+    result = asyncio.run(kill_executor.execute(symbol="BTCUSDT"))
+
+    assert result["Kill"]["symbol"] == "BTCUSDT"
+    assert client.kill_calls == 1
+

--- a/tests/risk_management/test_realtime_integration.py
+++ b/tests/risk_management/test_realtime_integration.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from risk_engine.policies import RiskViolation
+
+from risk_management.configuration import AccountConfig, RealtimeConfig
+from risk_management.realtime import AuthenticationError, RealtimeDataFetcher
+from risk_management.realtime_components import (
+    ClientOrchestrator,
+    NotificationDispatcher,
+    ResilientExecutor,
+)
+from services.telemetry import ResiliencePolicy, Telemetry
+
+
+class FakeEmailSender:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, tuple[str, ...]]] = []
+
+    def send(self, subject: str, body: str, recipients: list[str]) -> None:
+        self.sent.append((subject, body, tuple(recipients)))
+
+
+class FakeTelegramNotifier:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str, str]] = []
+
+    def send(self, token: str, chat_id: str, message: str) -> None:
+        self.sent.append((token, chat_id, message))
+
+
+class OutcomeClient:
+    def __init__(self, config: AccountConfig, outcomes: list[object]) -> None:
+        self.config = config
+        self._outcomes = list(outcomes)
+        self.calls = 0
+        self.kill_calls = 0
+
+    async def fetch(self):
+        self.calls += 1
+        if not self._outcomes:
+            raise RuntimeError("no more outcomes")
+        result = self._outcomes.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def kill_switch(self, symbol: str | None = None):
+        self.kill_calls += 1
+        return {"symbol": symbol or "*"}
+
+    async def close(self):  # pragma: no cover - required for interface
+        return None
+
+
+def test_realtime_components_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry = Telemetry(policy=ResiliencePolicy(max_retries=1, retry_backoff=0))
+    executor = ResilientExecutor(telemetry)
+
+    clients = [
+        OutcomeClient(
+            AccountConfig(name="Retry", exchange="binance"),
+            [
+                RuntimeError("flaky"),
+                {"name": "Retry", "balance": 100.0, "positions": []},
+                {"name": "Retry", "balance": 100.0, "positions": []},
+            ],
+        ),
+        OutcomeClient(
+            AccountConfig(name="Auth", exchange="okx"),
+            [AuthenticationError("denied"), AuthenticationError("denied"), AuthenticationError("denied"), AuthenticationError("denied")],
+        ),
+        OutcomeClient(
+            AccountConfig(name="Healthy", exchange="binance"),
+            [
+                {"name": "Healthy", "balance": 50.0, "positions": []},
+                {"name": "Healthy", "balance": 50.0, "positions": []},
+            ],
+        ),
+    ]
+    config = RealtimeConfig(
+        accounts=[client.config for client in clients],
+        alert_thresholds={
+            "wallet_exposure_pct": 0.1,
+            "position_wallet_exposure_pct": 0.1,
+            "max_drawdown_pct": 0.1,
+            "loss_threshold_pct": -0.1,
+        },
+        notification_channels=["email:ops@example.com", "telegram:token/chat"],
+    )
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return datetime(2024, 1, 1, 17, 0, tzinfo=tz or timezone.utc)
+
+    monkeypatch.setattr("risk_management.realtime_components.datetime", FixedDateTime)
+
+    email_sender = FakeEmailSender()
+    telegram_notifier = FakeTelegramNotifier()
+    dispatcher = NotificationDispatcher(
+        executor,
+        email_sender=email_sender,
+        email_recipients=["ops@example.com"],
+        telegram_notifier=telegram_notifier,
+        telegram_targets=[("token", "chat")],
+        timezone_name="UTC",
+    )
+
+    orchestrator = ClientOrchestrator(clients, executor, account_messages=config.account_messages)
+
+    def policy_eval(snapshot: dict) -> list[RiskViolation]:
+        return [RiskViolation("breach", "exceeded threshold")]
+
+    fetcher = RealtimeDataFetcher(
+        config,
+        account_clients=clients,
+        telemetry=telemetry,
+        policy_evaluator=policy_eval,
+        notification_dispatcher=dispatcher,
+        orchestrator=orchestrator,
+        executor=executor,
+    )
+
+    snapshot_first = asyncio.run(fetcher.fetch_snapshot())
+    asyncio.run(fetcher.fetch_snapshot())
+
+    assert snapshot_first["accounts"][0]["balance"] == 100.0
+    assert "Auth" in snapshot_first["account_messages"]
+    assert clients[0].calls >= 3  # retried once and succeeded again on next fetch
+    assert len(email_sender.sent) == 2  # daily + alert
+    assert len(telegram_notifier.sent) == 1
+
+    assert len(email_sender.sent) == 2  # no duplicates on second run
+    result = asyncio.run(fetcher.execute_kill_switch(account_name="Healthy", symbol="BTCUSDT"))
+    assert result["Healthy"]["symbol"] == "BTCUSDT"
+    assert clients[2].kill_calls == 1
+


### PR DESCRIPTION
## Summary
- extract reusable realtime components for orchestration, policy evaluation, notifications, and kill-switch execution
- add dependency injection points to ease mocking and resilience testing
- expand unit and integration test coverage for retries, auth handling, notifications, and kill-switch paths

## Testing
- python -m pytest tests/risk_management/test_realtime_components.py tests/risk_management/test_realtime_integration.py tests/test_risk_management_realtime.py tests/risk_management/test_realtime.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69356554e5a0832385c2059f50b2714a)